### PR TITLE
website: Add resource categories

### DIFF
--- a/website/docs/r/datacenter.html.markdown
+++ b/website/docs/r/datacenter.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_datacenter"
-sidebar_current: "docs-vsphere-resource-datacenter"
+sidebar_current: "docs-vsphere-resource-inventory-datacenter"
 description: |-
   Provides a VMware vSphere datacenter resource. This can be used as the primary container of inventory objects such as hosts and virtual machines.
 ---

--- a/website/docs/r/file.html.markdown
+++ b/website/docs/r/file.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_file"
-sidebar_current: "docs-vsphere-resource-file"
+sidebar_current: "docs-vsphere-resource-storage-file"
 description: |-
   Provides a VMware vSphere virtual machine file resource. This can be used to upload files (e.g. vmdk disks) from the Terraform host machine to a remote vSphere or copy fields within vSphere.
 ---

--- a/website/docs/r/folder.html.markdown
+++ b/website/docs/r/folder.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_folder"
-sidebar_current: "docs-vsphere-resource-folder"
+sidebar_current: "docs-vsphere-resource-inventory-folder"
 description: |-
   Provides a VMware vSphere virtual machine folder resource. This can be used to create and delete virtual machine folders.
 ---

--- a/website/docs/r/host_port_group.html.markdown
+++ b/website/docs/r/host_port_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_host_port_group"
-sidebar_current: "docs-vsphere-resource-host-port-group"
+sidebar_current: "docs-vsphere-resource-networking-host-port-group"
 description: |-
   Provides a vSphere Host Port Group Resource. This can be used to configure port groups direct on an ESXi host.
 ---

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_host_virtual_switch"
-sidebar_current: "docs-vsphere-resource-host-virtual-switch"
+sidebar_current: "docs-vsphere-resource-networking-host-virtual-switch"
 description: |-
   Provides a vSphere Host Virtual Switch Resource. This can be used to configure vSwitches direct on an ESXi host.
 ---

--- a/website/docs/r/license.html.markdown
+++ b/website/docs/r/license.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_license"
-sidebar_current: "docs-vsphere-resource-license"
+sidebar_current: "docs-vsphere-resource-admin-license"
 description: |-
   Provides a VMware vSphere license resource. This can be used to add and remove license keys.
 ---

--- a/website/docs/r/nas_datastore.html.markdown
+++ b/website/docs/r/nas_datastore.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_nas_datastore"
-sidebar_current: "docs-vsphere-resource-nas-datastore"
+sidebar_current: "docs-vsphere-resource-storage-nas-datastore"
 description: |-
   Provides a vSphere NAS datastore resource. This can be used to mount a NFS share as a datastore on a host.
 ---

--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_virtual_disk"
-sidebar_current: "docs-vsphere-resource-virtual-disk"
+sidebar_current: "docs-vsphere-resource-vm-virtual-disk"
 description: |-
   Provides a VMware virtual disk resource.  This can be used to create and delete virtual disks.
 ---

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_virtual_machine"
-sidebar_current: "docs-vsphere-resource-virtual-machine"
+sidebar_current: "docs-vsphere-resource-vm-virtual-machine"
 description: |-
   Provides a VMware vSphere virtual machine resource. This can be used to create, modify, and delete virtual machines.
 ---

--- a/website/docs/r/virtual_machine_snapshot.html.markdown
+++ b/website/docs/r/virtual_machine_snapshot.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_virtual_machine_snapshot"
-sidebar_current: "docs-vsphere-resource-virtual-machine-snapshot"
+sidebar_current: "docs-vsphere-resource-vm-virtual-machine-snapshot"
 description: |-
   Provides a VMware vSphere virtual machine snapshot resource. This can be used to create and delete virtual machine snapshots.
 ---

--- a/website/docs/r/vmfs_datastore.html.markdown
+++ b/website/docs/r/vmfs_datastore.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_vmfs_datastore"
-sidebar_current: "docs-vsphere-resource-vmfs-datastore"
+sidebar_current: "docs-vsphere-resource-storage-vmfs-datastore"
 description: |-
   Provides a vSphere VMFS datastore resource. This can be used to configure a VMFS datastore on a host or set of hosts.
 ---

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -25,47 +25,70 @@
           </ul>
         </li>
 
-        <li<%= sidebar_current("docs-vsphere-resource") %>>
-          <a href="#">Resources</a>
+        <li<%= sidebar_current("docs-vsphere-resource-inventory") %>>
+          <a href="#">Inventory Resources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-vsphere-resource-datacenter") %>>
+            <li<%= sidebar_current("docs-vsphere-resource-inventory-datacenter") %>>
               <a href="/docs/providers/vsphere/r/datacenter.html">vsphere_datacenter</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-file") %>>
-              <a href="/docs/providers/vsphere/r/file.html">vsphere_file</a>
-            </li>
-            <li<%= sidebar_current("docs-vsphere-resource-folder") %>>
+            <li<%= sidebar_current("docs-vsphere-resource-inventory-folder") %>>
               <a href="/docs/providers/vsphere/r/folder.html">vsphere_folder</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-host-port-group") %>>
-              <a href="/docs/providers/vsphere/r/host_port_group.html">vsphere_host_port_group</a>
-            </li>
-            <li<%= sidebar_current("docs-vsphere-resource-host-virtual-switch") %>>
-              <a href="/docs/providers/vsphere/r/host_virtual_switch.html">vsphere_host_virtual_switch</a>
-            </li>
-            <li<%= sidebar_current("docs-vsphere-resource-license") %>>
-              <a href="/docs/providers/vsphere/r/license.html">vsphere_license</a>
-            </li>
-            <li<%= sidebar_current("docs-vsphere-resource-virtual-disk") %>>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-vsphere-resource-vm") %>>
+          <a href="#">VM and Template Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-disk") %>>
               <a href="/docs/providers/vsphere/r/virtual_disk.html">vsphere_virtual_disk</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-virtual-machine") %>>
+            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-machine") %>>
               <a href="/docs/providers/vsphere/r/virtual_machine.html">vsphere_virtual_machine</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-nas-datastore") %>>
+            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-machine-snapshot") %>>
+              <a href="/docs/providers/vsphere/r/virtual_machine_snapshot.html">vsphere_virtual_machine_snapshot</a>
+            </li>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-vsphere-resource-storage") %>>
+          <a href="#">Storage Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-resource-storage-file") %>>
+              <a href="/docs/providers/vsphere/r/file.html">vsphere_file</a>
+            </li>
+            <li<%= sidebar_current("docs-vsphere-resource-storage-nas-datastore") %>>
               <a href="/docs/providers/vsphere/r/nas_datastore.html">vsphere_nas_datastore</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-vmfs-datastore") %>>
+            <li<%= sidebar_current("docs-vsphere-resource-storage-vmfs-datastore") %>>
               <a href="/docs/providers/vsphere/r/vmfs_datastore.html">vsphere_vmfs_datastore</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-virtual-machine-snapshot") %>>
-              <a href="/docs/providers/vsphere/r/virtual_machine_snapshot.html">vsphere_virtual_machine_snapshot</a>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-vsphere-resource-networking") %>>
+          <a href="#">Networking Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-resource-networking-host-port-group") %>>
+              <a href="/docs/providers/vsphere/r/host_port_group.html">vsphere_host_port_group</a>
+            </li>
+            <li<%= sidebar_current("docs-vsphere-resource-networking-host-virtual-switch") %>>
+              <a href="/docs/providers/vsphere/r/host_virtual_switch.html">vsphere_host_virtual_switch</a>
+            </li>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-vsphere-resource-admin") %>>
+          <a href="#">Administration Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-resource-admin-license") %>>
+              <a href="/docs/providers/vsphere/r/license.html">vsphere_license</a>
             </li>
           </ul>
         </li>
       </ul>
     </div>
   <% end %>
-
   <%= yield %>
 <% end %>

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -25,6 +25,15 @@
           </ul>
         </li>
 
+        <li<%= sidebar_current("docs-vsphere-resource-admin") %>>
+          <a href="#">Administration Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-resource-admin-license") %>>
+              <a href="/docs/providers/vsphere/r/license.html">vsphere_license</a>
+            </li>
+          </ul>
+        </li
+        >
         <li<%= sidebar_current("docs-vsphere-resource-inventory") %>>
           <a href="#">Inventory Resources</a>
           <ul class="nav nav-visible">
@@ -37,17 +46,14 @@
           </ul>
         </li>
 
-        <li<%= sidebar_current("docs-vsphere-resource-vm") %>>
-          <a href="#">VM and Template Resources</a>
+        <li<%= sidebar_current("docs-vsphere-resource-networking") %>>
+          <a href="#">Networking Resources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-disk") %>>
-              <a href="/docs/providers/vsphere/r/virtual_disk.html">vsphere_virtual_disk</a>
+            <li<%= sidebar_current("docs-vsphere-resource-networking-host-port-group") %>>
+              <a href="/docs/providers/vsphere/r/host_port_group.html">vsphere_host_port_group</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-machine") %>>
-              <a href="/docs/providers/vsphere/r/virtual_machine.html">vsphere_virtual_machine</a>
-            </li>
-            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-machine-snapshot") %>>
-              <a href="/docs/providers/vsphere/r/virtual_machine_snapshot.html">vsphere_virtual_machine_snapshot</a>
+            <li<%= sidebar_current("docs-vsphere-resource-networking-host-virtual-switch") %>>
+              <a href="/docs/providers/vsphere/r/host_virtual_switch.html">vsphere_host_virtual_switch</a>
             </li>
           </ul>
         </li>
@@ -67,23 +73,17 @@
           </ul>
         </li>
 
-        <li<%= sidebar_current("docs-vsphere-resource-networking") %>>
-          <a href="#">Networking Resources</a>
+        <li<%= sidebar_current("docs-vsphere-resource-vm") %>>
+          <a href="#">Virtual Machine Resources</a>
           <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-vsphere-resource-networking-host-port-group") %>>
-              <a href="/docs/providers/vsphere/r/host_port_group.html">vsphere_host_port_group</a>
+            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-disk") %>>
+              <a href="/docs/providers/vsphere/r/virtual_disk.html">vsphere_virtual_disk</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-networking-host-virtual-switch") %>>
-              <a href="/docs/providers/vsphere/r/host_virtual_switch.html">vsphere_host_virtual_switch</a>
+            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-machine") %>>
+              <a href="/docs/providers/vsphere/r/virtual_machine.html">vsphere_virtual_machine</a>
             </li>
-          </ul>
-        </li>
-
-        <li<%= sidebar_current("docs-vsphere-resource-admin") %>>
-          <a href="#">Administration Resources</a>
-          <ul class="nav nav-visible">
-            <li<%= sidebar_current("docs-vsphere-resource-admin-license") %>>
-              <a href="/docs/providers/vsphere/r/license.html">vsphere_license</a>
+            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-machine-snapshot") %>>
+              <a href="/docs/providers/vsphere/r/virtual_machine_snapshot.html">vsphere_virtual_machine_snapshot</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
We are getting more resources now, and it will be worthwhile to start
departing them into categories now.

I am breaking down the categories mainly into their specific resource
classes as they are generally seen in vCenter:

* Hosts and Clusters
* VMs and Templates
* Storage
* Networking

There are other classes as well that will have resources that are not
necessarily related to be above that make logical sense:

* Administration - For vCenter and vSphere SSO related admin resources.
Licenses are in this category currently and items like tags and what not
will probably fall here as well.
* Inventory - For inventory management resources, such as datacenters
(which is a fancy top-level resource grouping) and folders (which can be
used across all four of the major resource classes).