### PR TITLE
d/datacenter: Re-word "default" datacenter doc references

### DIFF
--- a/vsphere/data_source_vsphere_datacenter.go
+++ b/vsphere/data_source_vsphere_datacenter.go
@@ -14,7 +14,7 @@ func dataSourceVSphereDatacenter() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type: schema.TypeString,
-				Description: "The name of the datacenter. This can be a name or path.	If not provided, the default datacenter is used.",
+				Description: "The name of the datacenter. This can be a name or path.	Can be omitted if there is only one datacenter in your inventory.",
 				Optional: true,
 			},
 		},

--- a/website/docs/d/datacenter.html.markdown
+++ b/website/docs/d/datacenter.html.markdown
@@ -27,13 +27,13 @@ data "vsphere_datacenter" "datacenter" {
 
 The following arguments are supported:
 
-* `name` - (String) The name of the datacenter. This can be a name or path.	If
-  not provided, the default datacenter is used.
+* `name` - (String) The name of the datacenter. This can be a name or path.	Can
+  be omitted if there is only one datacenter in your inventory.
 
 ~> **NOTE:** When used against ESXi, this data source _always_ fetches the
 server's "default" datacenter, which is a special datacenter unrelated to the
-default datacenter that exists in vCenter. Hence, the `name` attribute is
-completely ignored.
+datacenters that exist in any vCenter server that might be managing this host.
+Hence, the `name` attribute is completely ignored.
 
 ## Attribute Reference
 


### PR DESCRIPTION
The "default" datacenter is actually for the most part a gvmomi thing, a
consequence of using the `DefaultDatacenter` calls in the find package.
This function simulates default datacenter fetching behaviour by
returning a single datacenter object from inventory if, and only if, a
singular datacenter object exists in inventory. This is always the case
on ESXi, but not on vCenter, and if there are multiple datacenters found
the call will fail. Docs have been updated to reflect this.