### PR TITLE
tags: Add tagging support for datacenters

### DIFF
--- a/vsphere/resource_vsphere_datacenter.go
+++ b/vsphere/resource_vsphere_datacenter.go
@@ -142,7 +142,7 @@ func resourceVSphereDatacenterRead(d *schema.ResourceData, meta interface{}) err
 
 	// Read tags if we have the ability to do so
 	if tagsClient, _ := meta.(*VSphereClient).TagsClient(); tagsClient != nil {
-		if err := readTagsForResoruce(tagsClient, dc, d); err != nil {
+		if err := readTagsForResource(tagsClient, dc, d); err != nil {
 			return err
 		}
 	}

--- a/website/docs/r/datacenter.html.markdown
+++ b/website/docs/r/datacenter.html.markdown
@@ -8,7 +8,8 @@ description: |-
 
 # vsphere\_datacenter
 
-Provides a VMware vSphere datacenter resource. This can be used as the primary container of inventory objects such as hosts and virtual machines.
+Provides a VMware vSphere datacenter resource. This can be used as the primary
+container of inventory objects such as hosts and virtual machines.
 
 ## Example Usages
 
@@ -33,7 +34,18 @@ resource "vsphere_datacenter" "research_datacenter" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the datacenter. This name needs to be unique within the folder.
+* `name` - (Required) The name of the datacenter. This name needs to be unique
+  within the folder. Forces a new resource if changed.
 * `folder` - (Optional) The folder where the datacenter should be created.
+  Forces a new resource if changed.
+* `tags` - (Optional) The IDs of any tags to attach to this resource. See
+  [here][docs-applying-tags] for a reference on how to apply tags.
 
-~> **NOTE**: Datacenters cannot be changed once they are created. Modifying any of these attributes will force a new resource!
+[docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
+
+~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.
+
+## Attribute Reference
+
+The only attribute exported is `id`, which is the name of the datacenter.


### PR DESCRIPTION
This update adds in the tagging support for datacenters. Just a few
minor modifications, nothing too serious, although this does now add the
`Read` function as tags on a datacenter (any object for that matter) are
modifiable in a non-destructive way.
