### PR TITLE
tags: Support tagging in datastore resources

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -43,7 +43,7 @@ type VSphereClient struct {
 // are, read them from the object and save them in the resource:
 //
 //   if tagsClient, _ := meta.(*VSphereClient).TagsClient(); tagsClient != nil {
-//     if err := readTagsForResoruce(tagsClient, obj, d); err != nil {
+//     if err := readTagsForResource(tagsClient, obj, d); err != nil {
 //       return err
 //     }
 //   }

--- a/vsphere/resource_vsphere_nas_datastore.go
+++ b/vsphere/resource_vsphere_nas_datastore.go
@@ -133,7 +133,7 @@ func resourceVSphereNasDatastoreRead(d *schema.ResourceData, meta interface{}) e
 
 	// Read tags if we have the ability to do so
 	if tagsClient, _ := meta.(*VSphereClient).TagsClient(); tagsClient != nil {
-		if err := readTagsForResoruce(tagsClient, ds, d); err != nil {
+		if err := readTagsForResource(tagsClient, ds, d); err != nil {
 			return err
 		}
 	}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1262,7 +1262,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 
 	// Read tags if we have the ability to do so
 	if tagsClient, _ := meta.(*VSphereClient).TagsClient(); tagsClient != nil {
-		if err := readTagsForResoruce(tagsClient, vm, d); err != nil {
+		if err := readTagsForResource(tagsClient, vm, d); err != nil {
 			return err
 		}
 	}

--- a/vsphere/resource_vsphere_vmfs_datastore.go
+++ b/vsphere/resource_vsphere_vmfs_datastore.go
@@ -218,7 +218,7 @@ func resourceVSphereVmfsDatastoreRead(d *schema.ResourceData, meta interface{}) 
 
 	// Read tags if we have the ability to do so
 	if tagsClient, _ := meta.(*VSphereClient).TagsClient(); tagsClient != nil {
-		if err := readTagsForResoruce(tagsClient, ds, d); err != nil {
+		if err := readTagsForResource(tagsClient, ds, d); err != nil {
 			return err
 		}
 	}

--- a/vsphere/resource_vsphere_vmfs_datastore.go
+++ b/vsphere/resource_vsphere_vmfs_datastore.go
@@ -83,6 +83,10 @@ func resourceVSphereVmfsDatastore() *schema.Resource {
 		},
 	}
 	mergeSchema(s, schemaDatastoreSummary())
+
+	// Add tags schema
+	s[vSphereTagAttributeKey] = tagsSchema()
+
 	return &schema.Resource{
 		Create: resourceVSphereVmfsDatastoreCreate,
 		Read:   resourceVSphereVmfsDatastoreRead,
@@ -97,6 +101,14 @@ func resourceVSphereVmfsDatastore() *schema.Resource {
 
 func resourceVSphereVmfsDatastoreCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*VSphereClient).vimClient
+
+	// Load up the tags client, which will validate a proper vCenter before
+	// attempting to proceed if we have tags defined.
+	tagsClient, err := tagsClientIfDefined(d, meta)
+	if err != nil {
+		return err
+	}
+
 	hsID := d.Get("host_system_id").(string)
 	dss, err := hostDatastoreSystemFromHostSystemID(client, hsID)
 	if err != nil {
@@ -131,6 +143,13 @@ func resourceVSphereVmfsDatastoreCreate(d *schema.ResourceData, meta interface{}
 				return fmt.Errorf(formatVmfsDatastoreCreateRollbackErrorFolder, folder, err, remErr)
 			}
 			return fmt.Errorf("could not move datastore to folder %q: %s", folder, err)
+		}
+	}
+
+	// Apply any pending tags now
+	if tagsClient != nil {
+		if err := processTagDiff(tagsClient, d, ds); err != nil {
+			return err
 		}
 	}
 
@@ -197,11 +216,26 @@ func resourceVSphereVmfsDatastoreRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
+	// Read tags if we have the ability to do so
+	if tagsClient, _ := meta.(*VSphereClient).TagsClient(); tagsClient != nil {
+		if err := readTagsForResoruce(tagsClient, ds, d); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 func resourceVSphereVmfsDatastoreUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*VSphereClient).vimClient
+
+	// Load up the tags client, which will validate a proper vCenter before
+	// attempting to proceed if we have tags defined.
+	tagsClient, err := tagsClientIfDefined(d, meta)
+	if err != nil {
+		return err
+	}
+
 	hsID := d.Get("host_system_id").(string)
 	dss, err := hostDatastoreSystemFromHostSystemID(client, hsID)
 	if err != nil {
@@ -226,6 +260,13 @@ func resourceVSphereVmfsDatastoreUpdate(d *schema.ResourceData, meta interface{}
 		folder := d.Get("folder").(string)
 		if err := moveDatastoreToFolder(client, ds, folder); err != nil {
 			return fmt.Errorf("Could not move datastore to folder %q: %s", folder, err)
+		}
+	}
+
+	// Apply any pending tags now
+	if tagsClient != nil {
+		if err := processTagDiff(tagsClient, d, ds); err != nil {
+			return err
 		}
 	}
 

--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -206,7 +206,7 @@ func tagTypeForObject(obj object.Reference) (string, error) {
 // readTagsForResource reads the tags for a given reference and saves the list
 // in the supplied ResourceData. It returns an error if there was an issue
 // reading the tags.
-func readTagsForResoruce(client *tags.RestClient, obj object.Reference, d *schema.ResourceData) error {
+func readTagsForResource(client *tags.RestClient, obj object.Reference, d *schema.ResourceData) error {
 	objID := obj.Reference().Value
 	objType, err := tagTypeForObject(obj)
 	if err != nil {

--- a/website/docs/r/nas_datastore.html.markdown
+++ b/website/docs/r/nas_datastore.html.markdown
@@ -80,6 +80,14 @@ The following arguments are supported:
 * `security_type` - (String, optional, forces new resource) The security type
   to use when using NFS v4.1. Can be one of `AUTH_SYS`, `SEC_KRB5`, or
   `SEC_KRB5I`.
+* `tags` - (List of strings, optional) The IDs of any tags to attach to this
+  resource. See [here][docs-applying-tags] for a reference on how to apply
+  tags.
+
+[docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
+
+~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.
 
 ## Attribute Reference
 

--- a/website/docs/r/vmfs_datastore.html.markdown
+++ b/website/docs/r/vmfs_datastore.html.markdown
@@ -132,6 +132,15 @@ The following arguments are supported:
   datastore folder located at `/dc1/datastore/foo/bar`, with the final
   inventory path being `/dc1/datastore/foo/bar/terraform-test`.
 * `disks` - (List of strings, required) The disks to use with the datastore.
+* `tags` - (List of strings, optional) The IDs of any tags to attach to this
+  resource. See [here][docs-applying-tags] for a reference on how to apply
+  tags.
+
+[docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
+
+~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.
+
 
 ## Attribute Reference
 


### PR DESCRIPTION
This update supports tagging in the `vsphere_nas_datastore` and
`vsphere_vmfs_datastore` resources. Using the same workflows applied to
the virtual machine resource.

In addition to the tests supplied for the datastore resources, I've
re-enabled the import test for `vsphere_vmfs_datastore` now that we have
`ImportStateIdFunc` to help generate the ID.