### PR TITLE
Updated docs to show permissions needed to perform tagging operations.

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -128,6 +128,9 @@ vCenter must be assigned the following privileges:
    - Inventory (all)
    - Provisioning (all)
 
+* vCenter Inventory Service
+   - vCenter Inventory Service Tagging (all)
+
 * License 
    - Add License
    - Remove License


### PR DESCRIPTION
It appears that starting with the 0.3.0 release tagging permissions are required when creating (at least) a folder, whether you set tags or not.