### PR TITLE
r/virtual_machine: Don't attempt to discover gateway on power off

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1183,7 +1183,7 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		}
 	}
 	log.Printf("[DEBUG] networks: %#v", networkInterfaces)
-	if mvm.Guest.IpStack != nil {
+	if mvm.Guest.IpStack != nil && len(mvm.Guest.Net) > 0 {
 		for _, v := range mvm.Guest.IpStack {
 			if v.IpRouteConfig != nil && v.IpRouteConfig.IpRoute != nil {
 				for _, route := range v.IpRouteConfig.IpRoute {


### PR DESCRIPTION
The new gateway discovery code inadvertently caused a regression in the
fixes that were made to prevent TF from crashing when a VM was powered
off. This fixes that by skipping the GW discovery altogether when there
is no guest device information to use for the association.