### PR TITLE
r/folder: Resource rewrite

### DIFF
--- a/tf-vsphere-devrc.mk.example
+++ b/tf-vsphere-devrc.mk.example
@@ -49,5 +49,6 @@ export VSPHERE_DS_VMFS_DISK2       ?= scsi-name2 # 3rd disk for vmfs_datastore
 export VSPHERE_DS_FOLDER           ?= ds-folder  # Path to a datastore folder
 export VSPHERE_NAS_HOST            ?= nas-host   # Hostname for nas_datastore
 export VSPHERE_NFS_PATH            ?= nfs-path   # NFS path for nas_datastore
+export VSPHERE_FOLDER_V0_PATH      ?= old-folder # vsphere_folder state test
 
 # vi: filetype=make

--- a/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
+++ b/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -103,6 +104,24 @@ func StringLenBetween(min, max int) schema.SchemaValidateFunc {
 		}
 		return
 	}
+}
+
+// NoZeroValues is a SchemaValidateFunc which tests if the provided value is
+// not a zero value. It's useful in situations where you want to catch
+// explicit zero values on things like required fields during validation.
+func NoZeroValues(i interface{}, k string) (s []string, es []error) {
+	if reflect.ValueOf(i).Interface() == reflect.Zero(reflect.TypeOf(i)).Interface() {
+		switch reflect.TypeOf(i).Kind() {
+		case reflect.String:
+			es = append(es, fmt.Errorf("%s must not be empty", k))
+		case reflect.Int, reflect.Float64:
+			es = append(es, fmt.Errorf("%s must not be zero", k))
+		default:
+			// this validator should only ever be applied to TypeString, TypeInt and TypeFloat
+			panic(fmt.Errorf("can't use NoZeroValues with %T attribute %s", i, k))
+		}
+	}
+	return
 }
 
 // CIDRNetwork returns a SchemaValidateFunc which tests if the provided value

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -542,12 +542,10 @@
 			"versionExact": "v0.10.5"
 		},
 		{
-			"checksumSHA1": "fezCwKJ4akxRr3v3Bti0firO240=",
+			"checksumSHA1": "jdwWpJZbTSU87GUlwLTuf6FwpmE=",
 			"path": "github.com/hashicorp/terraform/helper/validation",
-			"revision": "1f054df7525613cccbbc705d639024cb8ac2264a",
-			"revisionTime": "2017-09-14T18:15:35Z",
-			"version": "v0.10.5",
-			"versionExact": "v0.10.5"
+			"revision": "edb8e8904cee1a55eab293e8f8270a70ab7b9810",
+			"revisionTime": "2017-09-25T01:18:31Z"
 		},
 		{
 			"checksumSHA1": "yFWmdS6yEJZpRJzUqd/mULqCYGk=",

--- a/vsphere/folder_helper.go
+++ b/vsphere/folder_helper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"reflect"
 	"strings"
 
 	"github.com/vmware/govmomi"
@@ -14,39 +13,82 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+// vSphereFolderType is an enumeration type for vSphere folder types.
+type vSphereFolderType string
+
+// The following are constants for the 5 vSphere folder types - these are used
+// to help determine base paths and also to validate folder types in the
+// vsphere_folder resource.
+const (
+	vSphereFolderTypeVM        = vSphereFolderType("vm")
+	vSphereFolderTypeNetwork   = vSphereFolderType("network")
+	vSphereFolderTypeHost      = vSphereFolderType("host")
+	vSphereFolderTypeDatastore = vSphereFolderType("datastore")
+
+	// vSphereFolderTypeDatacenter is a special folder type - it does not get a
+	// root path particle generated for it as it is an integral part of the path
+	// generation process, but is defined so that it can be properly referenced
+	// and used in validation.
+	vSphereFolderTypeDatacenter = vSphereFolderType("datacenter")
+)
+
 // rootPathParticle is the section of a vSphere inventory path that denotes a
 // specific kind of inventory item.
-type rootPathParticle string
+type rootPathParticle vSphereFolderType
 
 // String implements Stringer for rootPathParticle.
 func (p rootPathParticle) String() string {
 	return string(p)
 }
 
-// Delimeter returns the path delimiter for the particle, which is basically
+// Delimiter returns the path delimiter for the particle, which is basically
 // just a particle with a leading slash.
-func (p rootPathParticle) Delimeter() string {
+func (p rootPathParticle) Delimiter() string {
 	return string("/" + p)
+}
+
+// RootFromDatacenter returns the root path for the particle from the given
+// datacenter's inventory path.
+func (p rootPathParticle) RootFromDatacenter(dc *object.Datacenter) string {
+	return dc.InventoryPath + "/" + string(p)
+}
+
+// PathFromDatacenter returns the combined result of RootFromDatacenter plus a
+// relative path for a given particle and datacenter object.
+func (p rootPathParticle) PathFromDatacenter(dc *object.Datacenter, relative string) string {
+	return p.RootFromDatacenter(dc) + "/" + relative
 }
 
 // SplitDatacenter is a convenience method that splits out the datacenter path
 // from the supplied path for the particle.
 func (p rootPathParticle) SplitDatacenter(inventoryPath string) (string, error) {
-	s := strings.SplitN(inventoryPath, p.Delimeter(), 2)
+	s := strings.SplitN(inventoryPath, p.Delimiter(), 2)
 	if len(s) != 2 {
-		return inventoryPath, fmt.Errorf("could not split path %q on %q", inventoryPath, p.Delimeter())
+		return inventoryPath, fmt.Errorf("could not split path %q on %q", inventoryPath, p.Delimiter())
 	}
 	return s[0], nil
 }
 
-// SplitRelativeFolder is a convenience method that splits out the relative
-// folder from the supplied path for the particle.
-func (p rootPathParticle) SplitRelativeFolder(inventoryPath string) (string, error) {
-	s := strings.SplitN(inventoryPath, p.Delimeter(), 2)
+// SplitRelative is a convenience method that splits out the relative path from
+// the supplied path for the particle.
+func (p rootPathParticle) SplitRelative(inventoryPath string) (string, error) {
+	s := strings.SplitN(inventoryPath, p.Delimiter(), 2)
 	if len(s) != 2 {
-		return inventoryPath, fmt.Errorf("could not split path %q on %q", inventoryPath, p.Delimeter())
+		return inventoryPath, fmt.Errorf("could not split path %q on %q", inventoryPath, p.Delimiter())
 	}
-	return path.Dir(s[1]), nil
+	return s[1], nil
+}
+
+// SplitRelativeFolder is a convenience method that returns the parent folder
+// for the result of SplitRelative on the supplied path.
+//
+// This is generally useful to get the folder for a managed entity, versus getting a full relative path. If you want that, use SplitRelative instead.
+func (p rootPathParticle) SplitRelativeFolder(inventoryPath string) (string, error) {
+	relative, err := p.SplitRelative(inventoryPath)
+	if err != nil {
+		return inventoryPath, err
+	}
+	return path.Dir(relative), nil
 }
 
 // NewRootFromPath takes the datacenter path for a specific entity, and then
@@ -76,10 +118,10 @@ func (p rootPathParticle) PathFromNewRoot(inventoryPath string, newParticle root
 }
 
 const (
-	rootPathParticleVM        = rootPathParticle("vm")
-	rootPathParticleNetwork   = rootPathParticle("network")
-	rootPathParticleHost      = rootPathParticle("host")
-	rootPathParticleDatastore = rootPathParticle("datastore")
+	rootPathParticleVM        = rootPathParticle(vSphereFolderTypeVM)
+	rootPathParticleNetwork   = rootPathParticle(vSphereFolderTypeNetwork)
+	rootPathParticleHost      = rootPathParticle(vSphereFolderTypeHost)
+	rootPathParticleDatastore = rootPathParticle(vSphereFolderTypeDatastore)
 )
 
 // datacenterPathFromHostSystemID returns the datacenter section of a
@@ -100,6 +142,19 @@ func datastoreRootPathFromHostSystemID(client *govmomi.Client, hsID string) (str
 		return "", err
 	}
 	return rootPathParticleHost.NewRootFromPath(hs.InventoryPath, rootPathParticleDatastore)
+}
+
+// folderFromAbsolutePath returns an *object.Folder from a given absolute path.
+// If no such folder is found, an appropriate error will be returned.
+func folderFromAbsolutePath(client *govmomi.Client, path string) (*object.Folder, error) {
+	finder := find.NewFinder(client.Client, false)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	folder, err := finder.Folder(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	return folder, nil
 }
 
 // folderFromObject returns an *object.Folder from a given object of specific
@@ -125,16 +180,7 @@ func folderFromObject(client *govmomi.Client, obj interface{}, folderType rootPa
 	if err != nil {
 		return nil, err
 	}
-	// Set up a finder. Don't set datacenter here as we are looking for full
-	// path, should not be necessary.
-	finder := find.NewFinder(client.Client, false)
-	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
-	defer cancel()
-	folder, err := finder.Folder(ctx, p)
-	if err != nil {
-		return nil, err
-	}
-	return folder, nil
+	return folderFromAbsolutePath(client, p)
 }
 
 // datastoreFolderFromObject returns an *object.Folder from a given object,
@@ -152,13 +198,11 @@ func datastoreFolderFromObject(client *govmomi.Client, obj interface{}, relative
 // validateDatastoreFolder checks to make sure the folder is a datastore
 // folder, and returns it if it is not, or an error if it isn't.
 func validateDatastoreFolder(folder *object.Folder) (*object.Folder, error) {
-	var props mo.Folder
-	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
-	defer cancel()
-	if err := folder.Properties(ctx, folder.Reference(), nil, &props); err != nil {
+	ft, err := findFolderType(folder)
+	if err != nil {
 		return nil, err
 	}
-	if !reflect.DeepEqual(props.ChildType, []string{"Folder", "Datastore", "StoragePod"}) {
+	if ft != vSphereFolderTypeDatastore {
 		return nil, fmt.Errorf("%q is not a datastore folder", folder.InventoryPath)
 	}
 	return folder, nil
@@ -190,4 +234,83 @@ func moveObjectToFolder(ref types.ManagedObjectReference, folder *object.Folder)
 	tctx, tcancel := context.WithTimeout(context.Background(), defaultAPITimeout)
 	defer tcancel()
 	return task.Wait(tctx)
+}
+
+// parentFolderFromPath takes a relative object path (usually a folder), an
+// object type, and an optional supplied datacenter, and returns the parent
+// *object.Folder if it exists.
+//
+// The datacenter supplied in dc cannot be nil if the folder type supplied by
+// ft is something else other than vSphereFolderTypeDatacenter.
+func parentFolderFromPath(c *govmomi.Client, p string, ft vSphereFolderType, dc *object.Datacenter) (*object.Folder, error) {
+	var fp string
+	if ft == vSphereFolderTypeDatacenter {
+		fp = "/" + p
+	} else {
+		pt := rootPathParticle(ft)
+		fp = pt.PathFromDatacenter(dc, p)
+	}
+	return folderFromAbsolutePath(c, path.Dir(fp))
+}
+
+// folderFromID locates a Folder by its managed object reference ID.
+func folderFromID(client *govmomi.Client, id string) (*object.Folder, error) {
+	finder := find.NewFinder(client.Client, false)
+
+	ref := types.ManagedObjectReference{
+		Type:  "Folder",
+		Value: id,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	folder, err := finder.ObjectReference(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return folder.(*object.Folder), nil
+}
+
+// folderProperties is a convenience method that wraps fetching the
+// Folder MO from its higher-level object.
+func folderProperties(folder *object.Folder) (*mo.Folder, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	var props mo.Folder
+	if err := folder.Properties(ctx, folder.Reference(), nil, &props); err != nil {
+		return nil, err
+	}
+	return &props, nil
+}
+
+// findFolderType returns a proper vSphereFolderType for a folder object by checking its child type.
+func findFolderType(folder *object.Folder) (vSphereFolderType, error) {
+	var ft vSphereFolderType
+
+	props, err := folderProperties(folder)
+	if err != nil {
+		return ft, err
+	}
+
+	ct := props.ChildType
+	if ct[0] != "Folder" {
+		return ft, fmt.Errorf("expected first childtype node to be Folder, got %s", ct[0])
+	}
+
+	switch ct[1] {
+	case "Datacenter":
+		ft = vSphereFolderTypeDatacenter
+	case "ComputeResource":
+		ft = vSphereFolderTypeHost
+	case "VirtualMachine":
+		ft = vSphereFolderTypeVM
+	case "Datastore":
+		ft = vSphereFolderTypeDatastore
+	case "Network":
+		ft = vSphereFolderTypeNetwork
+	default:
+		return ft, fmt.Errorf("unknown folder type: %#v", ct)
+	}
+
+	return ft, nil
 }

--- a/vsphere/folder_helper.go
+++ b/vsphere/folder_helper.go
@@ -314,3 +314,18 @@ func findFolderType(folder *object.Folder) (vSphereFolderType, error) {
 
 	return ft, nil
 }
+
+// folderHasChildren checks to see if a folder has any child items and returns
+// true if that is the case. This is useful when checking to see if a folder is
+// safe to delete - destroying a folder in vSphere destroys *all* children if
+// at all possible (including removing virtual machines), so extra verification
+// is necessary to prevent accidental removal.
+func folderHasChildren(f *object.Folder) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	children, err := f.Children(ctx)
+	if err != nil {
+		return false, err
+	}
+	return len(children) > 0, nil
+}

--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -274,3 +274,22 @@ func testAccResourceVSphereDatastoreCheckTags(dsResAddr, tagResName string) reso
 		return testObjectHasTags(s, tagsClient, ds, tagResName)
 	}
 }
+
+// testGetFolder is a convenience method to fetch a folder by resource name.
+func testGetFolder(s *terraform.State, resourceName string) (*object.Folder, error) {
+	tVars, err := testClientVariablesForResource(s, fmt.Sprintf("vsphere_folder.%s", resourceName))
+	if err != nil {
+		return nil, err
+	}
+	return folderFromID(tVars.client, tVars.resourceID)
+}
+
+// testGetFolderProperties is a convenience method that adds an extra step to
+// testGetFolder to get the properties of a folder.
+func testGetFolderProperties(s *terraform.State, resourceName string) (*mo.Folder, error) {
+	folder, err := testGetFolder(s, resourceName)
+	if err != nil {
+		return nil, err
+	}
+	return folderProperties(folder)
+}

--- a/vsphere/provider_test.go
+++ b/vsphere/provider_test.go
@@ -42,3 +42,17 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("VSPHERE_SERVER must be set for acceptance tests")
 	}
 }
+
+// testAccProviderMeta returns a instantiated VSphereClient for this provider.
+// It's useful in state migration tests where a provider connection is actually
+// needed, and we don't want to go through the regular provider configure
+// channels (so this function doesn't interfere with the testAccProvider
+// package global and standard acceptance tests).
+//
+// Note we lean on environment variables for most of the provider configuration
+// here and this will fail if those are missing. A pre-check is not run.
+func testAccProviderMeta(t *testing.T) (interface{}, error) {
+	t.Helper()
+	d := schema.TestResourceDataRaw(t, testAccProvider.Schema, make(map[string]interface{}))
+	return providerConfigure(d)
+}

--- a/vsphere/resource_vsphere_folder.go
+++ b/vsphere/resource_vsphere_folder.go
@@ -1,225 +1,272 @@
 package vsphere
 
 import (
+	"context"
+	"errors"
 	"fmt"
-	"log"
 	"path"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/vmware/govmomi"
-	"github.com/vmware/govmomi/find"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/vmware/govmomi/object"
-	"golang.org/x/net/context"
+	"github.com/vmware/govmomi/vim25/types"
 )
-
-type folder struct {
-	datacenter   string
-	existingPath string
-	path         string
-}
 
 func resourceVSphereFolder() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceVSphereFolderCreate,
 		Read:   resourceVSphereFolderRead,
+		Update: resourceVSphereFolderUpdate,
 		Delete: resourceVSphereFolderDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceVSphereFolderImport,
+		},
 
+		SchemaVersion: 1,
+		MigrateState:  resourceVSphereFolderMigrateState,
 		Schema: map[string]*schema.Schema{
-			"datacenter": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"path": {
+				Type:         schema.TypeString,
+				Description:  "The path of the folder and any parents, relative to the datacenter and folder type being defined.",
+				Required:     true,
+				StateFunc:    normalizeFolderPath,
+				ValidateFunc: validation.NoZeroValues,
 			},
-
-			"path": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+			"type": {
+				Type:        schema.TypeString,
+				Description: "The type of the folder.",
+				ForceNew:    true,
+				Required:    true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(vSphereFolderTypeVM),
+						string(vSphereFolderTypeNetwork),
+						string(vSphereFolderTypeHost),
+						string(vSphereFolderTypeDatastore),
+						string(vSphereFolderTypeDatacenter),
+					},
+					false,
+				),
 			},
-
-			"existing_path": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
+			"datacenter_id": {
+				Type:        schema.TypeString,
+				Description: "The ID of the datacenter. Can be ignored if creating a datacenter folder, otherwise required.",
+				ForceNew:    true,
+				Optional:    true,
 			},
+			// Tagging
+			vSphereTagAttributeKey: tagsSchema(),
 		},
 	}
 }
 
 func resourceVSphereFolderCreate(d *schema.ResourceData, meta interface{}) error {
-
 	client := meta.(*VSphereClient).vimClient
-
-	f := folder{
-		path: strings.TrimRight(d.Get("path").(string), "/"),
-	}
-
-	if v, ok := d.GetOk("datacenter"); ok {
-		f.datacenter = v.(string)
-	}
-
-	err := createFolder(client, &f)
+	tagsClient, err := tagsClientIfDefined(d, meta)
 	if err != nil {
 		return err
 	}
 
-	d.Set("existing_path", f.existingPath)
-	d.SetId(fmt.Sprintf("%v/%v", f.datacenter, f.path))
-	log.Printf("[INFO] Created folder: %s", f.path)
+	ft := vSphereFolderType(d.Get("type").(string))
+	var dc *object.Datacenter
+	if dcID, ok := d.GetOk("datacenter_id"); ok {
+		var err error
+		dc, err = datacenterFromID(client, dcID.(string))
+		if err != nil {
+			return fmt.Errorf("cannot locate datacenter: %s", err)
+		}
+	} else {
+		if ft != vSphereFolderTypeDatacenter {
+			return fmt.Errorf("datacenter_id cannot be empty when creating a folder of type %s", ft)
+		}
+	}
+
+	p := d.Get("path").(string)
+
+	// Determine the parent folder
+	parent, err := parentFolderFromPath(client, p, ft, dc)
+	if err != nil {
+		return fmt.Errorf("error trying to determine parent folder: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+
+	folder, err := parent.CreateFolder(ctx, path.Base(p))
+	if err != nil {
+		return fmt.Errorf("error creating folder: %s", err)
+	}
+
+	d.SetId(folder.Reference().Value)
+
+	// Apply any pending tags now
+	if tagsClient != nil {
+		if err := processTagDiff(tagsClient, d, folder); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
+	}
 
 	return resourceVSphereFolderRead(d, meta)
 }
 
-func createFolder(client *govmomi.Client, f *folder) error {
-
-	finder := find.NewFinder(client.Client, true)
-
-	dc, err := finder.Datacenter(context.TODO(), f.datacenter)
+func resourceVSphereFolderRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	folder, err := folderFromID(client, d.Id())
 	if err != nil {
-		return fmt.Errorf("error %s", err)
-	}
-	finder = finder.SetDatacenter(dc)
-	si := object.NewSearchIndex(client.Client)
-
-	dcFolders, err := dc.Folders(context.TODO())
-	if err != nil {
-		return fmt.Errorf("error %s", err)
+		return fmt.Errorf("cannot locate folder: %s", err)
 	}
 
-	folder := dcFolders.VmFolder
-	var workingPath string
+	// Determine the folder type first. We use the folder as the source of truth
+	// here versus the state so that we can support import.
+	ft, err := findFolderType(folder)
+	if err != nil {
+		return fmt.Errorf("cannot determine folder type: %s", err)
+	}
 
-	pathParts := strings.Split(f.path, "/")
-	for _, pathPart := range pathParts {
-		if len(workingPath) > 0 {
-			workingPath += "/"
-		}
-		workingPath += pathPart
-		subfolder, err := si.FindByInventoryPath(
-			context.TODO(), fmt.Sprintf("%v/vm/%v", f.datacenter, workingPath))
-
+	// Again, to support a clean import (which is done off of absolute path to
+	// the folder), we discover the datacenter from the path (if it's a thing).
+	var dc *object.Datacenter
+	p := folder.InventoryPath
+	if ft != vSphereFolderTypeDatacenter {
+		particle := rootPathParticle(ft)
+		dcp, err := particle.SplitDatacenter(p)
 		if err != nil {
-			return fmt.Errorf("error %s", err)
-		} else if subfolder == nil {
-			log.Printf("[DEBUG] folder not found; creating: %s", workingPath)
-			folder, err = folder.CreateFolder(context.TODO(), pathPart)
-			if err != nil {
-				return fmt.Errorf("Failed to create folder at %s; %s", workingPath, err)
-			}
-		} else {
-			log.Printf("[DEBUG] folder already exists: %s", workingPath)
-			f.existingPath = workingPath
-			folder = subfolder.(*object.Folder)
+			return fmt.Errorf("cannot determine datacenter path: %s", err)
+		}
+		dc, err = getDatacenter(client, dcp)
+		if err != nil {
+			return fmt.Errorf("cannot find datacenter from path %q: %s", dcp, err)
+		}
+		relative, err := particle.SplitRelative(p)
+		if err != nil {
+			return fmt.Errorf("cannot determine relative folder path: %s", err)
+		}
+		p = relative
+	}
+
+	d.Set("path", normalizeFolderPath(p))
+	d.Set("type", ft)
+	if dc != nil {
+		d.Set("datacenter_id", dc.Reference().Value)
+	}
+
+	// Read tags if we have the ability to do so
+	if tagsClient, _ := meta.(*VSphereClient).TagsClient(); tagsClient != nil {
+		if err := readTagsForResource(tagsClient, folder, d); err != nil {
+			return fmt.Errorf("error reading tags: %s", err)
 		}
 	}
+
 	return nil
 }
 
-func resourceVSphereFolderRead(d *schema.ResourceData, meta interface{}) error {
-
-	log.Printf("[DEBUG] reading folder: %#v", d)
+func resourceVSphereFolderUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*VSphereClient).vimClient
-
-	dc, err := getDatacenter(client, d.Get("datacenter").(string))
+	tagsClient, err := tagsClientIfDefined(d, meta)
 	if err != nil {
 		return err
 	}
 
-	finder := find.NewFinder(client.Client, true)
-	finder = finder.SetDatacenter(dc)
-
-	folder, err := object.NewSearchIndex(client.Client).FindByInventoryPath(
-		context.TODO(), fmt.Sprintf("%v/vm/%v", d.Get("datacenter").(string),
-			d.Get("path").(string)))
-
+	folder, err := folderFromID(client, d.Id())
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot locate folder: %s", err)
 	}
 
-	if folder == nil {
-		d.SetId("")
+	// Apply any pending tags first as it's the lesser expensive of the two
+	// operations
+	if tagsClient != nil {
+		if err := processTagDiff(tagsClient, d, folder); err != nil {
+			return fmt.Errorf("error updating tags: %s", err)
+		}
 	}
 
-	return nil
+	var dc *object.Datacenter
+	if dcID, ok := d.GetOk("datacenter_id"); ok {
+		var err error
+		dc, err = datacenterFromID(client, dcID.(string))
+		if err != nil {
+			return fmt.Errorf("cannot locate datacenter: %s", err)
+		}
+	}
+
+	if d.HasChange("path") {
+		// The path has changed, which could mean either a change in parent, a
+		// change in name, or both.
+		ft := vSphereFolderType(d.Get("type").(string))
+		oldp, newp := d.GetChange("path")
+		oldpa, err := parentFolderFromPath(client, oldp.(string), ft, dc)
+		if err != nil {
+			return fmt.Errorf("error parsing parent folder from path %q: %s", oldp.(string), err)
+		}
+		newpa, err := parentFolderFromPath(client, newp.(string), ft, dc)
+		if err != nil {
+			return fmt.Errorf("error parsing parent folder from path %q: %s", newp.(string), err)
+		}
+		oldn := path.Base(oldp.(string))
+		newn := path.Base(newp.(string))
+
+		if oldn != newn {
+			// Folder base name has changed and needs a rename
+			if err := renameObject(client, folder.Reference(), newn); err != nil {
+				return fmt.Errorf("could not rename folder: %s", err)
+			}
+		}
+		if oldpa.Reference().Value != newpa.Reference().Value {
+			// The parent folder has changed - we need to move the folder into the
+			// new path
+			ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+			defer cancel()
+			task, err := newpa.MoveInto(ctx, []types.ManagedObjectReference{folder.Reference()})
+			if err != nil {
+				return fmt.Errorf("could not move folder: %s", err)
+			}
+			tctx, tcancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+			defer tcancel()
+			if err := task.Wait(tctx); err != nil {
+				return fmt.Errorf("error on waiting for move task completion: %s", err)
+			}
+		}
+	}
+
+	return resourceVSphereFolderRead(d, meta)
 }
 
 func resourceVSphereFolderDelete(d *schema.ResourceData, meta interface{}) error {
-
-	f := folder{
-		path:         strings.TrimRight(d.Get("path").(string), "/"),
-		existingPath: d.Get("existing_path").(string),
-	}
-
-	if v, ok := d.GetOk("datacenter"); ok {
-		f.datacenter = v.(string)
-	}
-
 	client := meta.(*VSphereClient).vimClient
-
-	err := deleteFolder(client, &f)
+	folder, err := folderFromID(client, d.Id())
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot locate folder: %s", err)
 	}
 
-	d.SetId("")
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	task, err := folder.Destroy(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot delete folder: %s", err)
+	}
+	tctx, tcancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer tcancel()
+	if err := task.Wait(tctx); err != nil {
+		return fmt.Errorf("error on waiting for deletion task completion: %s", err)
+	}
+
 	return nil
 }
 
-func deleteFolder(client *govmomi.Client, f *folder) error {
-	dc, err := getDatacenter(client, f.datacenter)
+func resourceVSphereFolderImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Our subject is the full path to a specific folder, for which we just get
+	// the MOID for and then pass off to Read. Easy peasy.
+	p := d.Id()
+	if !strings.HasPrefix(p, "/") {
+		return nil, errors.New("path must start with a trailing slash")
+	}
+	client := meta.(*VSphereClient).vimClient
+	p = normalizeFolderPath(p)
+	folder, err := folderFromAbsolutePath(client, p)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	var folder *object.Folder
-	currentPath := f.path
-
-	finder := find.NewFinder(client.Client, true)
-	finder = finder.SetDatacenter(dc)
-	si := object.NewSearchIndex(client.Client)
-
-	folderRef, err := si.FindByInventoryPath(
-		context.TODO(), fmt.Sprintf("%v/vm/%v", f.datacenter, f.path))
-
-	if err != nil {
-		return fmt.Errorf("[ERROR] Could not locate folder %s: %v", f.path, err)
-	} else {
-		folder = folderRef.(*object.Folder)
-	}
-
-	log.Printf("[INFO] Deleting empty sub-folders of existing path: %s", f.existingPath)
-	for currentPath != f.existingPath {
-		log.Printf("[INFO] Deleting folder: %s", currentPath)
-		children, err := folder.Children(context.TODO())
-		if err != nil {
-			return err
-		}
-
-		if len(children) > 0 {
-			return fmt.Errorf("Folder %s is non-empty and will not be deleted", currentPath)
-		} else {
-			log.Printf("[DEBUG] current folder: %#v", folder)
-			currentPath = path.Dir(currentPath)
-			if currentPath == "." {
-				currentPath = ""
-			}
-			log.Printf("[INFO] parent path of %s is calculated as %s", f.path, currentPath)
-			task, err := folder.Destroy(context.TODO())
-			if err != nil {
-				return err
-			}
-			err = task.Wait(context.TODO())
-			if err != nil {
-				return err
-			}
-			folderRef, err = si.FindByInventoryPath(
-				context.TODO(), fmt.Sprintf("%v/vm/%v", f.datacenter, currentPath))
-
-			if err != nil {
-				return err
-			} else if folderRef != nil {
-				folder = folderRef.(*object.Folder)
-			}
-		}
-	}
-	return nil
+	d.SetId(folder.Reference().Value)
+	return []*schema.ResourceData{d}, nil
 }

--- a/vsphere/resource_vsphere_folder_migrate.go
+++ b/vsphere/resource_vsphere_folder_migrate.go
@@ -1,0 +1,71 @@
+package vsphere
+
+import "github.com/hashicorp/terraform/terraform"
+
+// resourceVSphereFolderMigrateState is the master state migration function for
+// the vsphere_folder resource.
+func resourceVSphereFolderMigrateState(version int, os *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	// Guard against a nil state.
+	if os == nil {
+		return nil, nil
+	}
+
+	// Guard against empty state, can't do anything with it
+	if os.Empty() {
+		return os, nil
+	}
+
+	ns := os.DeepCopy()
+	var migrateFunc func(*terraform.InstanceState, interface{}) error
+	switch version {
+	case 0:
+		migrateFunc = resourceVSphereFolderMigrateStateV1
+	default:
+		// Migration is complete
+		return ns, nil
+	}
+	if err := migrateFunc(ns, meta); err != nil {
+		return nil, err
+	}
+	version++
+	return resourceVSphereFolderMigrateState(version, ns, meta)
+}
+
+// resourceVSphereFolderMigrateStateV1 migrates the state of the vsphere_folder
+// from version 0 to version 1.
+func resourceVSphereFolderMigrateStateV1(s *terraform.InstanceState, meta interface{}) error {
+	// Our path for migration here is pretty much the same as our import path, so
+	// we just leverage that functionality.
+	//
+	// We just need the path and the datacenter to proceed. We don't have an
+	// analog in for existing_path in the new resource, so we just drop that on
+	// the floor.
+	dcp := normalizeFolderPath(s.Attributes["datacenter"])
+	p := normalizeFolderPath(s.Attributes["path"])
+
+	// Discover our datacenter first. This field can be empty, so we have to
+	// search for it as we normally would.
+	client := meta.(*VSphereClient).vimClient
+	dc, err := getDatacenter(client, dcp)
+	if err != nil {
+		return err
+	}
+
+	// The old resource only supported VM folders, so this part is easy enough,
+	// we can derive our full path by combining the VM path particle and our
+	// relative path.
+	fp := rootPathParticleVM.PathFromDatacenter(dc, p)
+	folder, err := folderFromAbsolutePath(client, fp)
+	if err != nil {
+		return err
+	}
+
+	// We got our folder!
+	//
+	// Read will handle everything except for the ID, so just wipe attributes,
+	// update the ID, and let read take care of the rest.
+	s.Attributes = make(map[string]string)
+	s.ID = folder.Reference().Value
+
+	return nil
+}

--- a/vsphere/resource_vsphere_folder_migrate_test.go
+++ b/vsphere/resource_vsphere_folder_migrate_test.go
@@ -19,8 +19,8 @@ func testAccResourceVSphereFolderMigrateStatePreCheck(t *testing.T) {
 }
 
 func TestAccResourceVSphereFolderMigrateState(t *testing.T) {
-	testAccPreCheck(t)
 	testAccResourceVSphereFolderMigrateStatePreCheck(t)
+	testAccPreCheck(t)
 
 	is := &terraform.InstanceState{
 		ID: fmt.Sprintf("%v/%v", os.Getenv("VSPHERE_DATACENTER"), os.Getenv("VSPHERE_FOLDER_V0_PATH")),
@@ -47,6 +47,9 @@ func TestAccResourceVSphereFolderMigrateState(t *testing.T) {
 func TestAccResourceVSphereFolderMigrateState_empty(t *testing.T) {
 	var is *terraform.InstanceState
 	var meta interface{}
+
+	testAccResourceVSphereFolderMigrateStatePreCheck(t)
+	testAccPreCheck(t)
 
 	// should handle nil
 	is, err := resourceVSphereFolderMigrateState(0, is, meta)

--- a/vsphere/resource_vsphere_folder_migrate_test.go
+++ b/vsphere/resource_vsphere_folder_migrate_test.go
@@ -1,0 +1,68 @@
+package vsphere
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func testAccResourceVSphereFolderMigrateStatePreCheck(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("set TF_ACC to run vsphere_folder state migration tests (provider connection is required)")
+	}
+	if os.Getenv("VSPHERE_FOLDER_V0_PATH") == "" {
+		t.Skip("set VSPHERE_FOLDER_V0_PATH to run vsphere_folder state migration tests")
+	}
+}
+
+func TestAccResourceVSphereFolderMigrateState(t *testing.T) {
+	testAccPreCheck(t)
+	testAccResourceVSphereFolderMigrateStatePreCheck(t)
+
+	is := &terraform.InstanceState{
+		ID: fmt.Sprintf("%v/%v", os.Getenv("VSPHERE_DATACENTER"), os.Getenv("VSPHERE_FOLDER_V0_PATH")),
+		Attributes: map[string]string{
+			"path": os.Getenv("VSPHERE_FOLDER_V0_PATH"),
+		},
+	}
+	if dc := os.Getenv("VSPHERE_DATACENTER"); dc != "" {
+		is.Attributes["datacenter"] = dc
+	}
+	meta, err := testAccProviderMeta(t)
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	is, err = resourceVSphereFolderMigrateState(0, is, meta)
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	if !strings.HasPrefix(is.ID, "group-") {
+		t.Fatalf("expected ID to start with \"group-\" got ID as %q", is.ID)
+	}
+}
+
+func TestAccResourceVSphereFolderMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta interface{}
+
+	// should handle nil
+	is, err := resourceVSphereFolderMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	is, err = resourceVSphereFolderMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+}

--- a/vsphere/resource_vsphere_folder_test.go
+++ b/vsphere/resource_vsphere_folder_test.go
@@ -7,269 +7,612 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/vmware/govmomi/find"
-	"github.com/vmware/govmomi/object"
-	"golang.org/x/net/context"
 )
 
-// Basic top-level folder creation
-func TestAccVSphereFolder_basic(t *testing.T) {
-	var f folder
-	datacenter := os.Getenv("VSPHERE_DATACENTER")
-	testMethod := "basic"
-	resourceName := "vsphere_folder." + testMethod
-	path := "tf_test_basic"
+const testAccResourceVSphereFolderConfigExpectedName = "terraform-test-folder"
+const testAccResourceVSphereFolderConfigExpectedAltName = "terraform-renamed-folder"
+const testAccResourceVSphereFolderConfigExpectedParentName = "terraform-test-parent"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVSphereFolderDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: fmt.Sprintf(
-					testAccCheckVSphereFolderConfig,
-					testMethod,
-					path,
-					datacenter,
-				),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVSphereFolderExists(resourceName, &f),
-					resource.TestCheckResourceAttr(
-						resourceName, "path", path),
-					resource.TestCheckResourceAttr(
-						resourceName, "existing_path", ""),
-				),
-			},
-		},
-	})
-}
-
-func TestAccVSphereFolder_nested(t *testing.T) {
-
-	var f folder
-	datacenter := os.Getenv("VSPHERE_DATACENTER")
-	testMethod := "nested"
-	resourceName := "vsphere_folder." + testMethod
-	path := "tf_test_nested/tf_test_folder"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVSphereFolderDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: fmt.Sprintf(
-					testAccCheckVSphereFolderConfig,
-					testMethod,
-					path,
-					datacenter,
-				),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVSphereFolderExists(resourceName, &f),
-					resource.TestCheckResourceAttr(
-						resourceName, "path", path),
-					resource.TestCheckResourceAttr(
-						resourceName, "existing_path", ""),
-				),
-			},
-		},
-	})
-}
-
-func TestAccVSphereFolder_dontDeleteExisting(t *testing.T) {
-
-	var f folder
-	datacenter := os.Getenv("VSPHERE_DATACENTER")
-	testMethod := "dontDeleteExisting"
-	resourceName := "vsphere_folder." + testMethod
-	existingPath := "tf_test_dontDeleteExisting/tf_existing"
-	path := existingPath + "/tf_nested/tf_test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		CheckDestroy: resource.ComposeTestCheckFunc(
-			assertVSphereFolderExists(datacenter, existingPath),
-			removeVSphereFolder(datacenter, existingPath, ""),
-		),
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				PreConfig: func() {
-					createVSphereFolder(datacenter, existingPath)
+func TestAccResourceVSphereFolder(t *testing.T) {
+	var tp *testing.T
+	testAccResourceVSphereFolderCases := []struct {
+		name     string
+		testCase resource.TestCase
+	}{
+		{
+			"basic (VM folder)",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
 				},
-				Config: fmt.Sprintf(
-					testAccCheckVSphereFolderConfig,
-					testMethod,
-					path,
-					datacenter,
-				),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVSphereFolderExistingPathExists(resourceName, &f),
-					resource.TestCheckResourceAttr(
-						resourceName, "path", path),
-					resource.TestCheckResourceAttr(
-						resourceName, "existing_path", existingPath),
-				),
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeVM,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+						),
+					},
+				},
 			},
 		},
-	})
-}
-
-func testAccCheckVSphereFolderDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*VSphereClient).vimClient
-	finder := find.NewFinder(client.Client, true)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "vsphere_folder" {
-			continue
-		}
-
-		dc, err := finder.Datacenter(context.TODO(), rs.Primary.Attributes["datacenter"])
-		if err != nil {
-			return fmt.Errorf("error %s", err)
-		}
-
-		dcFolders, err := dc.Folders(context.TODO())
-		if err != nil {
-			return fmt.Errorf("error %s", err)
-		}
-
-		f, err := object.NewSearchIndex(client.Client).FindChild(context.TODO(), dcFolders.VmFolder, rs.Primary.Attributes["path"])
-		if f != nil {
-			return fmt.Errorf("Record still exists")
-		}
+		{
+			"datastore folder",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeDatastore,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeDatastore),
+						),
+					},
+				},
+			},
+		},
+		{
+			"network folder",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeNetwork,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeNetwork),
+						),
+					},
+				},
+			},
+		},
+		{
+			"host folder",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeHost,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeHost),
+						),
+					},
+				},
+			},
+		},
+		{
+			"datacenter folder",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeDatacenter,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeDatacenter),
+						),
+					},
+				},
+			},
+		},
+		{
+			"rename",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeVM,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+						),
+					},
+					{
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedAltName,
+							vSphereFolderTypeVM,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedAltName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+						),
+					},
+				},
+			},
+		},
+		{
+			"subfolder",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigSubFolder(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeVM,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+							testAccResourceVSphereFolderHasParent(false, testAccResourceVSphereFolderConfigExpectedParentName),
+						),
+					},
+				},
+			},
+		},
+		{
+			"move to subfolder",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeVM,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+							testAccResourceVSphereFolderHasParent(true, "vm"),
+						),
+					},
+					{
+						Config: testAccResourceVSphereFolderConfigSubFolder(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeVM,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+							testAccResourceVSphereFolderHasParent(false, testAccResourceVSphereFolderConfigExpectedParentName),
+						),
+					},
+				},
+			},
+		},
+		{
+			"tags",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigTag(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+							testAccResourceVSphereFolderCheckTags("terraform-test-tag"),
+						),
+					},
+				},
+			},
+		},
+		{
+			"modify tags",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigTag(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+							testAccResourceVSphereFolderCheckTags("terraform-test-tag"),
+						),
+					},
+					{
+						Config: testAccResourceVSphereFolderConfigMultiTag(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+							testAccResourceVSphereFolderCheckTags("terraform-test-tags-alt"),
+						),
+					},
+				},
+			},
+		},
+		{
+			"import",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereFolderExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeVM,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+						),
+					},
+					{
+						ResourceName:      "vsphere_folder.folder",
+						ImportState:       true,
+						ImportStateVerify: true,
+						ImportStateIdFunc: func(s *terraform.State) (string, error) {
+							folder, err := testGetFolder(s, "folder")
+							if err != nil {
+								return "", err
+							}
+							return folder.InventoryPath, nil
+						},
+						Config: testAccResourceVSphereFolderConfigBasic(
+							testAccResourceVSphereFolderConfigExpectedName,
+							vSphereFolderTypeVM,
+						),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereFolderExists(true),
+							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+							testAccResourceVSphereFolderHasType(vSphereFolderTypeVM),
+						),
+					},
+				},
+			},
+		},
 	}
 
-	return nil
+	for _, tc := range testAccResourceVSphereFolderCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tp = t
+			resource.Test(t, tc.testCase)
+		})
+	}
 }
 
-func testAccCheckVSphereFolderExists(n string, f *folder) resource.TestCheckFunc {
+func testAccResourceVSphereFolderExists(expected bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Resource not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		client := testAccProvider.Meta().(*VSphereClient).vimClient
-		finder := find.NewFinder(client.Client, true)
-
-		dc, err := finder.Datacenter(context.TODO(), rs.Primary.Attributes["datacenter"])
+		folder, err := testGetFolder(s, "folder")
 		if err != nil {
-			return fmt.Errorf("error %s", err)
+			if isManagedObjectNotFoundError(err) && expected == false {
+				// Expected missing
+				return nil
+			}
+			return err
 		}
-
-		dcFolders, err := dc.Folders(context.TODO())
-		if err != nil {
-			return fmt.Errorf("error %s", err)
+		if !expected {
+			return fmt.Errorf("expected folder %q to be missing", folder.Reference().Value)
 		}
-
-		_, err = object.NewSearchIndex(client.Client).FindChild(context.TODO(), dcFolders.VmFolder, rs.Primary.Attributes["path"])
-
-		*f = folder{
-			path: rs.Primary.Attributes["path"],
-		}
-
 		return nil
 	}
 }
 
-func testAccCheckVSphereFolderExistingPathExists(n string, f *folder) resource.TestCheckFunc {
+func testAccResourceVSphereFolderHasName(expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Resource %s not found in %#v", n, s.RootModule().Resources)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		client := testAccProvider.Meta().(*VSphereClient).vimClient
-		finder := find.NewFinder(client.Client, true)
-
-		dc, err := finder.Datacenter(context.TODO(), rs.Primary.Attributes["datacenter"])
+		props, err := testGetFolderProperties(s, "folder")
 		if err != nil {
-			return fmt.Errorf("error %s", err)
+			return err
 		}
-
-		dcFolders, err := dc.Folders(context.TODO())
-		if err != nil {
-			return fmt.Errorf("error %s", err)
+		actual := props.Name
+		if expected != actual {
+			return fmt.Errorf("expected name to be %q, got %q", expected, actual)
 		}
-
-		_, err = object.NewSearchIndex(client.Client).FindChild(context.TODO(), dcFolders.VmFolder, rs.Primary.Attributes["existing_path"])
-
-		*f = folder{
-			path: rs.Primary.Attributes["path"],
-		}
-
 		return nil
 	}
 }
 
-func assertVSphereFolderExists(datacenter string, folder_name string) resource.TestCheckFunc {
-
+func testAccResourceVSphereFolderHasType(expected vSphereFolderType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*VSphereClient).vimClient
-		folder, err := object.NewSearchIndex(client.Client).FindByInventoryPath(
-			context.TODO(), fmt.Sprintf("%v/vm/%v", datacenter, folder_name))
+		folder, err := testGetFolder(s, "folder")
 		if err != nil {
-			return fmt.Errorf("Error: %s", err)
-		} else if folder == nil {
-			return fmt.Errorf("Folder %s does not exist!", folder_name)
+			return err
 		}
-
+		actual, err := findFolderType(folder)
+		if err != nil {
+			return err
+		}
+		if expected != actual {
+			return fmt.Errorf("expected type to be %q, got %q", expected, actual)
+		}
 		return nil
 	}
 }
 
-func createVSphereFolder(datacenter string, folder_name string) error {
-
-	client := testAccProvider.Meta().(*VSphereClient).vimClient
-
-	f := folder{path: folder_name, datacenter: datacenter}
-
-	folder, err := object.NewSearchIndex(client.Client).FindByInventoryPath(
-		context.TODO(), fmt.Sprintf("%v/vm/%v", datacenter, folder_name))
-	if err != nil {
-		return fmt.Errorf("error %s", err)
-	}
-
-	if folder == nil {
-		createFolder(client, &f)
-	} else {
-		return fmt.Errorf("Folder %s already exists", folder_name)
-	}
-
-	return nil
-}
-
-func removeVSphereFolder(datacenter string, folder_name string, existing_path string) resource.TestCheckFunc {
-
-	f := folder{path: folder_name, datacenter: datacenter, existingPath: existing_path}
-
+func testAccResourceVSphereFolderHasParent(expectedRoot bool, expectedName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
+		props, err := testGetFolderProperties(s, "folder")
+		if err != nil {
+			return err
+		}
+		if props.Parent.Type != "Folder" && !expectedRoot {
+			return fmt.Errorf("folder %q is a root folder", props.Name)
+		}
 		client := testAccProvider.Meta().(*VSphereClient).vimClient
-		// finder := find.NewFinder(client.Client, true)
-
-		folder, _ := object.NewSearchIndex(client.Client).FindByInventoryPath(
-			context.TODO(), fmt.Sprintf("%v/vm/%v", datacenter, folder_name))
-		if folder != nil {
-			deleteFolder(client, &f)
+		pfolder, err := folderFromID(client, props.Parent.Value)
+		if err != nil {
+			return err
+		}
+		pprops, err := folderProperties(pfolder)
+		if err != nil {
+			return err
 		}
 
+		actual := pprops.Name
+		if expectedName != actual {
+			return fmt.Errorf("expected parent folder name to be %q, got %q", expectedName, actual)
+		}
 		return nil
 	}
 }
 
-const testAccCheckVSphereFolderConfig = `
-resource "vsphere_folder" "%s" {
-	path = "%s"
-	datacenter = "%s"
+// testAccResourceVSphereFolderCheckTags is a check to ensure that any
+// tags that have been created with the supplied resource name have been
+// attached to the folder.
+func testAccResourceVSphereFolderCheckTags(tagResName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		folder, err := testGetFolder(s, "folder")
+		if err != nil {
+			return err
+		}
+		tagsClient, err := testAccProvider.Meta().(*VSphereClient).TagsClient()
+		if err != nil {
+			return err
+		}
+		return testObjectHasTags(s, tagsClient, folder, tagResName)
+	}
 }
-`
+
+func testAccResourceVSphereFolderConfigBasic(name string, ft vSphereFolderType) string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "folder_name" {
+  default = "%s"
+}
+
+variable "folder_type" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_folder" "folder" {
+  path          = "${var.folder_name}"
+  type          = "${var.folder_type}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		name,
+		ft,
+	)
+}
+
+func testAccResourceVSphereFolderConfigSubFolder(name string, ft vSphereFolderType) string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "folder_name" {
+  default = "%s"
+}
+
+variable "folder_type" {
+  default = "%s"
+}
+
+variable "parent_name" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_folder" "parent" {
+  path          = "${var.parent_name}"
+  type          = "${var.folder_type}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_folder" "folder" {
+  path          = "${vsphere_folder.parent.path}/${var.folder_name}"
+  type          = "${var.folder_type}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		name,
+		ft,
+		testAccResourceVSphereFolderConfigExpectedParentName,
+	)
+}
+
+func testAccResourceVSphereFolderConfigDatacenter() string {
+	return fmt.Sprintf(`
+variable "folder_name" {
+  default = "%s"
+}
+
+variable "folder_type" {
+  default = "%s"
+}
+
+resource "vsphere_folder" "folder" {
+  path          = "${var.folder_name}"
+  type          = "${var.folder_type}"
+}
+`,
+		testAccResourceVSphereFolderConfigExpectedName,
+		vSphereFolderTypeDatacenter,
+	)
+}
+
+func testAccResourceVSphereFolderConfigTag() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "folder_name" {
+  default = "%s"
+}
+
+variable "folder_type" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_tag_category" "terraform-test-category" {
+  name        = "terraform-test-tag-category"
+  cardinality = "MULTIPLE"
+
+  associable_types = [
+    "Folder",
+  ]
+}
+
+resource "vsphere_tag" "terraform-test-tag" {
+  name        = "terraform-test-tag"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+
+resource "vsphere_folder" "folder" {
+  path          = "${var.folder_name}"
+  type          = "${var.folder_type}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  tags          = ["${vsphere_tag.terraform-test-tag.id}"]
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		testAccResourceVSphereFolderConfigExpectedName,
+		vSphereFolderTypeVM,
+	)
+}
+
+func testAccResourceVSphereFolderConfigMultiTag() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "folder_name" {
+  default = "%s"
+}
+
+variable "folder_type" {
+  default = "%s"
+}
+
+variable "extra_tags" {
+  default = [
+    "terraform-test-thing1",
+    "terraform-test-thing2",
+  ]
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_tag_category" "terraform-test-category" {
+  name        = "terraform-test-tag-category"
+  cardinality = "MULTIPLE"
+
+  associable_types = [
+    "Folder",
+  ]
+}
+
+resource "vsphere_tag" "terraform-test-tag" {
+  name        = "terraform-test-tag"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+
+resource "vsphere_tag" "terraform-test-tags-alt" {
+  count       = "${length(var.extra_tags)}"
+  name        = "${var.extra_tags[count.index]}"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+
+resource "vsphere_folder" "folder" {
+  path          = "${var.folder_name}"
+  type          = "${var.folder_type}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  tags          = ["${vsphere_tag.terraform-test-tags-alt.*.id}"]
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		testAccResourceVSphereFolderConfigExpectedName,
+		vSphereFolderTypeVM,
+	)
+}

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -1255,9 +1255,14 @@ variable "linked_clone" {
   default = "%s"
 }
 
+data "vsphere_datacenter" "datacenter" {
+  name = "${var.datacenter}"
+}
+
 resource "vsphere_folder" "folder" {
-  datacenter = "${var.datacenter}"
-  path       = "terraform-test-vms"
+  path          = "terraform-test-vms"
+  type          = "vm"
+  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
 }
 
 resource "vsphere_virtual_machine" "vm" {

--- a/website/docs/r/folder.html.markdown
+++ b/website/docs/r/folder.html.markdown
@@ -3,18 +3,60 @@ layout: "vsphere"
 page_title: "VMware vSphere: vsphere_folder"
 sidebar_current: "docs-vsphere-resource-inventory-folder"
 description: |-
-  Provides a VMware vSphere virtual machine folder resource. This can be used to create and delete virtual machine folders.
+  Provides a VMware vSphere folder resource. This can be used to manage vSphere inventory folders.
 ---
 
 # vsphere\_folder
 
-Provides a VMware vSphere virtual machine folder resource. This can be used to create and delete virtual machine folders.
+The `vsphere_folder` resource can be used to manage vSphere inventory folders.
+The resource supports creating folders of the 5 major types - datacenter
+folders, host and cluster folders, virtual machine folders, datastore folders,
+and network folders.
+
+Paths are always relative to the specific type of folder you are creating.
+Subfolders are discovered by parsing the relative path specified in `name`, so
+`foo/bar` will create a folder named `bar` in the parent folder `foo`, as long
+as that folder exists.
 
 ## Example Usage
 
+The basic example below creates a virtual machine folder named
+`terraform-test-folder` in the default datacenter's VM hierarchy. 
+
 ```hcl
-resource "vsphere_folder" "web" {
-  path = "terraform_web_folder"
+data "vsphere_datacenter" "dc" {}
+
+resource "vsphere_folder" "folder" {
+  path          = "terraform-test-folder"
+  type          = "vm"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+```
+
+### Example with subfolders
+
+The below example builds off of the above by first creating a folder named
+`terraform-test-parent`, and then locating `terraform-test-folder` in that
+folder. To ensure the parent is created first, we create an interpolation
+dependency off the parent's `name` attribute.
+
+Note that if you change parents (for example, went from the above basic
+configuration to this one), your folder will be moved to be under the correct
+parent.
+
+```hcl
+data "vsphere_datacenter" "dc" {}
+
+resource "vsphere_folder" "parent" {
+  path          = "terraform-test-parent"
+  type          = "vm"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_folder" "folder" {
+  path          = "${vsphere_folder.parent.name}/terraform-test-folder"
+  type          = "vm"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 ```
 
@@ -22,7 +64,49 @@ resource "vsphere_folder" "web" {
 
 The following arguments are supported:
 
-* `path` - (Required) The path of the folder to be created (relative to the datacenter root); should not begin or end with a "/"
-* `datacenter` - (Optional) The name of a Datacenter in which the folder will be created
-* `existing_path` - (Computed) The path of any parent folder segments which existed at the time this folder was created; on a
-destroy action, the (pre-) existing path is not removed.
+* `path` - (Required) The path of the folder to be created. This is relative to
+  the root of the type of folder you are creating, and the supplied datacenter.
+  For example, given a default datacenter of `default-dc`, a folder of type
+  `vm` (denoting a virtual machine folder), and a supplied folder of
+  `terraform-test-folder`, the resulting path would be
+  `/default-dc/vm/terraform-test-folder`.
+
+~> **NOTE:** `path` can be modified - the resulting behavior is dependent on
+what section of `path` you are modifying. If you are modifying the parent (so
+any part before the last `/`), your folder will be moved to that new parent. If
+modifying the name (the part after the last `/`), your folder will be renamed.
+
+* `type` - (Required) The type of folder to create. Allowed options are
+  `datacenter` for datacenter folders, `host` for host and cluster folders,
+  `vm` for virtual machine folders, `datastore` for datastore folders, and
+  `network` for network folders. Forces a new resource if changed.
+* `datacenter_id` - The ID of the datacenter the folder will be created in.
+  Required for all folder types except for datacenter folders. Forces a new
+  resource if changed.
+* `tags` - (Optional) The IDs of any tags to attach to this resource. See
+  [here][docs-applying-tags] for a reference on how to apply tags.
+
+[docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
+
+~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
+requires vCenter 6.0 or higher.
+
+## Attribute Reference
+
+The only attribute that this resource exports is the `id`, which is set to the
+managed object ID of the folder.
+
+## Importing
+
+An existing folder can be [imported][docs-import] into this resource via
+its full path, via the following command:
+
+[docs-import]: https://www.terraform.io/docs/import/index.html
+
+```
+terraform import vsphere_folder.folder /default-dc/vm/terraform-test-folder
+```
+
+The above command would import the folder from our examples above, the VM
+folder named `terraform-test-folder` located in the datacenter named
+`default-dc`.


### PR DESCRIPTION
`vsphere_folder` has now been re-written, with the new version of the resource supporting all 5 major folder types, renaming, moving, and tagging. Documentation has also been fleshed out, and state migration is supported.

This work was undertaken as it was a little tricky to work with tags on the current incarnation of `vsphere_folder` resource, but also takes care of some work that has been pending for a long time to get `vsphere_folder` to support more than just virtual machines.