### PR TITLE
increase defaultAPITimeout to 10min

### DIFF
--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -10,7 +10,7 @@ import (
 
 // defaultAPITimeout is a default timeout value that is passed to functions
 // requiring contexts, and other various waiters.
-var defaultAPITimeout = time.Minute * 5
+var defaultAPITimeout = time.Minute * 10
 
 // Provider returns a terraform.ResourceProvider.
 func Provider() terraform.ResourceProvider {

--- a/vsphere/resource_vsphere_virtual_machine_snapshot.go
+++ b/vsphere/resource_vsphere_virtual_machine_snapshot.go
@@ -63,7 +63,7 @@ func resourceVSphereVirtualMachineSnapshotCreate(d *schema.ResourceData, meta in
 	if err != nil {
 		return fmt.Errorf("Error while getting the VirtualMachine :%s", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout) // This is 5 mins
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout) // This is 10 mins
 	defer cancel()
 	task, err := vm.CreateSnapshot(ctx, d.Get("snapshot_name").(string), d.Get("description").(string), d.Get("memory").(bool), d.Get("quiesce").(bool))
 	tctx, tcancel := context.WithTimeout(context.Background(), defaultAPITimeout)
@@ -112,7 +112,7 @@ func resourceVSphereVirtualMachineSnapshotDelete(d *schema.ResourceData, meta in
 	} else {
 		removeChildren = false
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout) // This is 5 mins
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout) // This is 10 mins
 	defer cancel()
 	task, err := vm.RemoveSnapshot(ctx, d.Id(), removeChildren, consolidatePtr)
 	if err != nil {
@@ -137,7 +137,7 @@ func resourceVSphereVirtualMachineSnapshotRead(d *schema.ResourceData, meta inte
 	if err != nil {
 		return fmt.Errorf("Error while getting the VirtualMachine :%s", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout) // This is 5 mins
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout) // This is 10 mins
 	defer cancel()
 	snapshot, err := vm.FindSnapshot(ctx, d.Id())
 	if err != nil {

--- a/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
@@ -84,7 +84,7 @@ func testAccCheckVirtualMachineSnapshotExists(n string) resource.TestCheckFunc {
 		if err != nil {
 			return fmt.Errorf("error %s", err)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout) // This is 5 mins
+		ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout) // This is 10 mins
 		defer cancel()
 		snapshot, err := vm.FindSnapshot(ctx, rs.Primary.ID)
 		if err != nil {


### PR DESCRIPTION
This PR responds to issue [#160](https://github.com/terraform-providers/terraform-provider-vsphere/issues/160)

The default value of `defaultAPITimeout` in some cases like vmware customization is set to too low value.
The proposal is to set `defaultAPITimeout` to 10 minutes from 5 minutes. I hope it should be enough for all vsphere actions.

Alternative solution is to add a global parameter `api_timeout` to vsphere provider or even to populate it to specific resources.