### PR TITLE
Fix for datastores with spaces in their name.

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -582,7 +582,7 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 					diskPath = disk["vmdk"].(string)
 				case disk["name"] != "":
 					snapshotFullDir := mo.Config.Files.SnapshotDirectory
-					split := strings.Split(snapshotFullDir, " ")
+					split := strings.Split(snapshotFullDir, "] ")
 					if len(split) != 2 {
 						return fmt.Errorf("[ERROR] createVirtualMachine - failed to split snapshot directory: %v", snapshotFullDir)
 					}
@@ -2024,7 +2024,7 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 			diskPath = vm.hardDisks[i].vmdkPath
 		case vm.hardDisks[i].name != "":
 			snapshotFullDir := vm_mo.Config.Files.SnapshotDirectory
-			split := strings.Split(snapshotFullDir, " ")
+			split := strings.Split(snapshotFullDir, "] ")
 			if len(split) != 2 {
 				return fmt.Errorf("[ERROR] setupVirtualMachine - failed to split snapshot directory: %v", snapshotFullDir)
 			}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -992,7 +992,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 			log.Printf("[DEBUG] resourceVSphereVirtualMachineRead - Analyzing disk: %v", diskFullPath)
 
 			// Separate datastore and path
-			diskFullPathSplit := strings.Split(diskFullPath, " ")
+			diskFullPathSplit := strings.Split(diskFullPath, "] ")
 			if len(diskFullPathSplit) != 2 {
 				return fmt.Errorf("[ERROR] Failed trying to parse disk path: %v", diskFullPath)
 			}


### PR DESCRIPTION
Three split functions in the vsphere virtual machine resource split on space which breaks functionality when the datastore has a space in its name. Considering this split only needs the second element, which is the vmdk path or the folder it resides in, a split on "] " will always correctly create the second element needed in the slice/array (still haven't figured out the exact difference between these in Go).

I am new to contributing to github and I am new to Golang. I attempted to modify the acceptance tests, but it appears the datastores are stubbed with local environment variables. I can't think of any modifications to acceptance testing in this way. Please direct me otherwise needed.