### PR TITLE
r/virtual_machine: Increase customization timeout to 10 mins

### DIFF
--- a/vsphere/event_helper.go
+++ b/vsphere/event_helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/event"
@@ -15,6 +16,10 @@ import (
 const (
 	eventTypeCustomizationSucceeded = "CustomizationSucceeded"
 )
+
+// virtualMachineCustomizationWaiterTimeout is the default time that
+// virtualMachineCustomizationWaiter waits for a success or failure event.
+const virtualMachineCustomizationWaiterTimeout = time.Minute * 10
 
 // virtualMachineCustomizationWaiter is an object that waits for customization
 // of a VirtualMachine to complete, by watching for success or failure events.
@@ -93,7 +98,7 @@ func (w *virtualMachineCustomizationWaiter) wait(client *govmomi.Client, vm *obj
 	// This is our waiter. We want to wait on all of these conditions. We also
 	// use a different context so that we can give a better error message on
 	// timeout without interfering with the subscriber's context.
-	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), virtualMachineCustomizationWaiterTimeout)
 	defer cancel()
 	select {
 	case err := <-mgrErr:

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -10,7 +10,7 @@ import (
 
 // defaultAPITimeout is a default timeout value that is passed to functions
 // requiring contexts, and other various waiters.
-var defaultAPITimeout = time.Minute * 5
+const defaultAPITimeout = time.Minute * 5
 
 // Provider returns a terraform.ResourceProvider.
 func Provider() terraform.ResourceProvider {


### PR DESCRIPTION
Users have been reporting that 5 minutes is probably too short. Indeed,
in our lab it takes about 3 mins to complete (using nested ESXi and
datastores that are on SSDs), so this is definitely reasonable.

Adjusting this to 10 minutes which should hopefully be good for the vast
majority of cases. If need be, we can make this configurable, but then
we are wading into provider timeout territory as well.

-----

Also included in this is the adjustment of `defaultAPITimeout` to a const, since `time.Duration` is an int64 and can accommodate this.

Fixes #160 