### PR TITLE
Set different hostname of a VM than name

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -78,6 +78,7 @@ type memoryAllocation struct {
 
 type virtualMachine struct {
 	name                  string
+	hostname              string
 	folder                string
 	datacenter            string
 	cluster               string
@@ -130,6 +131,12 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
+			},
+
+			"hostname": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -686,6 +693,10 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		memoryAllocation: memoryAllocation{
 			reservation: int64(d.Get("memory_reservation").(int)),
 		},
+	}
+
+	if v, ok := d.GetOk("hostname"); ok {
+		vm.hostname = v.(string)
 	}
 
 	if v, ok := d.GetOk("folder"); ok {
@@ -2107,9 +2118,13 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 
 			customIdentification := types.CustomizationIdentification{}
 
+			if len(vm.hostname) == 0 {
+				vm.hostname = vm.name
+			}
+
 			userData := types.CustomizationUserData{
 				ComputerName: &types.CustomizationFixedName{
-					Name: strings.Split(vm.name, ".")[0],
+					Name: strings.Split(vm.hostname, ".")[0],
 				},
 				ProductId: vm.windowsOptionalConfig.productKey,
 				FullName:  "terraform",
@@ -2138,9 +2153,14 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 				UserData:       userData,
 			}
 		} else {
+
+			if len(vm.hostname) == 0 {
+				vm.hostname = vm.name
+			}
+
 			identity_options = &types.CustomizationLinuxPrep{
 				HostName: &types.CustomizationFixedName{
-					Name: strings.Split(vm.name, ".")[0],
+					Name: strings.Split(vm.hostname, ".")[0],
 				},
 				Domain:     vm.domain,
 				TimeZone:   vm.timeZone,

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -330,6 +330,35 @@ func TestAccVSphereVirtualMachine_noPanicShutdown(t *testing.T) {
 	})
 }
 
+const testAccCheckVSphereVirtualMachineConfig_hostname = `
+resource "vsphere_virtual_machine" "foo" {
+    name = "terraform-test"
+    hostname = "testterraform"
+` + testAccTemplateBasicBodyWithEnd
+
+func TestAccVSphereVirtualMachine_hostname(t *testing.T) {
+	var vm virtualMachine
+	basic_vars := setupTemplateBasicBodyVars()
+	config := basic_vars.testSprintfTemplateBody(testAccCheckVSphereVirtualMachineConfig_hostname)
+
+	log.Printf("[DEBUG] template= %s", testAccCheckVSphereVirtualMachineConfig_hostname)
+	log.Printf("[DEBUG] template config= %s", config)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testBasicPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVSphereVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					TestFuncData{vm: vm, label: basic_vars.label}.testCheckFuncBasic(),
+				),
+			},
+		},
+	})
+}
+
 const testAccCheckVSphereVirtualMachineConfig_debug = `
 provider "vsphere" {
   client_debug = true

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -34,6 +34,7 @@ resource "vsphere_virtual_machine" "web" {
 ```hcl
 resource "vsphere_virtual_machine" "lb" {
   name          = "lb01"
+  hostname	= "lbalancer01"
   folder        = "Loadbalancers"
   vcpu          = 2
   memory        = 4096
@@ -64,6 +65,7 @@ The following arguments are supported:
 * `folder` - (Optional) The folder to group the VM in.
 * `vcpu` - (Required) The number of virtual CPUs to allocate to the virtual machine
 * `memory` - (Required) The amount of RAM (in MB) to allocate to the virtual machine
+* `hostname` - (Optional) The virtual machine hostname used during the OS customization - if not specified then `name` will be a hostname
 * `memory_reservation` - (Optional) The amount of RAM (in MB) to reserve physical memory resource; defaults to 0 (means not to reserve)
 * `datacenter` - (Optional) The name of a Datacenter in which to launch the virtual machine
 * `cluster` - (Optional) Name of a Cluster in which to launch the virtual machine

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -34,7 +34,7 @@ resource "vsphere_virtual_machine" "web" {
 ```hcl
 resource "vsphere_virtual_machine" "lb" {
   name          = "lb01"
-  hostname	= "lbalancer01"
+  hostname      = "lbalancer01"
   folder        = "Loadbalancers"
   vcpu          = 2
   memory        = 4096
@@ -65,7 +65,7 @@ The following arguments are supported:
 * `folder` - (Optional) The folder to group the VM in.
 * `vcpu` - (Required) The number of virtual CPUs to allocate to the virtual machine
 * `memory` - (Required) The amount of RAM (in MB) to allocate to the virtual machine
-* `hostname` - (Optional) The virtual machine hostname used during the OS customization - if not specified then `name` will be a hostname
+* `hostname` - (Optional) The virtual machine hostname used during the OS customization. Defaults to the `name` attribute.
 * `memory_reservation` - (Optional) The amount of RAM (in MB) to reserve physical memory resource; defaults to 0 (means not to reserve)
 * `datacenter` - (Optional) The name of a Datacenter in which to launch the virtual machine
 * `cluster` - (Optional) Name of a Cluster in which to launch the virtual machine


### PR DESCRIPTION
Migrated from the old [hashicorp/terraform#14769](https://github.com/hashicorp/terraform/pull/14769)

Acceptance tests:
```
$ make testacc TEST=./vsphere/ TESTARGS='-run=TestAccVSphereVirtualMachine_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./vsphere/ -v -run=TestAccVSphereVirtualMachine_basic -timeout 120m
=== RUN   TestAccVSphereVirtualMachine_basic
--- PASS: TestAccVSphereVirtualMachine_basic (751.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-vsphere/vsphere       751.427s
$ make testacc TEST=./vsphere/ TESTARGS='-run=TestAccVSphereVirtualMachine_hostname'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./vsphere/ -v -run=TestAccVSphereVirtualMachine_hostname -timeout 120m
=== RUN   TestAccVSphereVirtualMachine_hostname
--- PASS: TestAccVSphereVirtualMachine_hostname (635.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-vsphere/vsphere       635.819s
```

It resolves #91 