### PR TITLE
virtual_machine - template disk resize

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -832,16 +832,12 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 				}
 
 				if v, ok := disk["size"].(int); ok && v != 0 {
-					if v, ok := disk["template"].(string); ok && v != "" {
-						return fmt.Errorf("Cannot specify size of a template")
-					}
 
 					if v, ok := disk["name"].(string); ok && v != "" {
 						newDisk.name = v
-					} else {
+					} else if v, ok := disk["template"].(string); !ok && v != "" {
 						return fmt.Errorf("[ERROR] Disk name must be provided when creating a new disk")
 					}
-
 					newDisk.size = int64(v)
 				}
 
@@ -1664,6 +1660,54 @@ func buildStoragePlacementSpecClone(c *govmomi.Client, f *object.DatacenterFolde
 	return sps
 }
 
+// buildVirtualDeviceConfigSpecResize builds VirtualDeviceConfigSpec for Resize action.
+func buildVirtualDeviceConfigSpecResize(c *govmomi.Client, vm *object.VirtualMachine, diskSize int64) types.VirtualDeviceConfigSpec {
+	vmr := vm.Reference()
+
+	var o mo.VirtualMachine
+	err := vm.Properties(context.TODO(), vmr, []string{"datastore"}, &o)
+	if err != nil {
+		return types.VirtualDeviceConfigSpec{}
+	}
+	ds := object.NewDatastore(c.Client, o.Datastore[0])
+	log.Printf("[DEBUG] findDatastore: datastore: %#v\n", ds)
+
+	devices, err := vm.Device(context.TODO())
+	if err != nil {
+		return types.VirtualDeviceConfigSpec{}
+	}
+
+	var disks []*types.VirtualDisk
+	for _, device := range devices {
+		switch md := device.(type) {
+		case *types.VirtualDisk:
+			disks = append(disks, md)
+		default:
+			continue
+		}
+	}
+
+	var editdisk *types.VirtualDisk
+	if len(disks) == 1 {
+		editdisk = disks[0]
+	} else {
+		return types.VirtualDeviceConfigSpec{}
+	}
+
+	if int64(diskSize) != 0 {
+		editdisk.CapacityInKB = int64(diskSize) * 1024 * 1024
+	}
+
+	vdcs := types.VirtualDeviceConfigSpec{
+		Device:    editdisk,
+		Operation: types.VirtualDeviceConfigSpecOperationEdit,
+	}
+
+	vdcs.FileOperation = ""
+
+	return vdcs
+}
+
 // findDatastore finds Datastore object.
 func findDatastore(c *govmomi.Client, sps types.StoragePlacementSpec) (*object.Datastore, error) {
 	var datastore *object.Datastore
@@ -1779,6 +1823,9 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 	}
 	if vm.template == "" {
 		configSpec.GuestId = "otherLinux64Guest"
+	} else {
+		vdcs := buildVirtualDeviceConfigSpecResize(c, template, vm.hardDisks[0].size)
+		configSpec.DeviceChange = append(configSpec.DeviceChange, &vdcs)
 	}
 	log.Printf("[DEBUG] virtual machine config spec: %v", configSpec)
 

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -1471,6 +1471,72 @@ func TestAccVSphereVirtualMachine_DetachUnknownDisks(t *testing.T) {
 	})
 }
 
+const testAccCheckVSphereVirtualMachineConfig_templateResize = `
+resource "vsphere_virtual_machine" "template_resize" {
+%s
+    name = "terraform-test"
+    vcpu = 2
+    memory = 1024
+    network_interface {
+        label = "%s"
+    }
+     disk {
+%s
+        size = 10
+		template = "%s"
+	}
+	disk {
+        size = 3
+		name = "two"
+		keep_on_remove = false
+    }
+}
+`
+
+func TestAccVSphereVirtualMachine_templateResize(t *testing.T) {
+	var vm virtualMachine
+	basic_vars := setupTemplateBasicBodyVars()
+	config := fmt.Sprintf(
+		testAccCheckVSphereVirtualMachineConfig_templateResize,
+		basic_vars.locationOpt,
+		basic_vars.label,
+		basic_vars.datastoreOpt,
+		basic_vars.template,
+	)
+	var datastore string
+	if v := os.Getenv("VSPHERE_DATASTORE"); v != "" {
+		datastore = v
+	}
+	var datacenter string
+	if v := os.Getenv("VSPHERE_DATACENTER"); v != "" {
+		datacenter = v
+	}
+
+	vmName := "vsphere_virtual_machine.template_resize"
+
+	test_exists, test_name, test_cpu, test_uuid, test_mem, test_num_disk, test_num_of_nic, test_nic_label :=
+		TestFuncData{vm: vm, label: basic_vars.label, vmName: vmName, numDisks: "2"}.testCheckFuncBasic()
+
+	log.Printf("[DEBUG] template= %s", testAccCheckVSphereVirtualMachineConfig_templateResize)
+	log.Printf("[DEBUG] template config= %s", config)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVSphereVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					test_exists, test_name, test_cpu, test_uuid, test_mem, test_num_disk, test_num_of_nic, test_nic_label,
+					checkForDisk(datacenter, datastore, "terraform-test", "two.vmdk", true, false),
+				),
+			},
+		},
+	})
+
+}
+
 func createAndAttachDisk(t *testing.T, vmName string, size int, datastore string, diskPath string, diskType string, adapterType string, datacenter string) {
 	client := testAccProvider.Meta().(*govmomi.Client)
 	finder := find.NewFinder(client.Client, true)


### PR DESCRIPTION
disclaimer: first contribution to Terraform and a golang project.

Using vCenter, one can resize the boot disk with the clone wizard, however Terraform provider restricts resizing the disk if it's generated from a template. 

Change Allows resizing of Virtual Machine Disk from template
- removes the logic to check for "size" if disk is a template
- creates a new buildVirtualDeviceConfigSpecResize function to create a VirtualDeviceConfigSpec to be passed on during VM Clone event

```
resource "vsphere_virtual_machine" "test" {
  name   = "terraform-test"
  vcpu   = 2
  memory = 4096

  network_interface {
    label = "private"
  }

  disk {
    template = "/nyc/vm/templates/coreos_1409.2.0"
    datastore = "dscluster/datastore2"
    size = "50"
    type = "thin"
  }

  disk {
    name = "disk2"
    size = "20"
    type = "thin"
  }
}
```
As an example above will resize the template disk to 50 GB during cloning, and attach a second disk during customization process.