### PR TITLE
New data source: vsphere_datacenter

### DIFF
--- a/vsphere/data_source_vsphere_datacenter.go
+++ b/vsphere/data_source_vsphere_datacenter.go
@@ -17,11 +17,6 @@ func dataSourceVSphereDatacenter() *schema.Resource {
 				Description: "The name of the datacenter. This can be a name or path.	If not provided, the default datacenter is used.",
 				Optional: true,
 			},
-			"datacenter_id": &schema.Schema{
-				Type:        schema.TypeString,
-				Description: "The managed object ID of the datacenter.",
-				Computed:    true,
-			},
 		},
 	}
 }
@@ -35,7 +30,6 @@ func dataSourceVSphereDatacenterRead(d *schema.ResourceData, meta interface{}) e
 	}
 	id := dc.Reference().Value
 	d.SetId(id)
-	d.Set("datacenter_id", id)
 
 	return nil
 }

--- a/vsphere/data_source_vsphere_datacenter.go
+++ b/vsphere/data_source_vsphere_datacenter.go
@@ -1,0 +1,41 @@
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/vmware/govmomi"
+)
+
+func dataSourceVSphereDatacenter() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereDatacenterRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type: schema.TypeString,
+				Description: "The name of the datacenter. This can be a name or path.	If not provided, the default datacenter is used.",
+				Optional: true,
+			},
+			"datacenter_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The managed object ID of the datacenter.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceVSphereDatacenterRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*govmomi.Client)
+	datacenter := d.Get("name").(string)
+	dc, err := getDatacenter(client, datacenter)
+	if err != nil {
+		return fmt.Errorf("error fetching datacenter: %s", err)
+	}
+	id := dc.Reference().Value
+	d.SetId(id)
+	d.Set("datacenter_id", id)
+
+	return nil
+}

--- a/vsphere/data_source_vsphere_datacenter_test.go
+++ b/vsphere/data_source_vsphere_datacenter_test.go
@@ -1,0 +1,100 @@
+package vsphere
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+var testAccDataSourceVSphereDatacenterExpectedRegexp = regexp.MustCompile("^datacenter-")
+
+func TestAccDataSourceVSphereDatacenter(t *testing.T) {
+	var tp *testing.T
+	testAccDataSourceVSphereDatacenterCases := []struct {
+		name     string
+		testCase resource.TestCase
+	}{
+		{
+			"basic",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccDataSourceVSphereDatacenterPreCheck(tp)
+				},
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataSourceVSphereDatacenterConfig(),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr(
+								"data.vsphere_datacenter.dc",
+								"id",
+								testAccDataSourceVSphereDatacenterExpectedRegexp,
+							),
+							resource.TestMatchResourceAttr(
+								"data.vsphere_datacenter.dc",
+								"datacenter_id",
+								testAccDataSourceVSphereDatacenterExpectedRegexp,
+							),
+						),
+					},
+				},
+			},
+		},
+		{
+			"default",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccDataSourceVSphereDatacenterPreCheck(tp)
+				},
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataSourceVSphereDatacenterConfigDefault,
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr(
+								"data.vsphere_datacenter.dc",
+								"id",
+								testAccDataSourceVSphereDatacenterExpectedRegexp,
+							),
+							resource.TestMatchResourceAttr(
+								"data.vsphere_datacenter.dc",
+								"datacenter_id",
+								testAccDataSourceVSphereDatacenterExpectedRegexp,
+							),
+						),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testAccDataSourceVSphereDatacenterCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tp = t
+			resource.Test(t, tc.testCase)
+		})
+	}
+}
+
+func testAccDataSourceVSphereDatacenterPreCheck(t *testing.T) {
+	if os.Getenv("VSPHERE_DATACENTER") == "" {
+		t.Skip("set VSPHERE_DATACENTER to run vsphere_datacenter acceptance tests")
+	}
+}
+
+func testAccDataSourceVSphereDatacenterConfig() string {
+	return fmt.Sprintf(`
+data "vsphere_datacenter" "dc" {
+  name = "%s"
+}
+`, os.Getenv("VSPHERE_DATACENTER"))
+}
+
+const testAccDataSourceVSphereDatacenterConfigDefault = `
+data "vsphere_datacenter" "dc" {}
+`

--- a/vsphere/data_source_vsphere_datacenter_test.go
+++ b/vsphere/data_source_vsphere_datacenter_test.go
@@ -34,11 +34,6 @@ func TestAccDataSourceVSphereDatacenter(t *testing.T) {
 								"id",
 								testAccDataSourceVSphereDatacenterExpectedRegexp,
 							),
-							resource.TestMatchResourceAttr(
-								"data.vsphere_datacenter.dc",
-								"datacenter_id",
-								testAccDataSourceVSphereDatacenterExpectedRegexp,
-							),
 						),
 					},
 				},
@@ -59,11 +54,6 @@ func TestAccDataSourceVSphereDatacenter(t *testing.T) {
 							resource.TestMatchResourceAttr(
 								"data.vsphere_datacenter.dc",
 								"id",
-								testAccDataSourceVSphereDatacenterExpectedRegexp,
-							),
-							resource.TestMatchResourceAttr(
-								"data.vsphere_datacenter.dc",
-								"datacenter_id",
 								testAccDataSourceVSphereDatacenterExpectedRegexp,
 							),
 						),

--- a/vsphere/datacenter_helper.go
+++ b/vsphere/datacenter_helper.go
@@ -1,0 +1,30 @@
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"golang.org/x/net/context"
+)
+
+// getDatacenter gets the higher-level datacenter object for the datacenter
+// name supplied by dc.
+//
+// The default datacenter is denoted by using an empty string. When working
+// with ESXi directly, the default datacenter is always selected.
+func getDatacenter(c *govmomi.Client, dc string) (*object.Datacenter, error) {
+	finder := find.NewFinder(c.Client, true)
+	t := c.ServiceContent.About.ApiType
+	switch t {
+	case "HostAgent":
+		return finder.DefaultDatacenter(context.TODO())
+	case "VirtualCenter":
+		if dc != "" {
+			return finder.Datacenter(context.TODO(), dc)
+		}
+		return finder.DefaultDatacenter(context.TODO())
+	}
+	return nil, fmt.Errorf("unsupported ApiType: %s", t)
+}

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -72,6 +72,10 @@ func Provider() terraform.ResourceProvider {
 			"vsphere_license":         resourceVSphereLicense(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"vsphere_datacenter": dataSourceVSphereDatacenter(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/vsphere/resource_vsphere_folder.go
+++ b/vsphere/resource_vsphere_folder.go
@@ -223,15 +223,3 @@ func deleteFolder(client *govmomi.Client, f *folder) error {
 	}
 	return nil
 }
-
-// getDatacenter gets datacenter object
-func getDatacenter(c *govmomi.Client, dc string) (*object.Datacenter, error) {
-	finder := find.NewFinder(c.Client, true)
-	if dc != "" {
-		d, err := finder.Datacenter(context.TODO(), dc)
-		return d, err
-	} else {
-		d, err := finder.DefaultDatacenter(context.TODO())
-		return d, err
-	}
-}

--- a/website/docs/d/datacenter.html.markdown
+++ b/website/docs/d/datacenter.html.markdown
@@ -34,6 +34,5 @@ The following arguments are supported:
 
 ## Attribute Reference
 
-* `id` - The managed object ID of this datacenter.
-* `datacenter_id` - (String) The managed object ID of this datacenter (same as
-  `id`).
+The only exported attribute is `id`, which is the managed object ID of this
+datacenter.

--- a/website/docs/d/datacenter.html.markdown
+++ b/website/docs/d/datacenter.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_datacenter"
+sidebar_current: "docs-vsphere-data-source-datacenter"
+description: |-
+  A data source that can be used to get the ID of a datacenter.
+---
+
+# vsphere\_datacenter
+
+The `vsphere_datacenter` data source can be used to discover the ID of a
+vSphere datacenter. It can also be used to fetch the "default datacenter" on
+ESXi, however this can be done with [`vsphere_host`][data-source-vsphere-host]
+as well.
+
+[data-source-vsphere-host]: /docs/providers/vsphere/d/host.html
+
+## Example Usage
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name = "dc1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (String) The name of the datacenter. This can be a name or path.	If
+  not provided, the default datacenter is used.
+
+~> **NOTE:** `name` is ignored on ESXi, and is not required.
+
+## Attribute Reference
+
+* `id` - The managed object ID of this datacenter.
+* `datacenter_id` - (String) The managed object ID of this datacenter (same as
+  `id`).

--- a/website/docs/d/datacenter.html.markdown
+++ b/website/docs/d/datacenter.html.markdown
@@ -9,9 +9,9 @@ description: |-
 # vsphere\_datacenter
 
 The `vsphere_datacenter` data source can be used to discover the ID of a
-vSphere datacenter. It can also be used to fetch the "default datacenter" on
-ESXi, however this can be done with [`vsphere_host`][data-source-vsphere-host]
-as well.
+vSphere datacenter. This can then be used with resources or data sources that
+require a datacenter, such as the [`vsphere_host`][data-source-vsphere-host]
+data source.
 
 [data-source-vsphere-host]: /docs/providers/vsphere/d/host.html
 
@@ -30,7 +30,10 @@ The following arguments are supported:
 * `name` - (String) The name of the datacenter. This can be a name or path.	If
   not provided, the default datacenter is used.
 
-~> **NOTE:** `name` is ignored on ESXi, and is not required.
+~> **NOTE:** When used against ESXi, this data source _always_ fetches the
+server's "default" datacenter, which is a special datacenter unrelated to the
+default datacenter that exists in vCenter. Hence, the `name` attribute is
+completely ignored.
 
 ## Attribute Reference
 

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -10,26 +10,35 @@
           <a href="/docs/providers/vsphere/index.html">VMware vSphere Provider</a>
         </li>
 
+        <li<%= sidebar_current("docs-vsphere-data-source") %>>
+          <a href="#">Data Sources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-data-source-datacenter") %>>
+              <a href="/docs/providers/vsphere/d/datacenter.html">vsphere_datacenter</a>
+            </li>
+          </ul>
+        </li>
+
         <li<%= sidebar_current("docs-vsphere-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-vsphere-resource-virtual-machine") %>>
-              <a href="/docs/providers/vsphere/r/virtual_machine.html">vsphere_virtual_machine</a>
-            </li>
-            <li<%= sidebar_current("docs-vsphere-resource-folder") %>>
-              <a href="/docs/providers/vsphere/r/folder.html">vsphere_folder</a>
+            <li<%= sidebar_current("docs-vsphere-resource-datacenter") %>>
+              <a href="/docs/providers/vsphere/r/datacenter.html">vsphere_datacenter</a>
             </li>
             <li<%= sidebar_current("docs-vsphere-resource-file") %>>
               <a href="/docs/providers/vsphere/r/file.html">vsphere_file</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-virtual-disk") %>>
-              <a href="/docs/providers/vsphere/r/virtual_disk.html">vsphere_virtual_disk</a>
+            <li<%= sidebar_current("docs-vsphere-resource-folder") %>>
+              <a href="/docs/providers/vsphere/r/folder.html">vsphere_folder</a>
             </li>
             <li<%= sidebar_current("docs-vsphere-resource-license") %>>
               <a href="/docs/providers/vsphere/r/license.html">vsphere_license</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-datacenter") %>>
-              <a href="/docs/providers/vsphere/r/datacenter.html">vsphere_datacenter</a>
+            <li<%= sidebar_current("docs-vsphere-resource-virtual-disk") %>>
+              <a href="/docs/providers/vsphere/r/virtual_disk.html">vsphere_virtual_disk</a>
+            </li>
+            <li<%= sidebar_current("docs-vsphere-resource-virtual-machine") %>>
+              <a href="/docs/providers/vsphere/r/virtual_machine.html">vsphere_virtual_machine</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This data source fetches the managed object ID for a vSphere datacenter, and is
intended for use in other up-and-coming resources that will use a
managed object reference to a datacenter to fetch other resources (like
host systems), or tell resources where they need to be deployed to (may
eventually be used in `vsphere_virtual_machine`, for example).