### PR TITLE
New resource and data source: vsphere_tag

### DIFF
--- a/vendor/github.com/vmware/vic/pkg/vsphere/tags/tags.go
+++ b/vendor/github.com/vmware/vic/pkg/vsphere/tags/tags.go
@@ -41,6 +41,15 @@ type TagCreate struct {
 	Name        string `json:"name"`
 }
 
+type TagUpdateSpec struct {
+	UpdateSpec TagUpdate `json:"update_spec"`
+}
+
+type TagUpdate struct {
+	Description string `json:"description"`
+	Name        string `json:"name"`
+}
+
 type Tag struct {
 	ID          string   `json:"id"`
 	Description string   `json:"description"`
@@ -130,6 +139,19 @@ func (c *RestClient) GetTag(ctx context.Context, id string) (*Tag, error) {
 		return nil, errors.Wrapf(err, "failed to get tag %s", id)
 	}
 	return &(pTag.Value), nil
+}
+
+func (c *RestClient) UpdateTag(ctx context.Context, id string, spec *TagUpdateSpec) error {
+	Logger.Debugf("Update tag %v", spec)
+	_, _, status, err := c.call(ctx, "PATCH", fmt.Sprintf("%s/id:%s", TagURL, id), spec, nil)
+
+	Logger.Debugf("Get status code: %d", status)
+	if status != http.StatusOK || err != nil {
+		Logger.Debugf("Update tag failed with status code: %d, error message: %s", status, errors.WithStack(err))
+		return errors.Wrapf(err, "Status code: %d", status)
+	}
+
+	return nil
 }
 
 func (c *RestClient) DeleteTag(ctx context.Context, id string) error {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -844,11 +844,11 @@
 			"versionExact": "v0.15.0"
 		},
 		{
-			"checksumSHA1": "Q8wmC6TMEu4D4BpkHyXPKkoCOLk=",
+			"checksumSHA1": "jxajBXMRa5ObHWsnT1ANtYvpMAQ=",
 			"origin": "github.com/vancluever/vic/pkg/vsphere/tags",
 			"path": "github.com/vmware/vic/pkg/vsphere/tags",
-			"revision": "0ca6b21ab856d28af7f7192f0b608a02306764e6",
-			"revisionTime": "2017-09-17T15:19:26Z"
+			"revision": "b2171f171d8d190d3cff1d779b339a848b32b8a7",
+			"revisionTime": "2017-09-20T22:12:48Z"
 		},
 		{
 			"checksumSHA1": "vE43s37+4CJ2CDU6TlOUOYE0K9c=",

--- a/vsphere/data_source_vsphere_tag.go
+++ b/vsphere/data_source_vsphere_tag.go
@@ -1,0 +1,44 @@
+package vsphere
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func dataSourceVSphereTag() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereTagRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The display name of the tag.",
+				Required:    true,
+			},
+			"category_id": {
+				Type:        schema.TypeString,
+				Description: "The unique identifier of the parent category for this tag.",
+				Required:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "The description of the tag.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceVSphereTagRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*VSphereClient).TagsClient()
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name").(string)
+	categoryID := d.Get("category_id").(string)
+
+	tagID, err := tagByName(client, name, categoryID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(tagID)
+	return resourceVSphereTagRead(d, meta)
+}

--- a/vsphere/data_source_vsphere_tag_test.go
+++ b/vsphere/data_source_vsphere_tag_test.go
@@ -1,0 +1,119 @@
+package vsphere
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceVSphereTag(t *testing.T) {
+	var tp *testing.T
+	testAccDataSourceVSphereTagCases := []struct {
+		name     string
+		testCase resource.TestCase
+	}{
+		{
+			"basic",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataSourceVSphereTagConfig(),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr(
+								"data.vsphere_tag.terraform-test-tag-data",
+								"name",
+								testAccDataSourceVSphereTagConfigName,
+							),
+							resource.TestCheckResourceAttr(
+								"data.vsphere_tag.terraform-test-tag-data",
+								"description",
+								testAccDataSourceVSphereTagConfigDescription,
+							),
+							resource.TestCheckResourceAttrPair(
+								"data.vsphere_tag.terraform-test-tag-data", "id",
+								"vsphere_tag.terraform-test-tag", "id",
+							),
+							resource.TestCheckResourceAttrPair(
+								"data.vsphere_tag.terraform-test-tag-data", "category_id",
+								"vsphere_tag_category.terraform-test-category", "id",
+							),
+						),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testAccDataSourceVSphereTagCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tp = t
+			resource.Test(t, tc.testCase)
+		})
+	}
+}
+
+const testAccDataSourceVSphereTagConfigName = "terraform-test-tag"
+const testAccDataSourceVSphereTagConfigDescription = "Managed by Terraform"
+
+func testAccDataSourceVSphereTagConfig() string {
+	return fmt.Sprintf(`
+variable "tag_category_name" {
+  default = "%s"
+}
+
+variable "tag_category_description" {
+  default = "%s"
+}
+
+variable "tag_category_cardinality" {
+  default = "%s"
+}
+
+variable "tag_category_associable_types" {
+  default = [
+    "%s",
+  ]
+}
+
+variable "tag_name" {
+  default = "%s"
+}
+
+variable "tag_description" {
+  default = "%s"
+}
+
+resource "vsphere_tag_category" "terraform-test-category" {
+  name        = "${var.tag_category_name}"
+  description = "${var.tag_category_description}"
+  cardinality = "${var.tag_category_cardinality}"
+
+  associable_types = [
+    "${var.tag_category_associable_types}",
+  ]
+}
+
+resource "vsphere_tag" "terraform-test-tag" {
+  name        = "${var.tag_name}"
+  description = "${var.tag_description}"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+
+data "vsphere_tag" "terraform-test-tag-data" {
+  name        = "${vsphere_tag.terraform-test-tag.name}"
+  category_id = "${vsphere_tag.terraform-test-tag.category_id}"
+}
+`,
+		testAccDataSourceVSphereTagCategoryConfigName,
+		testAccDataSourceVSphereTagCategoryConfigDescription,
+		testAccDataSourceVSphereTagCategoryConfigCardinality,
+		testAccDataSourceVSphereTagCategoryConfigAssociableType,
+		testAccDataSourceVSphereTagConfigName,
+		testAccDataSourceVSphereTagConfigDescription,
+	)
+}

--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -169,6 +169,22 @@ func testGetTagCategory(s *terraform.State, resourceName string) (*tags.Category
 	return category, nil
 }
 
+// testGetTag gets a tag by name.
+func testGetTag(s *terraform.State, resourceName string) (*tags.Tag, error) {
+	tVars, err := testClientVariablesForResource(s, fmt.Sprintf("vsphere_tag.%s", resourceName))
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	tag, err := tVars.tagsClient.GetTag(ctx, tVars.resourceID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get tag for ID %q: %s", tVars.resourceID, err)
+	}
+
+	return tag, nil
+}
+
 // copyStatePtr returns a TestCheckFunc that copies the reference to the test
 // run's state to t. This allows access to the state data in later steps where
 // it's not normally accessible (ie: in pre-config parts in another test step).

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -75,6 +75,7 @@ func Provider() terraform.ResourceProvider {
 			"vsphere_host_port_group":          resourceVSphereHostPortGroup(),
 			"vsphere_host_virtual_switch":      resourceVSphereHostVirtualSwitch(),
 			"vsphere_license":                  resourceVSphereLicense(),
+			"vsphere_tag":                      resourceVSphereTag(),
 			"vsphere_tag_category":             resourceVSphereTagCategory(),
 			"vsphere_virtual_disk":             resourceVSphereVirtualDisk(),
 			"vsphere_virtual_machine":          resourceVSphereVirtualMachine(),

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -87,6 +87,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"vsphere_datacenter":   dataSourceVSphereDatacenter(),
 			"vsphere_host":         dataSourceVSphereHost(),
+			"vsphere_tag":          dataSourceVSphereTag(),
 			"vsphere_tag_category": dataSourceVSphereTagCategory(),
 			"vsphere_vmfs_disks":   dataSourceVSphereVmfsDisks(),
 		},

--- a/vsphere/resource_vsphere_tag.go
+++ b/vsphere/resource_vsphere_tag.go
@@ -1,0 +1,167 @@
+package vsphere
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/vmware/vic/pkg/vsphere/tags"
+)
+
+func resourceVSphereTag() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVSphereTagCreate,
+		Read:   resourceVSphereTagRead,
+		Update: resourceVSphereTagUpdate,
+		Delete: resourceVSphereTagDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceVSphereTagImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The display name of the tag. The name must be unique within its category.",
+				Required:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "The description of the tag.",
+				Optional:    true,
+			},
+			"category_id": {
+				Type:        schema.TypeString,
+				Description: "The unique identifier of the parent category in which this tag will be created.",
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceVSphereTagCreate(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*VSphereClient).TagsClient()
+	if err != nil {
+		return err
+	}
+
+	spec := &tags.TagCreateSpec{
+		CreateSpec: tags.TagCreate{
+			CategoryID:  d.Get("category_id").(string),
+			Description: d.Get("description").(string),
+			Name:        d.Get("name").(string),
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	id, err := client.CreateTag(ctx, spec)
+	if err != nil {
+		return fmt.Errorf("could not create tag: %s", err)
+	}
+	if id == nil {
+		return errors.New("no ID was returned")
+	}
+	d.SetId(*id)
+	return resourceVSphereTagRead(d, meta)
+}
+
+func resourceVSphereTagRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*VSphereClient).TagsClient()
+	if err != nil {
+		return err
+	}
+
+	id := d.Id()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	tag, err := client.GetTag(ctx, id)
+	if err != nil {
+		return fmt.Errorf("could not locate tag with id %q: %s", id, err)
+	}
+	d.Set("name", tag.Name)
+	d.Set("description", tag.Description)
+	d.Set("category_id", tag.CategoryID)
+
+	return nil
+}
+
+func resourceVSphereTagUpdate(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*VSphereClient).TagsClient()
+	if err != nil {
+		return err
+	}
+
+	id := d.Id()
+	spec := &tags.TagUpdateSpec{
+		UpdateSpec: tags.TagUpdate{
+			Description: d.Get("description").(string),
+			Name:        d.Get("name").(string),
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	err = client.UpdateTag(ctx, id, spec)
+	if err != nil {
+		return fmt.Errorf("could not update tag with id %q: %s", id, err)
+	}
+	return resourceVSphereTagRead(d, meta)
+}
+
+func resourceVSphereTagDelete(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*VSphereClient).TagsClient()
+	if err != nil {
+		return err
+	}
+
+	id := d.Id()
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	err = client.DeleteTag(ctx, id)
+	if err != nil {
+		return fmt.Errorf("could not delete tag with id %q: %s", id, err)
+	}
+	return nil
+}
+
+func resourceVSphereTagImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Import takes the tag and category names through JSON to make sure we can
+	// search on special characters, since there does not seem to be any sort of
+	// prohibited kind of character when dealing with either tags or categories.
+	//
+	// We just decode to a map[string]string and handle the rest from there. We
+	// don't care about any other kind of value, so we lean on JSON errors in
+	// those cases.
+	var data map[string]string
+	if err := json.Unmarshal([]byte(d.Id()), &data); err != nil {
+		return nil, err
+	}
+	categoryName, ok := data["category_name"]
+	if !ok {
+		return nil, errors.New("missing category_name in input data")
+	}
+	tagName, ok := data["tag_name"]
+	if !ok {
+		return nil, errors.New("missing tag_name in input data")
+	}
+
+	client, err := meta.(*VSphereClient).TagsClient()
+	if err != nil {
+		return nil, err
+	}
+
+	categoryID, err := tagCategoryByName(client, categoryName)
+	if err != nil {
+		return nil, err
+	}
+	tagID, err := tagByName(client, tagName, categoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(tagID)
+	return []*schema.ResourceData{d}, nil
+}

--- a/vsphere/resource_vsphere_tag_test.go
+++ b/vsphere/resource_vsphere_tag_test.go
@@ -1,0 +1,261 @@
+package vsphere
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccResourceVSphereTag(t *testing.T) {
+	var tp *testing.T
+	testAccResourceVSphereTagCases := []struct {
+		name     string
+		testCase resource.TestCase
+	}{
+		{
+			"basic",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereTagExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereTagConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereTagExists(true),
+							testAccResourceVSphereTagHasName("terraform-test-tag"),
+							testAccResourceVSphereTagHasDescription("Managed by Terraform"),
+							testAccResourceVSphereTagHasCategory(),
+						),
+					},
+				},
+			},
+		},
+		{
+			"change name",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereTagExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereTagConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereTagExists(true),
+						),
+					},
+					{
+						Config: testAccResourceVSphereTagConfigAltName,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereTagExists(true),
+							testAccResourceVSphereTagHasName("terraform-test-tag-renamed"),
+						),
+					},
+				},
+			},
+		},
+		{
+			"change description",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereTagExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereTagConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereTagExists(true),
+						),
+					},
+					{
+						Config: testAccResourceVSphereTagConfigAltDescription,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereTagExists(true),
+							testAccResourceVSphereTagHasDescription("Still managed by Terraform"),
+						),
+					},
+				},
+			},
+		},
+		{
+			"import",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereTagExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereTagConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereTagExists(true),
+						),
+					},
+					{
+						ResourceName:      "vsphere_tag.terraform-test-tag",
+						ImportState:       true,
+						ImportStateVerify: true,
+						ImportStateIdFunc: func(s *terraform.State) (string, error) {
+							cat, err := testGetTagCategory(s, "terraform-test-category")
+							if err != nil {
+								return "", err
+							}
+							tag, err := testGetTag(s, "terraform-test-tag")
+							if err != nil {
+								return "", err
+							}
+							m := make(map[string]string)
+							m["category_name"] = cat.Name
+							m["tag_name"] = tag.Name
+							b, err := json.Marshal(m)
+							if err != nil {
+								return "", err
+							}
+
+							return string(b), nil
+						},
+						Config: testAccResourceVSphereTagConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereTagExists(true),
+						),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testAccResourceVSphereTagCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tp = t
+			resource.Test(t, tc.testCase)
+		})
+	}
+}
+
+func testAccResourceVSphereTagExists(expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := testGetTag(s, "terraform-test-tag")
+		if err != nil {
+			if strings.Contains(err.Error(), "Status code: 404") && !expected {
+				// Expected missing
+				return nil
+			}
+			return err
+		}
+		if !expected {
+			return errors.New("expected tag to be missing")
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereTagHasName(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tag, err := testGetTag(s, "terraform-test-tag")
+		if err != nil {
+			return err
+		}
+		actual := tag.Name
+		if expected != actual {
+			return fmt.Errorf("expected name to be %q, got %q", expected, actual)
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereTagHasDescription(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tag, err := testGetTag(s, "terraform-test-tag")
+		if err != nil {
+			return err
+		}
+		actual := tag.Description
+		if expected != actual {
+			return fmt.Errorf("expected description to be %q, got %q", expected, actual)
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereTagHasCategory() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tag, err := testGetTag(s, "terraform-test-tag")
+		if err != nil {
+			return err
+		}
+		category, err := testGetTagCategory(s, "terraform-test-category")
+		if err != nil {
+			return err
+		}
+
+		expected := category.ID
+		actual := tag.CategoryID
+		if expected != actual {
+			return fmt.Errorf("expected ID to be %q, got %q", expected, actual)
+		}
+		return nil
+	}
+}
+
+const testAccResourceVSphereTagConfigBasic = `
+resource "vsphere_tag_category" "terraform-test-category" {
+  name        = "terraform-test-category"
+  cardinality = "SINGLE"
+
+  associable_types = [
+    "All",
+  ]
+}
+
+resource "vsphere_tag" "terraform-test-tag" {
+  name        = "terraform-test-tag"
+  description = "Managed by Terraform"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+`
+
+const testAccResourceVSphereTagConfigAltName = `
+resource "vsphere_tag_category" "terraform-test-category" {
+  name        = "terraform-test-category"
+  cardinality = "SINGLE"
+
+  associable_types = [
+    "All",
+  ]
+}
+
+resource "vsphere_tag" "terraform-test-tag" {
+  name        = "terraform-test-tag-renamed"
+  description = "Managed by Terraform"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+`
+
+const testAccResourceVSphereTagConfigAltDescription = `
+resource "vsphere_tag_category" "terraform-test-category" {
+  name        = "terraform-test-category"
+  cardinality = "SINGLE"
+
+  associable_types = [
+    "All",
+  ]
+}
+
+resource "vsphere_tag" "terraform-test-tag" {
+  name        = "terraform-test-tag"
+  description = "Still managed by Terraform"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+`

--- a/website/docs/d/tag.html.markdown
+++ b/website/docs/d/tag.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_tag"
+sidebar_current: "docs-vsphere-data-source-tag-data-source"
+description: |-
+  Provides a vSphere tag data source. This can be used to reference tags not managed in Terraform.
+---
+
+# vsphere\_tag
+
+The `vsphere_tag` data source can be used to reference tags that are not
+managed by Terraform. Its attributes are exactly the same as the [`vsphere_tag`
+resource][resource-tag], and, like importing, the data source takes a name and
+category to search on. The `id` and other attributes are then populated with
+the data found by the search.
+
+[resource-tag]: /docs/providers/vsphere/r/tag.html
+
+~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.
+
+## Example Usage
+
+```hcl
+data "vsphere_tag_category" "category" {
+  name = "terraform-test-category"
+}
+
+data "vsphere_tag" "tag" 
+  name        = "terraform-test-tag"
+  category_id = "${data.vsphere_tag_category.category.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (String, required) The name of the tag.
+* `category_id` - (String, required) The ID of the tag category the tag is
+  located in.
+
+## Attribute Reference
+
+In addition to the `id` being exported, all of the fields that are available in
+the [`vsphere_tag` resource][resource-tag] are also populated. See that page
+for further details.

--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_tag"
+sidebar_current: "docs-vsphere-resource-inventory-tag-resource"
+description: |-
+  Provides a vSphere tag resource. This can be used to manage tags in vSphere.
+---
+
+# vsphere\_tag
+
+The `vsphere_tag` resource can be used to create and manage tags, which allow
+you to attach metadata to objects in the vSphere inventory to make these
+objects more sortable and searchable.
+
+For more information about tags, click [here][ext-tags-general].
+
+[ext-tags-general]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html
+
+~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.
+
+## Example Usage
+
+This example creates a tag named `terraform-test-tag`. This tag is assigned the
+`terraform-test-category` category, which was created by the
+[`vsphere_tag_category` resource][docs-tag-category-resource]. The resulting
+tag can be assigned to VMs and datastores only, and can be the only value in
+the category that can be assigned, as per the restrictions defined by the
+category.
+
+[docs-tag-category-resource]: /docs/providers/vsphere/r/tag_category.html
+
+```hcl
+resource "vsphere_tag_category" "category" {
+  name        = "terraform-test-category"
+  description = "Managed by Terraform"
+  cardinality = "SINGLE"
+
+  associable_types = [
+    "VirtualMachine",
+    "Datastore",
+  ]
+}
+
+resource "vsphere_tag" "tag" {
+  name        = "terraform-test-tag"
+  description = "Managed by Terraform"
+  category_id = "${vsphere_tag_category.category.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (String, required) The display name of the tag. The name must be
+  unique within its category.
+* `description` - (String, optional) A description for the tag.
+* `category_id` - (String, required, forces new resource) The unique identifier
+  of the parent category in which this tag will be created.
+
+## Attribute Reference
+
+The only attribute that is exported for this resource is the `id`, which is the
+uniform resource name (URN) of this tag.
+
+## Importing
+
+An existing tag can be [imported][docs-import] into this resource by supplying
+both the tag's category name and the name of the tag as a JSON string to
+`terraform import`, as per the example below:
+
+[docs-import]: https://www.terraform.io/docs/import/index.html
+
+```
+terraform import vsphere_tag.tag \
+  '{"category_name": "terraform-test-category", "tag_name": "terraform-test-tag"}'
+```

--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -33,8 +33,8 @@ category.
 ```hcl
 resource "vsphere_tag_category" "category" {
   name        = "terraform-test-category"
-  description = "Managed by Terraform"
   cardinality = "SINGLE"
+  description = "Managed by Terraform"
 
   associable_types = [
     "VirtualMachine",
@@ -44,8 +44,8 @@ resource "vsphere_tag_category" "category" {
 
 resource "vsphere_tag" "tag" {
   name        = "terraform-test-tag"
-  description = "Managed by Terraform"
   category_id = "${vsphere_tag_category.category.id}"
+  description = "Managed by Terraform"
 }
 ```
 
@@ -55,9 +55,9 @@ The following arguments are supported:
 
 * `name` - (String, required) The display name of the tag. The name must be
   unique within its category.
-* `description` - (String, optional) A description for the tag.
 * `category_id` - (String, required, forces new resource) The unique identifier
   of the parent category in which this tag will be created.
+* `description` - (String, optional) A description for the tag.
 
 ## Attribute Reference
 

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -19,6 +19,9 @@
             <li<%= sidebar_current("docs-vsphere-data-source-host") %>>
               <a href="/docs/providers/vsphere/d/host.html">vsphere_host</a>
             </li>
+            <li<%= sidebar_current("docs-vsphere-data-source-tag-data-source") %>>
+              <a href="/docs/providers/vsphere/d/tag.html">vsphere_tag</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-data-source-tag-category") %>>
               <a href="/docs/providers/vsphere/d/tag_category.html">vsphere_tag_category</a>
             </li>
@@ -45,6 +48,9 @@
             </li>
             <li<%= sidebar_current("docs-vsphere-resource-inventory-folder") %>>
               <a href="/docs/providers/vsphere/r/folder.html">vsphere_folder</a>
+            </li>
+            <li<%= sidebar_current("docs-vsphere-resource-inventory-tag-resource") %>>
+              <a href="/docs/providers/vsphere/r/tag.html">vsphere_tag</a>
             </li>
             <li<%= sidebar_current("docs-vsphere-resource-inventory-tag-category") %>>
               <a href="/docs/providers/vsphere/r/tag_category.html">vsphere_tag_category</a>


### PR DESCRIPTION
This adds the `vsphere_tag` resource and data source, allowing the ability to manage and pull in tags.

Next step is adding the ability to tag all of the objects in the provider that can be tagged!

PS: This also includes an update to the vic package which was also missing tag update support.
