### PR TITLE
virtual machine - add annotation argument

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -86,6 +86,7 @@ type virtualMachine struct {
 	vcpu                  int32
 	memoryMb              int64
 	memoryAllocation      memoryAllocation
+	annotation            string
 	template              string
 	networkInterfaces     []networkInterface
 	hardDisks             []hardDisk
@@ -153,6 +154,11 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 				Optional: true,
 				Default:  0,
 				ForceNew: true,
+			},
+
+			"annotation": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"datacenter": &schema.Schema{
@@ -504,6 +510,11 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 		rebootRequired = true
 	}
 
+	if d.HasChange("annotation") {
+		configSpec.Annotation = d.Get("annotation").(string)
+		hasChanges = true
+	}
+
 	client := meta.(*govmomi.Client)
 	dc, err := getDatacenter(client, d.Get("datacenter").(string))
 	if err != nil {
@@ -694,6 +705,12 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 
 	if v, ok := d.GetOk("time_zone"); ok {
 		vm.timeZone = v.(string)
+	}
+
+	if v, ok := d.GetOk("annotation"); ok {
+		vm.annotation = v.(string)
+	} else {
+		vm.annotation = ""
 	}
 
 	if v, ok := d.GetOk("linked_clone"); ok {
@@ -1136,6 +1153,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	d.Set("cpu", mvm.Summary.Config.NumCpu)
 	d.Set("datastore", rootDatastore)
 	d.Set("uuid", mvm.Summary.Config.Uuid)
+	d.Set("annotation", mvm.Summary.Config.Annotation)
 
 	return nil
 }
@@ -1776,6 +1794,7 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 		Flags: &types.VirtualMachineFlagInfo{
 			DiskUuidEnabled: &vm.enableDiskUUID,
 		},
+		Annotation: vm.annotation,
 	}
 	if vm.template == "" {
 		configSpec.GuestId = "otherLinux64Guest"

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -82,6 +82,7 @@ The following arguments are supported:
 * `enable_disk_uuid` - (Optional) This option causes the vm to mount disks by uuid on the guest OS.
 * `custom_configuration_parameters` - (Optional) Map of values that is set as virtual machine custom configurations.
 * `skip_customization` - (Optional) skip virtual machine customization (useful if OS is not in the guest OS support matrix of VMware like "other3xLinux64Guest").
+* `annotation` - (Optional) Edit the annotation notes field
 
 The `network_interface` block supports:
 


### PR DESCRIPTION
In our environment, we use the annotation field to store additional information about the virtual machine. I added the ability to use this field when creating a virtual machine.