### PR TITLE
r/virtual_machine: Enforce powered on state

### DIFF
--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -116,8 +116,8 @@ func testGetVirtualMachine(s *terraform.State, resourceName string) (*object.Vir
 	return virtualMachineFromUUID(tVars.client, uuid)
 }
 
-// testGetVirtualMachineProperties is a convenience that adds an extra step to
-// testGetVirtualMachine to get the properties of a virtual machine.
+// testGetVirtualMachineProperties is a convenience method that adds an extra
+// step to testGetVirtualMachine to get the properties of a virtual machine.
 func testGetVirtualMachineProperties(s *terraform.State, resourceName string) (*mo.VirtualMachine, error) {
 	vm, err := testGetVirtualMachine(s, resourceName)
 	if err != nil {

--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -1,14 +1,18 @@
 package vsphere
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -19,6 +23,9 @@ type testCheckVariables struct {
 
 	// The subject resource's ID.
 	resourceID string
+
+	// The subject resource's attributes.
+	resourceAttributes map[string]string
 
 	// The ESXi host that a various API call is directed at.
 	esxiHost string
@@ -37,11 +44,12 @@ func testClientVariablesForResource(s *terraform.State, addr string) (testCheckV
 	}
 
 	return testCheckVariables{
-		client:     testAccProvider.Meta().(*govmomi.Client),
-		resourceID: rs.Primary.ID,
-		esxiHost:   os.Getenv("VSPHERE_ESXI_HOST"),
-		datacenter: os.Getenv("VSPHERE_DATACENTER"),
-		timeout:    time.Minute * 5,
+		client:             testAccProvider.Meta().(*govmomi.Client),
+		resourceID:         rs.Primary.ID,
+		resourceAttributes: rs.Primary.Attributes,
+		esxiHost:           os.Getenv("VSPHERE_ESXI_HOST"),
+		datacenter:         os.Getenv("VSPHERE_DATACENTER"),
+		timeout:            time.Minute * 5,
 	}, nil
 }
 
@@ -92,4 +100,60 @@ func testGetPortGroup(s *terraform.State, resourceName string) (*types.HostPortG
 	}
 
 	return hostPortGroupFromName(tVars.client, ns, name)
+}
+
+// testGetVirtualMachine is a convenience method to fetch a virtual machine by
+// resource name.
+func testGetVirtualMachine(s *terraform.State, resourceName string) (*object.VirtualMachine, error) {
+	tVars, err := testClientVariablesForResource(s, fmt.Sprintf("vsphere_virtual_machine.%s", resourceName))
+	if err != nil {
+		return nil, err
+	}
+	uuid, ok := tVars.resourceAttributes["uuid"]
+	if !ok {
+		return nil, fmt.Errorf("resource %q has no UUID", resourceName)
+	}
+	return virtualMachineFromUUID(tVars.client, uuid)
+}
+
+// testGetVirtualMachineProperties is a convenience that adds an extra step to
+// testGetVirtualMachine to get the properties of a virtual machine.
+func testGetVirtualMachineProperties(s *terraform.State, resourceName string) (*mo.VirtualMachine, error) {
+	vm, err := testGetVirtualMachine(s, resourceName)
+	if err != nil {
+		return nil, err
+	}
+	return virtualMachineProperties(vm)
+}
+
+// testPowerOffVM does an immediate power-off of the supplied virtual machine
+// resource defined by the supplied resource address name. It is used to help
+// set up a test scenarios where a VM is powered off.
+func testPowerOffVM(s *terraform.State, resourceName string) error {
+	vm, err := testGetVirtualMachine(s, resourceName)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	task, err := vm.PowerOff(ctx)
+	if err != nil {
+		return fmt.Errorf("error powering off VM: %s", err)
+	}
+	tctx, tcancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer tcancel()
+	if err := task.Wait(tctx); err != nil {
+		return fmt.Errorf("error waiting for poweroff: %s", err)
+	}
+	return nil
+}
+
+// copyStatePtr returns a TestCheckFunc that copies the reference to the test
+// run's state to t. This allows access to the state data in later steps where
+// it's not normally accessible (ie: in pre-config parts in another test step).
+func copyStatePtr(t **terraform.State) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		*t = s
+		return nil
+	}
 }

--- a/vsphere/virtual_machine_helper.go
+++ b/vsphere/virtual_machine_helper.go
@@ -1,0 +1,37 @@
+package vsphere
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+// virtualMachineFromUUID locates a virtualMachine by its UUID.
+func virtualMachineFromUUID(client *govmomi.Client, uuid string) (*object.VirtualMachine, error) {
+	search := object.NewSearchIndex(client.Client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	vm, err := search.FindByUuid(ctx, nil, uuid, true, boolPtr(false))
+	if err != nil {
+		return nil, err
+	}
+	// Should be safe to return here. If our reference returned here and is not a
+	// VM, then we have bigger problems and to be honest we should be panicking
+	// anyway.
+	return vm.(*object.VirtualMachine), nil
+}
+
+// virtualMachineProperties is a convenience method that wraps fetching the
+// VirtualMachine MO from its higher-level object.
+func virtualMachineProperties(vm *object.VirtualMachine) (*mo.VirtualMachine, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	var props mo.VirtualMachine
+	if err := vm.Properties(ctx, vm.Reference(), nil, &props); err != nil {
+		return nil, err
+	}
+	return &props, nil
+}

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -151,3 +151,9 @@ The following attributes are exported:
 * `network_interface/ipv4_prefix_length` - See Argument Reference above.
 * `network_interface/ipv6_address` - Assigned static IPv6 address.
 * `network_interface/ipv6_prefix_length` - Prefix length of assigned static IPv6 address.
+* `power_state` - The power state of the virtual machine. Can be one of
+  `poweredOff`, `poweredOn`, or `suspended`.
+
+~> **NOTE:** `power_state` is a pseudo-computed value which enforces
+Terraform's expectation that managed virtual machines are either powered on, or
+destroyed. You cannot edit this value to set a different expected power state.


### PR DESCRIPTION
This commit adds something that we generally assume is correct in
Terraform - that an instance's power state is either one of two states:
on, or gone.

`vsphere_virtual_machine` has had a couple of issues that have been
attributed to power state in the last few months that have been fixed,
but the issue of ensuring that VMs are always powered on has not been
touched on yet.

In this commit, we add the `power_state` pseudo-computed variable,
working around the fact that the provider can't manipulate the diff
directly by using an immutable default to always indicate that a VM that
is powered off or suspended will be turned back on during the next
Terraform run. If a VM is powered off, this turns the VM back on during
the configuration modification phase at the end of the update.

Fixes #134.
Related to #103.