### PR TITLE
tags: Support tagging on vsphere_virtual_machine (and up-front work for other objects)

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -35,6 +35,18 @@ type VSphereClient struct {
 //
 // This function should be used whenever possible to return the client from the
 // provider meta variable for use, to determine if it can be used at all.
+//
+// The nil value that is returned on an unsupported connection can be
+// considered stable behavior for read purposes on resources that need to be
+// able to read tags if they are present. You can use the snippet below in a
+// Read call to determine if tags are supported on this connection, and if they
+// are, read them from the object and save them in the resource:
+//
+//   if tagsClient, _ := meta.(*VSphereClient).TagsClient(); tagsClient != nil {
+//     if err := readTagsForResoruce(tagsClient, obj, d); err != nil {
+//       return err
+//     }
+//   }
 func (c *VSphereClient) TagsClient() (*tags.RestClient, error) {
 	if err := validateVirtualCenter(c.vimClient); err != nil {
 		return nil, err

--- a/vsphere/data_source_vsphere_tag_category_test.go
+++ b/vsphere/data_source_vsphere_tag_category_test.go
@@ -71,7 +71,7 @@ func TestAccDataSourceVSphereTagCategory(t *testing.T) {
 const testAccDataSourceVSphereTagCategoryConfigName = "terraform-test-category"
 const testAccDataSourceVSphereTagCategoryConfigDescription = "Managed by Terraform"
 const testAccDataSourceVSphereTagCategoryConfigCardinality = vSphereTagCategoryCardinalitySingle
-const testAccDataSourceVSphereTagCategoryConfigAssociableType = vSphereTagCategoryAssociableTypeVirtualMachine
+const testAccDataSourceVSphereTagCategoryConfigAssociableType = vSphereTagTypeVirtualMachine
 
 func testAccDataSourceVSphereTagCategoryConfig() string {
 	return fmt.Sprintf(`

--- a/vsphere/host_network_system_helper.go
+++ b/vsphere/host_network_system_helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -66,4 +67,63 @@ func hostPortGroupFromName(client *govmomi.Client, ns *object.HostNetworkSystem,
 	}
 
 	return nil, fmt.Errorf("could not find port group %s", name)
+}
+
+// networkProperties gets the properties for a specific Network.
+//
+// The Network type usually represents a standard port group in vCenter - it
+// has been set up on a host or a set of hosts, and is usually configured via
+// through an appropriate HostNetworkSystem. vCenter, however, groups up these
+// networks and displays them as a single network that VM can use across hosts,
+// facilitating HA and vMotion for VMs that use standard port groups versus DVS
+// port groups. Hence the "Network" object is mainly a read-only MO and is only
+// useful for checking some very base level attributes.
+func networkProperties(net *object.Network) (*mo.Network, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	var props mo.Network
+	if err := net.Properties(ctx, net.Reference(), nil, &props); err != nil {
+		return nil, err
+	}
+	return &props, nil
+}
+
+// networkObjectFromHostSystem locates the network object in vCenter for a
+// specific HostSystem and network name.
+//
+// It does this by searching for all networks in the folder hierarchy that
+// match the given network name for the HostSystem's managed object reference
+// ID. This match is returned - if nothing is found, an error is given.
+func networkObjectFromHostSystem(client *govmomi.Client, hs *object.HostSystem, name string) (*object.Network, error) {
+	// Validate vCenter as this function is only relevant there
+	if err := validateVirtualCenter(client); err != nil {
+		return nil, err
+	}
+	finder := find.NewFinder(client.Client, false)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	nets, err := finder.NetworkList(ctx, "*/"+name)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, n := range nets {
+		net, ok := n.(*object.Network)
+		if !ok {
+			// Not a standard port group (possibly DVS, etc), pass
+			continue
+		}
+		props, err := networkProperties(net)
+		if err != nil {
+			return nil, err
+		}
+		for _, hsRef := range props.Host {
+			if hsRef.Value == hs.Reference().Value {
+				// This is our network
+				return net, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("could not find a matching %q on host ID %q", name, hs.Reference().Value)
 }

--- a/vsphere/resource_vsphere_tag_category.go
+++ b/vsphere/resource_vsphere_tag_category.go
@@ -10,53 +10,14 @@ import (
 	"github.com/vmware/vic/pkg/vsphere/tags"
 )
 
-// A list of valid types for cardinality and associable types are below. The
-// latter is more significant, even though they are not used in the resource
-// itself, to ensure all associable types are properly documented so we can
-// reference it later, in addition to providing the list for future validation
-// if we add the ability to validate lists and sets in core.
 const (
-	vSphereTagCategoryCardinalitySingle   = "SINGLE"
+	// vSphereTagCategoryCardinalitySingle defines the API type for single
+	// cardinality.
+	vSphereTagCategoryCardinalitySingle = "SINGLE"
+
+	// vSphereTagCategoryCardinalityMultiple defines the API type for multiple
+	// cardinality.
 	vSphereTagCategoryCardinalityMultiple = "MULTIPLE"
-
-	vSphereTagCategoryAssociableTypeFolder                         = "Folder"
-	vSphereTagCategoryAssociableTypeClusterComputeResource         = "ClusterComputeResource"
-	vSphereTagCategoryAssociableTypeDatacenter                     = "Datacenter"
-	vSphereTagCategoryAssociableTypeDatastore                      = "Datastore"
-	vSphereTagCategoryAssociableTypeStoragePod                     = "StoragePod"
-	vSphereTagCategoryAssociableTypeDistributedVirtualPortgroup    = "DistributedVirtualPortgroup"
-	vSphereTagCategoryAssociableTypeDistributedVirtualSwitch       = "DistributedVirtualSwitch"
-	vSphereTagCategoryAssociableTypeVmwareDistributedVirtualSwitch = "VmwareDistributedVirtualSwitch"
-	vSphereTagCategoryAssociableTypeHostSystem                     = "HostSystem"
-	vSphereTagCategoryAssociableTypeContentLibrary                 = "com.vmware.content.Library"
-	vSphereTagCategoryAssociableTypeContentLibraryItem             = "com.vmware.content.library.Item"
-	vSphereTagCategoryAssociableTypeHostNetwork                    = "HostNetwork"
-	vSphereTagCategoryAssociableTypeNetwork                        = "Network"
-	vSphereTagCategoryAssociableTypeOpaqueNetwork                  = "OpaqueNetwork"
-	vSphereTagCategoryAssociableTypeResourcePool                   = "ResourcePool"
-	vSphereTagCategoryAssociableTypeVirtualApp                     = "VirtualApp"
-	vSphereTagCategoryAssociableTypeVirtualMachine                 = "VirtualMachine"
-
-	vSphereTagCategoryAssociableTypeAll = "All"
-)
-
-// The following groups are type groups that are associated with the same type
-// selection in the vSphere Client tag category UI.
-var (
-	// vSphereTagCategoryAssociableTypesForDistributedVirtualSwitch represents
-	// types for virtual switches.
-	vSphereTagCategoryAssociableTypesForDistributedVirtualSwitch = []string{
-		vSphereTagCategoryAssociableTypeDistributedVirtualSwitch,
-		vSphereTagCategoryAssociableTypeVmwareDistributedVirtualSwitch,
-	}
-
-	// vSphereTagCategoryAssociableTypesForNetwork represents the types for
-	// networks.
-	vSphereTagCategoryAssociableTypesForNetwork = []string{
-		vSphereTagCategoryAssociableTypeHostNetwork,
-		vSphereTagCategoryAssociableTypeNetwork,
-		vSphereTagCategoryAssociableTypeOpaqueNetwork,
-	}
 )
 
 func resourceVSphereTagCategory() *schema.Resource {

--- a/vsphere/resource_vsphere_tag_category_test.go
+++ b/vsphere/resource_vsphere_tag_category_test.go
@@ -35,7 +35,7 @@ func TestAccResourceVSphereTagCategory(t *testing.T) {
 							testAccResourceVSphereTagCategoryHasName("terraform-test-category"),
 							testAccResourceVSphereTagCategoryHasCardinality(vSphereTagCategoryCardinalitySingle),
 							testAccResourceVSphereTagCategoryHasTypes([]string{
-								vSphereTagCategoryAssociableTypeVirtualMachine,
+								vSphereTagTypeVirtualMachine,
 							}),
 						),
 					},
@@ -56,7 +56,7 @@ func TestAccResourceVSphereTagCategory(t *testing.T) {
 						Check: resource.ComposeTestCheckFunc(
 							testAccResourceVSphereTagCategoryExists(true),
 							testAccResourceVSphereTagCategoryHasTypes([]string{
-								vSphereTagCategoryAssociableTypeVirtualMachine,
+								vSphereTagTypeVirtualMachine,
 							}),
 						),
 					},
@@ -65,8 +65,8 @@ func TestAccResourceVSphereTagCategory(t *testing.T) {
 						Check: resource.ComposeTestCheckFunc(
 							testAccResourceVSphereTagCategoryExists(true),
 							testAccResourceVSphereTagCategoryHasTypes([]string{
-								vSphereTagCategoryAssociableTypeVirtualMachine,
-								vSphereTagCategoryAssociableTypeDatastore,
+								vSphereTagTypeVirtualMachine,
+								vSphereTagTypeDatastore,
 							}),
 						),
 					},

--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -4,8 +4,53 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/vic/pkg/vsphere/tags"
+)
+
+// A list of valid object types for tagging are below. These are referenced by
+// various helpers and tests.
+const (
+	vSphereTagTypeFolder                         = "Folder"
+	vSphereTagTypeClusterComputeResource         = "ClusterComputeResource"
+	vSphereTagTypeDatacenter                     = "Datacenter"
+	vSphereTagTypeDatastore                      = "Datastore"
+	vSphereTagTypeStoragePod                     = "StoragePod"
+	vSphereTagTypeDistributedVirtualPortgroup    = "DistributedVirtualPortgroup"
+	vSphereTagTypeDistributedVirtualSwitch       = "DistributedVirtualSwitch"
+	vSphereTagTypeVmwareDistributedVirtualSwitch = "VmwareDistributedVirtualSwitch"
+	vSphereTagTypeHostSystem                     = "HostSystem"
+	vSphereTagTypeContentLibrary                 = "com.vmware.content.Library"
+	vSphereTagTypeContentLibraryItem             = "com.vmware.content.library.Item"
+	vSphereTagTypeHostNetwork                    = "HostNetwork"
+	vSphereTagTypeNetwork                        = "Network"
+	vSphereTagTypeOpaqueNetwork                  = "OpaqueNetwork"
+	vSphereTagTypeResourcePool                   = "ResourcePool"
+	vSphereTagTypeVirtualApp                     = "VirtualApp"
+	vSphereTagTypeVirtualMachine                 = "VirtualMachine"
+
+	vSphereTagTypeAll = "All"
+)
+
+// The following groups are type groups that are associated with the same type
+// selection in the vSphere Client tag category UI.
+var (
+	// vSphereTagTypesForDistributedVirtualSwitch represents
+	// types for virtual switches.
+	vSphereTagTypesForDistributedVirtualSwitch = []string{
+		vSphereTagTypeDistributedVirtualSwitch,
+		vSphereTagTypeVmwareDistributedVirtualSwitch,
+	}
+
+	// vSphereTagTypesForNetwork represents the types for
+	// networks.
+	vSphereTagTypesForNetwork = []string{
+		vSphereTagTypeHostNetwork,
+		vSphereTagTypeNetwork,
+		vSphereTagTypeOpaqueNetwork,
+	}
 )
 
 // vSphereTagCategorySearchErrMultiple is an error message format for a tag
@@ -33,6 +78,18 @@ https://github.com/terraform-providers/terraform-provider-vsphere/issues
 This version of the provider requires unique tag names. To work around
 this issue, please use a tag name unique within your vCenter system.
 `
+
+// vSphereTagAttributeKey is the string key that should always be used as the
+// argument to pass tags in to. Various resource tag helpers will depend on
+// this value being consistent across resources.
+//
+// When adding tags to a resource schema, the easiest way to do that (for now)
+// will be to use the following line:
+//
+//   vSphereTagAttributeKey: tagsSchema(),
+//
+// This will ensure that the correct key and schema is used across all resources.
+const vSphereTagAttributeKey = "tags"
 
 // tagsMinVersion is the minimum vSphere version required for tags.
 var tagsMinVersion = vSphereVersion{
@@ -103,4 +160,192 @@ func tagByName(client *tags.RestClient, name, categoryID string) (string, error)
 	}
 
 	return tags[0].ID, nil
+}
+
+// tagsSchema returns the schema for the tags configuration attribute for each
+// resource that needs it.
+//
+// The key is usually "tags" and should be a list of tag IDs to associate with
+// this resource.
+func tagsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeSet,
+		Description: "A list of tag IDs to apply to this object.",
+		Optional:    true,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+	}
+}
+
+// tagTypeForObject takes an object.Reference and returns the tag type based on
+// its underlying type. If it's not in this list, we don't support it for
+// tagging and we return an error.
+func tagTypeForObject(obj object.Reference) (string, error) {
+	switch obj.(type) {
+	case *object.VirtualMachine:
+		return vSphereTagTypeVirtualMachine, nil
+	case *object.Datastore:
+		return vSphereTagTypeDatastore, nil
+	case *object.Network:
+		return vSphereTagTypeNetwork, nil
+	case *object.Folder:
+		return vSphereTagTypeFolder, nil
+	case *object.VmwareDistributedVirtualSwitch:
+		return vSphereTagTypeVmwareDistributedVirtualSwitch, nil
+	case *object.DistributedVirtualSwitch:
+		return vSphereTagTypeDistributedVirtualSwitch, nil
+	case *object.Datacenter:
+		return vSphereTagTypeDatacenter, nil
+	case *object.ClusterComputeResource:
+		return vSphereTagTypeClusterComputeResource, nil
+	case *object.HostSystem:
+		return vSphereTagTypeHostSystem, nil
+	}
+	return "", fmt.Errorf("unsupported type for tagging: %T", obj)
+}
+
+// readTagsForResource reads the tags for a given reference and saves the list
+// in the supplied ResourceData. It returns an error if there was an issue
+// reading the tags.
+func readTagsForResoruce(client *tags.RestClient, obj object.Reference, d *schema.ResourceData) error {
+	objID := obj.Reference().Value
+	objType, err := tagTypeForObject(obj)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	ids, err := client.ListAttachedTags(ctx, objID, objType)
+	if err != nil {
+		return err
+	}
+	if err := d.Set(vSphereTagAttributeKey, ids); err != nil {
+		return fmt.Errorf("error saving tag IDs to resource data: %s", err)
+	}
+	return nil
+}
+
+// tagDiffProcessor is an object that wraps the "complex" adding and removal of
+// tags from an object.
+type tagDiffProcessor struct {
+	// The client connection.
+	client *tags.RestClient
+
+	// The object that is the subject of the tag addition and removal operations.
+	subject object.Reference
+
+	// A list of old (current) tags attached to the subject.
+	oldTagIDs []string
+
+	// The list of tags that should be attached to the subject.
+	newTagIDs []string
+}
+
+// diffOldNew returns any elements of old that were missing in new.
+func (p *tagDiffProcessor) diffOldNew() []string {
+	return p.diff(p.oldTagIDs, p.newTagIDs)
+}
+
+// diffNewOld returns any elements of new that were missing in old.
+func (p *tagDiffProcessor) diffNewOld() []string {
+	return p.diff(p.newTagIDs, p.oldTagIDs)
+}
+
+// diff is what diffOldNew and diffNewOld hand off to.
+func (p *tagDiffProcessor) diff(a, b []string) []string {
+	var found bool
+	c := make([]string, 0)
+	for _, v1 := range a {
+		for _, v2 := range b {
+			if v1 == v2 {
+				found = true
+			}
+		}
+		if !found {
+			c = append(c, v1)
+		}
+	}
+	return c
+}
+
+// processAttachOperations processes all pending attach operations by diffing old
+// and new and adding any IDs that were not found in old.
+func (p *tagDiffProcessor) processAttachOperations() error {
+	tagIDs := p.diffNewOld()
+	if len(tagIDs) < 1 {
+		// Nothing to do
+		return nil
+	}
+	for _, tagID := range tagIDs {
+		objID := p.subject.Reference().Value
+		objType, err := tagTypeForObject(p.subject)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+		defer cancel()
+		if err := p.client.AttachTagToObject(ctx, tagID, objID, objType); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// processDetachOperations processes all pending detach operations by diffing
+// new and old, and removing any IDs that were not found in new.
+func (p *tagDiffProcessor) processDetachOperations() error {
+	tagIDs := p.diffOldNew()
+	if len(tagIDs) < 1 {
+		// Nothing to do
+		return nil
+	}
+	for _, tagID := range tagIDs {
+		objID := p.subject.Reference().Value
+		objType, err := tagTypeForObject(p.subject)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+		defer cancel()
+		if err := p.client.DetachTagFromObject(ctx, tagID, objID, objType); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// tagsClientIfDefined goes through the client validation process and returns
+// the tags client only if there are tags defined in the supplied ResourceData.
+//
+// This should be used to fetch the tagging REST client on resources that
+// support tags, usually closer to the beginning of a CRUD function to check to
+// make sure it's worth proceeding with most of the operation. The returned
+// client should be checked for nil before passing it to processTagDiff.
+func tagsClientIfDefined(d *schema.ResourceData, meta interface{}) (*tags.RestClient, error) {
+	if _, ok := d.GetOk(vSphereTagAttributeKey); ok {
+		client, err := meta.(*VSphereClient).TagsClient()
+		if err != nil {
+			return nil, err
+		}
+		return client, nil
+	}
+	return nil, nil
+}
+
+// processTagDiff wraps the whole tag diffing operation into a nice clean
+// function that resources can use.
+func processTagDiff(client *tags.RestClient, d *schema.ResourceData, obj object.Reference) error {
+	old, new := d.GetChange(vSphereTagAttributeKey)
+	tdp := &tagDiffProcessor{
+		client:    client,
+		subject:   obj,
+		oldTagIDs: sliceInterfacesToStrings(old.(*schema.Set).List()),
+		newTagIDs: sliceInterfacesToStrings(new.(*schema.Set).List()),
+	}
+	if err := tdp.processDetachOperations(); err != nil {
+		return fmt.Errorf("error detaching tags to object ID %q: %s", obj.Reference().Value, err)
+	}
+	if err := tdp.processAttachOperations(); err != nil {
+		return fmt.Errorf("error attaching tags to object ID %q: %s", obj.Reference().Value, err)
+	}
+	return nil
 }

--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -63,8 +63,8 @@ created tag to it:
 ```hcl
 resource "vsphere_tag_category" "category" {
   name        = "terraform-test-category"
-  description = "Managed by Terraform"
   cardinality = "SINGLE"
+  description = "Managed by Terraform"
 
   associable_types = [
     "VirtualMachine",
@@ -74,8 +74,8 @@ resource "vsphere_tag_category" "category" {
 
 resource "vsphere_tag" "tag" {
   name        = "terraform-test-tag"
-  description = "Managed by Terraform"
   category_id = "${vsphere_tag_category.category.id}"
+  description = "Managed by Terraform"
 }
 
 resource "vsphere_virtual_machine" "web" {

--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -49,6 +49,52 @@ resource "vsphere_tag" "tag" {
 }
 ```
 
+## Using Tags in a Supported Resource
+
+Tags can be applied to vSphere resources in Terraform via the `tags` argument
+in any supported resource.
+
+The following example builds on the above example by creating a
+[`vsphere_virtual_machine`][docs-virtual-machine-resource] and applying the
+created tag to it:
+
+[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html
+
+```hcl
+resource "vsphere_tag_category" "category" {
+  name        = "terraform-test-category"
+  description = "Managed by Terraform"
+  cardinality = "SINGLE"
+
+  associable_types = [
+    "VirtualMachine",
+    "Datastore",
+  ]
+}
+
+resource "vsphere_tag" "tag" {
+  name        = "terraform-test-tag"
+  description = "Managed by Terraform"
+  category_id = "${vsphere_tag_category.category.id}"
+}
+
+resource "vsphere_virtual_machine" "web" {
+  name   = "terraform-web"
+  vcpu   = 2
+  memory = 4096
+
+  network_interface {
+    label = "VM Network"
+  }
+
+  disk {
+    template = "centos-7"
+  }
+
+  tags = ["${vsphere_tag.tag.id}"]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -116,6 +116,13 @@ The following arguments are supported:
   `network_interface`s has a gateway assigned, or if all interfaces have been
   left unconfigured. Default: `true`.
 * `annotation` - (Optional) Edit the annotation notes field
+* `tags` - (Optional) The IDs of any tags to attach to this resource. See
+  [here][docs-applying-tags] for a reference on how to apply tags.
+
+[docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
+
+~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.
 
 The `network_interface` block supports:
 


### PR DESCRIPTION
This commit contains most of the up-front work necessary to tag objects, in addition to adding tagging capability to `vsphere_virtual_machine`.  With the work done here, adding tagging support to any resource that can support it should be a trivial act.

The one major exception is `vsphere_host_port_group`, which is an odd case as created port groups appear to be aggregated into a single network in vSphere. This commit includes helpers to determine a Network object ID from a specific network name and `HostSystem`, but are not tested at this point in time. We will probably need to support this case via a `vsphere_host_network_tag_association` resource and a `vsphere_standard_network` data source, the latter to derive the correct network MO and the former to associate the tag correctly. These items will be added once tagging is added for all other objects, so that they can be added in a different PR.
