### PR TITLE
WIP: add domain as dns suffix option

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -779,7 +779,11 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 			vm.dnsSuffixes = append(vm.dnsSuffixes, v.(string))
 		}
 	} else {
-		vm.dnsSuffixes = DefaultDNSSuffixes
+		if v, ok := d.GetOk("domain"); ok {
+			vm.dnsSuffixes = append(vm.dnsSuffixes, v.(string))
+		} else {
+			vm.dnsSuffixes = DefaultDNSSuffixes
+		}
 	}
 
 	if raw, ok := d.GetOk("dns_servers"); ok {


### PR DESCRIPTION
default virtual machines get customized with vsphere.local as dns lookup suffix. While most of the time there is a better alternative, being the domain name of the VM. This adds a check for this alternative

This was suggested a while ago and lived as a stash in my git folder.
rebased it, and pushed it.

I can test it tomorrow at work.