### PR TITLE
 Add multiple virtual core support closes #42 

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
 * `name` - (Required) The virtual machine name (cannot contain underscores and must be less than 15 characters)
 * `folder` - (Optional) The folder to group the VM in.
 * `vcpu` - (Required) The number of virtual CPUs to allocate to the virtual machine
+* `vcores_per_socket` - (Optional) The number of virtual CPUs for each socket; the number of virtual CPUs must be evenly divisible by the number of cores
 * `memory` - (Required) The amount of RAM (in MB) to allocate to the virtual machine
 * `memory_reservation` - (Optional) The amount of RAM (in MB) to reserve physical memory resource; defaults to 0 (means not to reserve)
 * `datacenter` - (Optional) The name of a Datacenter in which to launch the virtual machine


### PR DESCRIPTION
Add support for customizing the number of cores per socket. Enforces
that the number of virtual CPUs is evenly divisible by the selected
number of virtual cores for the optimal socket size.