### PR TITLE
created adapter_type variable for network interfaces

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -36,6 +36,11 @@ var DiskControllerTypes = []string{
 	"ide",
 }
 
+var NetworkAdapterTypes = []string{
+	"vmxnet3",
+	"e1000",
+}
+
 type networkInterface struct {
 	deviceName       string
 	label            string
@@ -45,7 +50,7 @@ type networkInterface struct {
 	ipv6Address      string
 	ipv6PrefixLength int
 	ipv6Gateway      string
-	adapterType      string // TODO: Make "adapter_type" argument
+	adapterType      string
 	macAddress       string
 }
 
@@ -382,6 +387,21 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+							Default: "vmxnet3",
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+                                                                value := v.(string)
+                                                                found := false
+                                                                for _, t := range NetworkAdapterTypes {
+                                                                        if t == value {
+                                                                                found = true
+                                                                        }
+                                                                }
+                                                                if !found {
+                                                                        errors = append(errors, fmt.Errorf(
+                                                                                "Supported values for 'adapter_type' are %v", strings.Join(NetworkAdapterTypes, ", ")))
+                                                                }
+                                                                return
+                                                        },
 						},
 
 						"mac_address": &schema.Schema{
@@ -867,6 +887,9 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 			if v, ok := network["mac_address"].(string); ok && v != "" {
 				networks[i].macAddress = v
 			}
+			if v, ok := network["adapter_type"].(string); ok && v != "" {
+				networks[i].adapterType = v
+			}
 		}
 		vm.networkInterfaces = networks
 		log.Printf("[DEBUG] network_interface init: %v", networks)
@@ -1144,6 +1167,12 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	log.Printf("[DEBUG] Device list %+v", deviceList)
 	for _, device := range deviceList {
 		networkInterface := make(map[string]interface{})
+		adapter_type_string := fmt.Sprintf("%T", device)
+		if adapter_type_string == "*types.VirtualE1000" {
+			networkInterface["adapter_type"] = "e1000"
+		} else {
+			networkInterface["adapter_type"] = "vmxnet3"
+		}
 		virtualDevice := device.GetVirtualDevice()
 		nic := device.(types.BaseVirtualEthernetCard)
 		DeviceName, _ := getNetworkName(client, vm, nic)
@@ -1999,13 +2028,7 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 	networkConfigs := []types.CustomizationAdapterMapping{}
 	for _, network := range vm.networkInterfaces {
 		// network device
-		var networkDeviceType string
-		if vm.template == "" {
-			networkDeviceType = "e1000"
-		} else {
-			networkDeviceType = "vmxnet3"
-		}
-		nd, err := buildNetworkDevice(finder, network.label, networkDeviceType, network.macAddress)
+		nd, err := buildNetworkDevice(finder, network.label, network.adapterType, network.macAddress)
 		if err != nil {
 			return err
 		}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -384,11 +384,11 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 							DiffSuppressFunc: suppressIpDifferences},
 
 						"adapter_type": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-							Default: "vmxnet3",
-                            ValidateFunc: validation.StringInSlice(virtualMachineNetworkAdapterTypeAllowedValues, false),
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							Default:      "vmxnet3",
+							ValidateFunc: validation.StringInSlice(virtualMachineNetworkAdapterTypeAllowedValues, false),
 						},
 
 						"mac_address": &schema.Schema{
@@ -1154,11 +1154,11 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	log.Printf("[DEBUG] Device list %+v", deviceList)
 	for _, device := range deviceList {
 		networkInterface := make(map[string]interface{})
-        if _, ok := device.(*types.VirtualE1000); ok {
-            networkInterface["adapter_type"] = "e1000"
-        } else {
-            networkInterface["adapter_type"] = "vmxnet3"
-        }
+		if _, ok := device.(*types.VirtualE1000); ok {
+			networkInterface["adapter_type"] = "e1000"
+		} else {
+			networkInterface["adapter_type"] = "vmxnet3"
+		}
 		virtualDevice := device.GetVirtualDevice()
 		nic := device.(types.BaseVirtualEthernetCard)
 		DeviceName, _ := getNetworkName(client, vm, nic)

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -127,6 +127,8 @@ requires vCenter 6.0 or higher.
 The `network_interface` block supports:
 
 * `label` - (Required) Label to assign to this network interface
+* `adapter_type` - (Optional) The adapter type on the network interface. Can be
+  one of `vmxnet3` or `e1000`. Default: `vmxnet3`.
 * `ipv4_address` - (Optional) Static IPv4 to assign to this network interface.
   Interface will use DHCP if this is left blank.
 * `ipv4_prefix_length` - (Optional) prefix length to use when statically


### PR DESCRIPTION
I needed this functionality and noticed that it was already commented with "TODO". It's my first foray into go so the following might be better worked out another way:

adapter_type_string := fmt.Sprintf("%T", device)
if adapter_type_string == "*types.VirtualE1000" {

Otherwise though it seems to work just fine.