### PR TITLE
Cleanup devrc

### DIFF
--- a/tf-vsphere-devrc.mk.example
+++ b/tf-vsphere-devrc.mk.example
@@ -4,7 +4,7 @@
 #
 # This should be copied to ~/.tf-vsphere-devrc.mk and edited accordingly.
 #
-# Note that the use of all of this file is not required - enviornment variables
+# Note that the use of all of this file is not required - environment variables
 # can still be completely set from the command line or your existing
 # environment. In this case, don't use this file as it may cause conflicts.
 # 
@@ -16,16 +16,19 @@ export VSPHERE_PASSWORD ?= changeme
 # Enable this if you want to skip SSL verification
 export VSPHERE_ALLOW_UNVERIFIED_SSL ?= false
 
-# vsphere_virtaul_machine variables
-export VSPHERE_TEMPLATE            ?= base-linux
-export VSPHERE_NETWORK_LABEL       ?= vm-network
-export VSPHERE_NETWORK_LABEL_DHCP  ?= vm-network
-export VSPHERE_IPV4_ADDRESS        ?= 10.0.0.100
-export VSPHERE_IPV4_PREFIX         ?= 24
-export VSPHERE_IPV4_GATEWAY        ?= 10.0.0.1
-export VSPHERE_DATACENTER          ?= vm-dc
-export VSPHERE_CLUSTER             ?= vm-cluster1
-export VSPHERE_RESOURCE_POOL       ?= vm-resource-pool
-export VSPHERE_DATASTORE           ?= datastore1
+# The following variables are shared across various tests. To ensure all tests
+# succeed, it's probably best to set all of these to valid values.
+export VSPHERE_TEMPLATE            ?= base-linux # VM template to clone
+export VSPHERE_NETWORK_LABEL       ?= vm-network # Port group label
+export VSPHERE_NETWORK_LABEL_DHCP  ?= vm-network # Port group label for DHCP
+export VSPHERE_IPV4_ADDRESS        ?= 10.0.0.100 # Customization IP address
+export VSPHERE_IPV4_PREFIX         ?= 24         # Customization netmask
+export VSPHERE_IPV4_GATEWAY        ?= 10.0.0.1   # Customization gateway
+export VSPHERE_DATACENTER          ?= vm-dc      # VM placement DC
+export VSPHERE_CLUSTER             ?= vm-clus1   # VM placement cluster
+export VSPHERE_RESOURCE_POOL       ?= vm-respool # VM resource resource pool
+export VSPHERE_DATASTORE           ?= datastore1 # VM placement datastore
+export VSPHERE_INIT_TYPE           ?= thin       # vDisk type
+export VSPHERE_ADAPTER_TYPE        ?= lsiLogic   # Virtual disk adapter type
 
 # vi: filetype=make


### PR DESCRIPTION
Correct a spelling mistake and consolidate variables. Some of these vars
are shared between tests and annotating them to a single resource did
not make sense. On the other hand, added annotations to reflect what the
variables represent so that there is as little ambiguity as possible.