### PR TITLE
r/host_virtual_switch: Doc update for ID attribute

### DIFF
--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -170,4 +170,7 @@ probing (configured with [`check_beacon`](#check_beacon)).
 ## Attribute Reference
 
 The only exported attribute, other than the attributes above, is the `id` of
-the resource, which is set to the name of the virtual switch.
+the resource. This is set to an ID value unique to Terraform - the convention
+is a prefix, the host system ID, and the virtual switch name. An example would
+be `tf-HostVirtualSwitch:host-10:vSwitchTerraformTest`.
+


### PR DESCRIPTION
The ID attribute is now a composite attribute that we assemble in code,
and not just the name of the resource, because that is not a unique
value or very telling of where the resource is actually located.

The ID change went in with #138, but I forgot to update the docs.