### PR TITLE
r/virtual_machine: Updated customization and net waiter behaviour

### DIFF
--- a/tf-vsphere-devrc.mk.example
+++ b/tf-vsphere-devrc.mk.example
@@ -22,6 +22,7 @@ export VSPHERE_ALLOW_UNVERIFIED_SSL ?= false
 # The following variables are shared across various tests. To ensure all tests
 # succeed, it's probably best to set all of these to valid values.
 export VSPHERE_TEMPLATE            ?= base-linux # VM template to clone
+export VSPHERE_TEMPLATE_WINDOWS    ?= base-win   # Windows VM template
 export VSPHERE_NETWORK_LABEL       ?= vm-network # Port group label
 export VSPHERE_NETWORK_LABEL_DHCP  ?= vm-network # Port group label for DHCP
 export VSPHERE_IPV4_ADDRESS        ?= 10.0.0.100 # Customization IP address

--- a/vsphere/event_helper.go
+++ b/vsphere/event_helper.go
@@ -1,0 +1,104 @@
+package vsphere
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/event"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// virtualMachineCustomizationWaiter is an object that waits for customization
+// of a VirtualMachine to complete, by watching for success or failure events.
+//
+// The waiter should be created with newWaiter **before** the start of the
+// customization task to be 100% certain that completion events are not missed.
+type virtualMachineCustomizationWaiter struct {
+	// This channel will be closed upon completion, and should be blocked on.
+	done chan struct{}
+
+	// Any error received from the waiter - be it the customization failure
+	// itself, timeouts waiting for the completion events, or other API-related
+	// errors. This will always be nil until done is closed.
+	err error
+}
+
+// Done returns the done channel. This channel will be closed upon completion,
+// and should be blocked on.
+func (w *virtualMachineCustomizationWaiter) Done() chan struct{} {
+	return w.done
+}
+
+// Err returns any error received from the waiter. This will always be nil
+// until the channel returned by Done is closed.
+func (w *virtualMachineCustomizationWaiter) Err() error {
+	return w.err
+}
+
+// newVirtualMachineCustomizationWaiter returns a new
+// virtualMachineCustomizationWaiter to use to wait for customization on.
+//
+// This should be called **before** the start of the customization task to be
+// 100% certain that completion events are not missed.
+func newVirtualMachineCustomizationWaiter(client *govmomi.Client, vm *object.VirtualMachine) *virtualMachineCustomizationWaiter {
+	w := &virtualMachineCustomizationWaiter{
+		done: make(chan struct{}),
+	}
+	go func() {
+		w.err = w.wait(client, vm)
+		close(w.done)
+	}()
+	return w
+}
+
+// wait waits for the customization of a supplied VirtualMachine to complete,
+// either due to success or error. It does this by watching specifically for
+// CustomizationSucceeded and CustomizationFailed events. If the customization
+// failed due to some sort of error, the full formatted message is returned as
+// an error.
+func (w *virtualMachineCustomizationWaiter) wait(client *govmomi.Client, vm *object.VirtualMachine) error {
+	// Our listener loop callback.
+	success := make(chan struct{})
+	cb := func(obj types.ManagedObjectReference, page []types.BaseEvent) error {
+		for _, be := range page {
+			switch e := be.(type) {
+			case *types.CustomizationFailed:
+				return errors.New(e.GetEvent().FullFormattedMessage)
+			case *types.CustomizationSucceeded:
+				close(success)
+			}
+		}
+		return nil
+	}
+
+	mgr := event.NewManager(client.Client)
+	mgrErr := make(chan error, 1)
+	// Make a proper background context so that we can gracefully cancel the
+	// subscriber when we are done with it. This eventually gets passed down to
+	// the property collector SOAP calls.
+	pctx, pcancel := context.WithCancel(context.Background())
+	defer pcancel()
+	go func() {
+		mgrErr <- mgr.Events(pctx, []types.ManagedObjectReference{vm.Reference()}, 10, true, false, cb)
+	}()
+
+	// This is our waiter. We want to wait on all of these conditions. We also
+	// use a different context so that we can give a better error message on
+	// timeout without interfering with the subscriber's context.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	select {
+	case err := <-mgrErr:
+		return err
+	case <-ctx.Done():
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("timeout waiting for customization to complete")
+		}
+	case <-success:
+		// Pass case to break to success
+	}
+	return nil
+}

--- a/vsphere/virtual_machine_helper.go
+++ b/vsphere/virtual_machine_helper.go
@@ -3,11 +3,14 @@ package vsphere
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 // virtualMachineFromUUID locates a virtualMachine by its UUID.
@@ -53,4 +56,65 @@ func virtualMachineProperties(vm *object.VirtualMachine) (*mo.VirtualMachine, er
 		return nil, err
 	}
 	return &props, nil
+}
+
+// waitForGuestVMNet waits for a virtual machine to have routeable network
+// access. This is denoted as a gateway, and at least one IP address that can
+// reach that gateway. This function supports both IPv4 and IPv6, and returns
+// the moment either stack is routeable - it doesn't wait for both.
+func waitForGuestVMNet(client *govmomi.Client, vm *object.VirtualMachine) error {
+	var v4gw, v6gw net.IP
+
+	p := client.PropertyCollector()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+
+	err := property.Wait(ctx, p, vm.Reference(), []string{"guest.net", "guest.ipStack"}, func(pc []types.PropertyChange) bool {
+		for _, c := range pc {
+			if c.Op != types.PropertyChangeOpAssign {
+				continue
+			}
+
+			switch v := c.Val.(type) {
+			case types.ArrayOfGuestStackInfo:
+				for _, s := range v.GuestStackInfo {
+					if s.IpRouteConfig != nil {
+						for _, r := range s.IpRouteConfig.IpRoute {
+							switch r.Network {
+							case "0.0.0.0":
+								v4gw = net.ParseIP(r.Gateway.IpAddress)
+							case "::":
+								v6gw = net.ParseIP(r.Gateway.IpAddress)
+							}
+						}
+					}
+				}
+			case types.ArrayOfGuestNicInfo:
+				for _, n := range v.GuestNicInfo {
+					if n.IpConfig != nil {
+						for _, addr := range n.IpConfig.IpAddress {
+							ip := net.ParseIP(addr.IpAddress)
+							var mask net.IPMask
+							if ip.To4() != nil {
+								mask = net.CIDRMask(int(addr.PrefixLength), 32)
+							} else {
+								mask = net.CIDRMask(int(addr.PrefixLength), 128)
+							}
+							if ip.Mask(mask).Equal(v4gw.Mask(mask)) || ip.Mask(mask).Equal(v6gw.Mask(mask)) {
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return false
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -61,41 +61,79 @@ resource "vsphere_virtual_machine" "lb" {
 
 The following arguments are supported:
 
-* `name` - (Required) The virtual machine name (cannot contain underscores and must be less than 15 characters)
+* `name` - (Required) The virtual machine name (cannot contain underscores and
+  must be less than 15 characters)
 * `folder` - (Optional) The folder to group the VM in.
-* `vcpu` - (Required) The number of virtual CPUs to allocate to the virtual machine
-* `memory` - (Required) The amount of RAM (in MB) to allocate to the virtual machine
-* `hostname` - (Optional) The virtual machine hostname used during the OS customization. Defaults to the `name` attribute.
-* `memory_reservation` - (Optional) The amount of RAM (in MB) to reserve physical memory resource; defaults to 0 (means not to reserve)
-* `datacenter` - (Optional) The name of a Datacenter in which to launch the virtual machine
-* `cluster` - (Optional) Name of a Cluster in which to launch the virtual machine
-* `resource_pool` (Optional) The name of a Resource Pool in which to launch the virtual machine. Requires full path (see cluster example).
-* `gateway` - __Deprecated, please use `network_interface.ipv4_gateway` instead__.
-* `domain` - (Optional) A FQDN for the virtual machine; defaults to "vsphere.local"
-* `time_zone` - (Optional) The [Linux](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/timezone.html) or [Windows](https://msdn.microsoft.com/en-us/library/ms912391.aspx) time zone to set on the virtual machine. Defaults to "Etc/UTC"
-* `dns_suffixes` - (Optional) List of name resolution suffixes for the virtual network adapter
-* `dns_servers` - (Optional) List of DNS servers for the virtual network adapter; defaults to 8.8.8.8, 8.8.4.4
-* `network_interface` - (Required) Configures virtual network interfaces; see [Network Interfaces](#network-interfaces) below for details.
-* `disk` - (Required) Configures virtual disks; see [Disks](#disks) below for details
-* `detach_unknown_disks_on_delete` - (Optional) will detach disks not managed by this resource on delete (avoids deletion of disks attached after resource creation outside of Terraform scope).
-* `cdrom` - (Optional) Configures a CDROM device and mounts an image as its media; see [CDROM](#cdrom) below for more details.
-* `windows_opt_config` - (Optional) Extra options for clones of Windows machines.
-* `linked_clone` - (Optional) Specifies if the new machine is a [linked clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396) of another machine or not.
-* `enable_disk_uuid` - (Optional) This option causes the vm to mount disks by uuid on the guest OS.
-* `custom_configuration_parameters` - (Optional) Map of values that is set as virtual machine custom configurations.
-* `skip_customization` - (Optional) skip virtual machine customization (useful if OS is not in the guest OS support matrix of VMware like "other3xLinux64Guest").
+* `vcpu` - (Required) The number of virtual CPUs to allocate to the virtual
+  machine
+* `memory` - (Required) The amount of RAM (in MB) to allocate to the virtual
+  machine
+* `hostname` - (Optional) The virtual machine hostname used during the OS
+  customization. Defaults to the `name` attribute.
+* `memory_reservation` - (Optional) The amount of RAM (in MB) to reserve
+  physical memory resource; defaults to 0 (means not to reserve)
+* `datacenter` - (Optional) The name of a Datacenter in which to launch the
+  virtual machine
+* `cluster` - (Optional) Name of a Cluster in which to launch the virtual
+  machine
+* `resource_pool` (Optional) The name of a Resource Pool in which to launch the
+  virtual machine. Requires full path (see cluster example).
+* `gateway` - __Deprecated, please use `network_interface.ipv4_gateway`
+  instead__.
+* `domain` - (Optional) A FQDN for the virtual machine; defaults to
+  "vsphere.local"
+* `time_zone` - (Optional) The
+  [Linux](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/timezone.html)
+  or [Windows](https://msdn.microsoft.com/en-us/library/ms912391.aspx) time
+  zone to set on the virtual machine. Defaults to "Etc/UTC"
+* `dns_suffixes` - (Optional) List of name resolution suffixes for the virtual
+  network adapter
+* `dns_servers` - (Optional) List of DNS servers for the virtual network
+  adapter; defaults to 8.8.8.8, 8.8.4.4
+* `network_interface` - (Required) Configures virtual network interfaces; see
+  [Network Interfaces](#network-interfaces) below for details.
+* `disk` - (Required) Configures virtual disks; see [Disks](#disks) below for
+  details
+* `detach_unknown_disks_on_delete` - (Optional) will detach disks not managed
+  by this resource on delete (avoids deletion of disks attached after resource
+  creation outside of Terraform scope).
+* `cdrom` - (Optional) Configures a CDROM device and mounts an image as its
+  media; see [CDROM](#cdrom) below for more details.
+* `windows_opt_config` - (Optional) Extra options for clones of Windows
+  machines.
+* `linked_clone` - (Optional) Specifies if the new machine is a [linked
+  clone](https://www.vmware.com/support/ws5/doc/ws_clone_overview.html#wp1036396)
+  of another machine or not.
+* `enable_disk_uuid` - (Optional) This option causes the vm to mount disks by
+  uuid on the guest OS.
+* `custom_configuration_parameters` - (Optional) Map of values that is set as
+  virtual machine custom configurations.
+* `skip_customization` - (Optional) Skip virtual machine customization (useful
+  if OS is not in the guest OS support matrix of VMware like
+  "other3xLinux64Guest").
+* `wait_for_guest_net` - (Optional) Whether or not to wait for a VM to have
+  routeable network access. Should be set to `false` if none of the defined
+  `network_interface`s has a gateway assigned, or if all interfaces have been
+  left unconfigured. Default: `true`.
 * `annotation` - (Optional) Edit the annotation notes field
 
 The `network_interface` block supports:
 
 * `label` - (Required) Label to assign to this network interface
-* `ipv4_address` - (Optional) Static IPv4 to assign to this network interface. Interface will use DHCP if this is left blank.
-* `ipv4_prefix_length` - (Optional) prefix length to use when statically assigning an IPv4 address.
+* `ipv4_address` - (Optional) Static IPv4 to assign to this network interface.
+  Interface will use DHCP if this is left blank.
+* `ipv4_prefix_length` - (Optional) prefix length to use when statically
+  assigning an IPv4 address.
 * `ipv4_gateway` - (Optional) IPv4 gateway IP address to use.
-* `ipv6_address` - (Optional) Static IPv6 to assign to this network interface. Interface will use DHCPv6 if this is left blank.
-* `ipv6_prefix_length` - (Optional) prefix length to use when statically assigning an IPv6.
+* `ipv6_address` - (Optional) Static IPv6 to assign to this network interface.
+  Interface will use DHCPv6 if this is left blank.
+* `ipv6_prefix_length` - (Optional) prefix length to use when statically
+  assigning an IPv6.
 * `ipv6_gateway` - (Optional) IPv6 gateway IP address to use.
-* `mac_address` - (Optional) Manual MAC address to assign to this network interface. Will be generated by VMware if not set. ([VMware KB: Setting a static MAC address for a virtual NIC (219)](https://kb.vmware.com/selfservice/microsites/search.do?cmd=displayKC&externalId=219))
+* `mac_address` - (Optional) Manual MAC address to assign to this network
+  interface. Will be generated by VMware if not set. ([VMware KB: Setting a
+  static MAC address for a virtual NIC
+  (219)](https://kb.vmware.com/selfservice/microsites/search.do?cmd=displayKC&externalId=219))
 
 The following arguments are maintained for backwards compatibility and may be
 removed in a future version:
@@ -105,9 +143,14 @@ removed in a future version:
 
 The `windows_opt_config` block supports:
 
-* `product_key` - (Optional) Serial number for new installation of Windows. This serial number is ignored if the original guest operating system was installed using a volume-licensed CD.
-* `admin_password` - (Optional) The password for the new `administrator` account. Omit for passwordless admin (using `""` does not work).
-* `domain` - (Optional) Domain that the new machine will be placed into. If `domain`, `domain_user`, and `domain_user_password` are not all set, all three will be ignored.
+* `product_key` - (Optional) Serial number for new installation of Windows.
+  This serial number is ignored if the original guest operating system was
+  installed using a volume-licensed CD.
+* `admin_password` - (Optional) The password for the new `administrator`
+  account. Omit for passwordless admin (using `""` does not work).
+* `domain` - (Optional) Domain that the new machine will be placed into. If
+  `domain`, `domain_user`, and `domain_user_password` are not all set, all
+  three will be ignored.
 * `domain_user` - (Optional) User that is a member of the specified domain.
 * `domain_user_password` - (Optional) Password for domain user, in plain text.
 
@@ -116,15 +159,22 @@ The `windows_opt_config` block supports:
 
 The `disk` block supports:
 
-* `template` - (Required if size and bootable_vmdk_path not provided) Template for this disk.
+* `template` - (Required if size and bootable_vmdk_path not provided) Template
+  for this disk.
 * `datastore` - (Optional) Datastore for this disk
-* `size` - (Required if template and bootable_vmdks_path not provided) Size of this disk (in GB).
-* `name` - (Required if size is provided when creating a new disk) This "name" is used for the disk file name in vSphere, when the new disk is created.
+* `size` - (Required if template and bootable_vmdks_path not provided) Size of
+  this disk (in GB).
+* `name` - (Required if size is provided when creating a new disk) This "name"
+  is used for the disk file name in vSphere, when the new disk is created.
 * `iops` - (Optional) Number of virtual iops to allocate for this disk.
-* `type` - (Optional) 'eager_zeroed' (the default), 'lazy', or 'thin' are supported options.
-* `vmdk` - (Required if template and size not provided) Path to a vmdk in a vSphere datastore.
-* `bootable` - (Optional) Set to 'true' if a vmdk was given and it should attempt to boot after creation.
-* `controller_type` - (Optional) Controller type to attach the disk to.  'scsi' (the default), or 'ide' are supported options.
+* `type` - (Optional) 'eager_zeroed' (the default), 'lazy', or 'thin' are
+  supported options.
+* `vmdk` - (Required if template and size not provided) Path to a vmdk in a
+  vSphere datastore.
+* `bootable` - (Optional) Set to 'true' if a vmdk was given and it should
+  attempt to boot after creation.
+* `controller_type` - (Optional) Controller type to attach the disk to.  'scsi'
+  (the default), or 'ide' are supported options.
 * `keep_on_remove` - (Optional) Set to 'true' to not delete a disk on removal.
 
 <a id="cdrom"></a>
@@ -132,7 +182,8 @@ The `disk` block supports:
 
 The `cdrom` block supports:
 
-* `datastore` - (Required) The name of the datastore where the disk image is stored.
+* `datastore` - (Required) The name of the datastore where the disk image is
+  stored.
 * `path` - (Required) The absolute path to the image within the datastore.
 
 ## Attributes Reference
@@ -150,7 +201,8 @@ The following attributes are exported:
 * `network_interface/ipv4_address` - See Argument Reference above.
 * `network_interface/ipv4_prefix_length` - See Argument Reference above.
 * `network_interface/ipv6_address` - Assigned static IPv6 address.
-* `network_interface/ipv6_prefix_length` - Prefix length of assigned static IPv6 address.
+* `network_interface/ipv6_prefix_length` - Prefix length of assigned static
+  IPv6 address.
 * `power_state` - The power state of the virtual machine. Can be one of
   `poweredOff`, `poweredOn`, or `suspended`.
 


### PR DESCRIPTION
This is a two-part change that ultimately changes/Fixes customization
workflow, but has some other implications:

* First off, we are now waiting for customization to complete by
watching VM events. This is the correct way to wait for customization to
complete as the actual customization task returns very quickly, while
the actual customization process can actually take a few minutes and
fail out-of-band of the initial task.

* Second off, we are now no longer waiting for all interfaces to have IP
addresses during Read, rather we are now waiting for a **routeable**
network. This fixes situations where a template may be configured for
DHCP and gets an auto-configuration address before actually getting an
IP. This seems to come up during Windows customization especially,
which is what we are trying to fix with this work, so having the event
watch fix without having this one would not fix the issue completely.

* The `wait_for_guest_net` option has also been added, which allows
someone to completely turn off the network waiter. This should help
alleviate some edge cases where NICs have not been configured with IP
addresses, and also allows someone to bypass this behaviour if they are
not configuring a gateway on the VM through either static configuration
of DHCP.

-----

Finally, as part of the additional testing work, the network waiter has been moved to the `Create` and `Update` functions of the resource, rather than the `Read` function. This is required especially on `Create` to ensure that created VMs can be rolled back properly by `terraform destroy`, which will do an initial refresh prior to destroy to get an updated state.

Fixes #140.