### PR TITLE
New data source: vsphere_tag_category

### DIFF
--- a/vsphere/data_source_vsphere_tag_category.go
+++ b/vsphere/data_source_vsphere_tag_category.go
@@ -1,0 +1,47 @@
+package vsphere
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func dataSourceVSphereTagCategory() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereTagCategoryRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The display name of the category.",
+				Required:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the category.",
+			},
+			"cardinality": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The associated cardinality of the category. Can be one of SINGLE (object can only be assigned one tag in this category) or MULTIPLE (object can be assigned multiple tags in this category).",
+			},
+			"associable_types": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Object types to which this category's tags can be attached.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceVSphereTagCategoryRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*VSphereClient).TagsClient()
+	if err != nil {
+		return err
+	}
+
+	id, err := tagCategoryByName(client, d.Get("name").(string))
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id)
+	return resourceVSphereTagCategoryRead(d, meta)
+}

--- a/vsphere/data_source_vsphere_tag_category_test.go
+++ b/vsphere/data_source_vsphere_tag_category_test.go
@@ -1,0 +1,115 @@
+package vsphere
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceVSphereTagCategory(t *testing.T) {
+	var tp *testing.T
+	testAccDataSourceVSphereTagCategoryCases := []struct {
+		name     string
+		testCase resource.TestCase
+	}{
+		{
+			"basic",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataSourceVSphereTagCategoryConfig(),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr(
+								"data.vsphere_tag_category.terraform-test-category-data",
+								"name",
+								testAccDataSourceVSphereTagCategoryConfigName,
+							),
+							resource.TestCheckResourceAttr(
+								"data.vsphere_tag_category.terraform-test-category-data",
+								"description",
+								testAccDataSourceVSphereTagCategoryConfigDescription,
+							),
+							resource.TestCheckResourceAttr(
+								"data.vsphere_tag_category.terraform-test-category-data",
+								"cardinality",
+								testAccDataSourceVSphereTagCategoryConfigCardinality,
+							),
+							resource.TestCheckResourceAttr(
+								"data.vsphere_tag_category.terraform-test-category-data",
+								"associable_types.#",
+								"1",
+							),
+							resource.TestCheckResourceAttr(
+								"data.vsphere_tag_category.terraform-test-category-data",
+								"associable_types.3125094965",
+								testAccDataSourceVSphereTagCategoryConfigAssociableType,
+							),
+							resource.TestCheckResourceAttrPair(
+								"data.vsphere_tag_category.terraform-test-category-data", "id",
+								"vsphere_tag_category.terraform-test-category", "id",
+							),
+						),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testAccDataSourceVSphereTagCategoryCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tp = t
+			resource.Test(t, tc.testCase)
+		})
+	}
+}
+
+const testAccDataSourceVSphereTagCategoryConfigName = "terraform-test-category"
+const testAccDataSourceVSphereTagCategoryConfigDescription = "Managed by Terraform"
+const testAccDataSourceVSphereTagCategoryConfigCardinality = vSphereTagCategoryCardinalitySingle
+const testAccDataSourceVSphereTagCategoryConfigAssociableType = vSphereTagCategoryAssociableTypeVirtualMachine
+
+func testAccDataSourceVSphereTagCategoryConfig() string {
+	return fmt.Sprintf(`
+variable "tag_category_name" {
+  default = "%s"
+}
+
+variable "tag_category_description" {
+  default = "%s"
+}
+
+variable "tag_category_cardinality" {
+  default = "%s"
+}
+
+variable "tag_category_associable_types" {
+  default = [
+    "%s",
+  ]
+}
+
+resource "vsphere_tag_category" "terraform-test-category" {
+  name        = "${var.tag_category_name}"
+  description = "${var.tag_category_description}"
+  cardinality = "${var.tag_category_cardinality}"
+
+  associable_types = [
+    "${var.tag_category_associable_types}",
+  ]
+}
+
+data "vsphere_tag_category" "terraform-test-category-data" {
+  name = "${vsphere_tag_category.terraform-test-category.name}"
+}
+`,
+		testAccDataSourceVSphereTagCategoryConfigName,
+		testAccDataSourceVSphereTagCategoryConfigDescription,
+		testAccDataSourceVSphereTagCategoryConfigCardinality,
+		testAccDataSourceVSphereTagCategoryConfigAssociableType,
+	)
+}

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -84,9 +84,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"vsphere_datacenter": dataSourceVSphereDatacenter(),
-			"vsphere_host":       dataSourceVSphereHost(),
-			"vsphere_vmfs_disks": dataSourceVSphereVmfsDisks(),
+			"vsphere_datacenter":   dataSourceVSphereDatacenter(),
+			"vsphere_host":         dataSourceVSphereHost(),
+			"vsphere_tag_category": dataSourceVSphereTagCategory(),
+			"vsphere_vmfs_disks":   dataSourceVSphereVmfsDisks(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -1,8 +1,25 @@
 package vsphere
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/vmware/govmomi"
+	"github.com/vmware/vic/pkg/vsphere/tags"
 )
+
+// vSphereTagCategorySearchErrMultiple is an error message format for a tag
+// category search that returned multiple results. This is a bug and needs to
+// be reported so we can adjust the API.
+const vSphereTagCategorySearchErrMultiple = `
+Category name %q returned multiple results!
+
+This is a bug - please report it at:
+https://github.com/terraform-providers/terraform-provider-vsphere/issues
+
+This version of the provider requires unique category names. To work around
+this issue, please use a category name unique within your vCenter system.
+`
 
 // tagsMinVersion is the minimum vSphere version required for tags.
 var tagsMinVersion = vSphereVersion{
@@ -23,4 +40,29 @@ func isEligibleTagEndpoint(client *govmomi.Client) bool {
 		return false
 	}
 	return true
+}
+
+// tagCategoryByName locates a tag category by name. It's used by the
+// vsphere_tag_category data source, and the resource importer.
+func tagCategoryByName(client *tags.RestClient, name string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	cats, err := client.GetCategoriesByName(ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("could not get category for name %q: %s", name, err)
+	}
+
+	if len(cats) < 1 {
+		return "", fmt.Errorf("category name %q not found", name)
+	}
+	if len(cats) > 1 {
+		// Although GetCategoriesByName does not seem to think that tag categories
+		// are unique, empirical observation via the console and API show that they
+		// are. If for some reason the returned results includes more than one ID,
+		// we give an error, indicating that this is a bug and the user should
+		// submit an issue.
+		return "", fmt.Errorf(vSphereTagCategorySearchErrMultiple, name)
+	}
+
+	return cats[0].ID, nil
 }

--- a/website/docs/d/tag_category.html.markdown
+++ b/website/docs/d/tag_category.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_tag_category"
+sidebar_current: "docs-vsphere-data-source-tag-category"
+description: |-
+  Provides a vSphere tag category data source. This can be used to reference tag categories not managed in Terraform.
+---
+
+# vsphere\_tag\_category
+
+The `vsphere_tag_category` data source can be used to reference tag categories
+that are not managed by Terraform. Its attributes are exactly the same as the
+[`vsphere_tag_category` resource][resource-tag-category], and, like importing,
+the data source takes a name to search on. The `id` and other attributes are
+then populated with the data found by the search.
+
+[resource-tag-category]: /docs/providers/vsphere/r/tag_category.html
+
+~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.
+
+## Example Usage
+
+```hcl
+data "vsphere_tag_category" "category" {
+  name = "terraform-test-category"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (String, required) The name of the tag category.
+
+## Attribute Reference
+
+In addition to the `id` being exported, all of the fields that are available in
+the [`vsphere_tag_category` resource][resource-tag-category] are also
+populated. See that page for further details.

--- a/website/docs/r/tag_category.html.markdown
+++ b/website/docs/r/tag_category.html.markdown
@@ -22,8 +22,6 @@ information about tag categories specifically, click
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.
 
-[resource-vmfs-datastore]: /docs/providers/vsphere/r/vmfs_datastore.html
-
 ## Example Usage
 
 This example creates a tag category named `terraform-test-category`, with
@@ -48,8 +46,8 @@ resource "vsphere_tag_category" "category" {
 
 The following arguments are supported:
 
-* `name` - (String, required) The name of the tag.
-* `description` - (String, optional) A description for the tag.
+* `name` - (String, required) The name of the category.
+* `description` - (String, optional) A description for the category.
 * `cardinality` - (String, required, forces new resource) The number of tags
   that can be assigned from this category to a single object at once. Can be
   one of `SINGLE` (object can only be assigned one tag in this category), to

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -19,6 +19,9 @@
             <li<%= sidebar_current("docs-vsphere-data-source-host") %>>
               <a href="/docs/providers/vsphere/d/host.html">vsphere_host</a>
             </li>
+            <li<%= sidebar_current("docs-vsphere-data-source-tag-category") %>>
+              <a href="/docs/providers/vsphere/d/tag_category.html">vsphere_tag_category</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-data-source-vmfs-disks") %>>
               <a href="/docs/providers/vsphere/d/vmfs_disks.html">vsphere_vmfs_disks</a>
             </li>


### PR DESCRIPTION
This is the data source counterpart to the new `vsphere_tag_category`
resource. It allows one to pull in an external tag category by name,
using most of the same search call stack as importing.