### PR TITLE
r/virtual_machine: Allow tuning of customization waiter

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -111,6 +111,15 @@ The following arguments are supported:
 * `skip_customization` - (Optional) Skip virtual machine customization (useful
   if OS is not in the guest OS support matrix of VMware like
   "other3xLinux64Guest").
+* `wait_for_customization_timeout` - (Optional) The amount of time, in minutes,
+  to wait for guest OS customization to complete before returning with an
+  error. Setting this value to `0` or a negative value skips the waiter.
+  Default: `10` (10 minutes).
+
+~> **NOTE:** Disabling the customization waiter may require you to set
+`wait_for_guest_net` to `false` if the VM will not be available with a
+routeable network interface within 5 minutes.
+
 * `wait_for_guest_net` - (Optional) Whether or not to wait for a VM to have
   routeable network access. Should be set to `false` if none of the defined
   `network_interface`s has a gateway assigned, or if all interfaces have been


### PR DESCRIPTION
The current value is hardcoded at 10 minutes, which has been possibly
causing some issues. This allows for the modification of the timeout -
so that it can be change to be a later value if customization takes a
long time (possible on systems with older hardware or non-SSD disk), or
disabled altogether to eliminate it as a source of problems.

Note that disabling the waiter pushes waiting over to the guest
networking waiter, which is currently also hardcoded at 5 minutes.
Modification of this attribute to a different value will require a state
migration (to translate `true` => `5min` and `false` => `<disabled>`) which is a
bit more of an involved change, so I want to take a wait-and-see
approach to see if it is required, especially considering the resource
will be undergoing a larger refactor very soon.

Ref: #183