### PR TITLE
tags: Ensure complete removal of tags is working

### DIFF
--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -243,6 +243,27 @@ func testObjectHasTags(s *terraform.State, client *tags.RestClient, obj object.R
 	return nil
 }
 
+// testObjectHasNoTags checks to make sure that an object has no tags attached
+// to it. The parameters are the same as testObjectHasTags, but no tag resource
+// needs to be supplied.
+func testObjectHasNoTags(s *terraform.State, client *tags.RestClient, obj object.Reference) error {
+	objID := obj.Reference().Value
+	objType, err := tagTypeForObject(obj)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	actualIDs, err := client.ListAttachedTags(ctx, objID, objType)
+	if err != nil {
+		return err
+	}
+	if len(actualIDs) > 0 {
+		return fmt.Errorf("object %q still has tags (%#v)", obj.Reference().Value, actualIDs)
+	}
+	return nil
+}
+
 // testGetDatastore gets the datastore at the supplied full address. This
 // function works for multiple datastore resources (example:
 // vsphere_nas_datastore and vsphere_vmfs_datastore), hence the need for the

--- a/vsphere/resource_vsphere_folder_test.go
+++ b/vsphere/resource_vsphere_folder_test.go
@@ -476,6 +476,24 @@ func testAccResourceVSphereFolderCheckTags(tagResName string) resource.TestCheck
 	}
 }
 
+// testAccResourceVSphereFolderCheckNoTags is a check to ensure that a folder
+// has no tags on it. This is used by the vsphere_tag tests specifically to
+// test to make sure that complete tag removal is explicitly working without
+// having to rely on the simple empty diff test after the final step.
+func testAccResourceVSphereFolderCheckNoTags() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		folder, err := testGetFolder(s, "folder")
+		if err != nil {
+			return err
+		}
+		tagsClient, err := testAccProvider.Meta().(*VSphereClient).TagsClient()
+		if err != nil {
+			return err
+		}
+		return testObjectHasNoTags(s, tagsClient, folder)
+	}
+}
+
 // testAccResourceVSphereFolderCreateOOB creates an out-of-band folder that is
 // not tracked by TF. This is used in deletion checks to make sure we don't
 // perform unsafe recursive deletions.

--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -323,7 +323,8 @@ func (p *tagDiffProcessor) processDetachOperations() error {
 // make sure it's worth proceeding with most of the operation. The returned
 // client should be checked for nil before passing it to processTagDiff.
 func tagsClientIfDefined(d *schema.ResourceData, meta interface{}) (*tags.RestClient, error) {
-	if _, ok := d.GetOk(vSphereTagAttributeKey); ok {
+	old, new := d.GetChange(vSphereTagAttributeKey)
+	if len(old.(*schema.Set).List()) > 0 || len(new.(*schema.Set).List()) > 0 {
 		client, err := meta.(*VSphereClient).TagsClient()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
`tagsClientIfDefined` was checking to see if the tags client was defined
as a condition to loading up the tags client for `Create` and `Update`
operations. While this generally worked for adding the tags to new
resources and changing tags when necessary, it was not working for
complete tag removal due to its reliance on `GetOk`, which fails if a
field is removed from config completely.

This fixes `tagsClientIfDefined` so that it checks both the old and new
incarnations of the `tags` argument to make sure that both are empty
before passing on loading the tags client.