### PR TITLE
r/distributed_port_group: Use MOID as resource ID

### DIFF
--- a/website/docs/r/distributed_port_group.html.markdown
+++ b/website/docs/r/distributed_port_group.html.markdown
@@ -210,7 +210,14 @@ group can be overridden on the individual port:
 
 The following attributes are exported:
 
-* `id`: The UUID of the created port group.
+* `id`: The managed object reference ID of the created port group.
+* `key`: The generated UUID of the portgroup.
+
+~> **NOTE:** While `id` and `key` may look the same in state, they are
+documented differently in the vSphere API and come from different fields in the
+port group object. If you are asked to supply an managed object reference ID to
+another resource, be sure to use the `id` field.
+
 * `config_version`: The current version of the port group configuration,
   incremented by subsequent updates to the port group.
 


### PR DESCRIPTION
The additions that are in #201 dictate the basis for how we will be
working with vSphere networks in the future - any resource that requires
a network for a backing (ie: virtual ethernet cards, VMkernel nics, etc)
will require a MOID to some sort of network, versus the name itself,
allowing us to circumvent actually searching for the network in the
downstream resource itself. Searching would be circumvented altogether
in the case of DVS portgroups being managed by TF completely as we would
just pass the MOID to the downstream resource.

The current behaviour of the `vsphere_distributed_port_group` resource is
to use the `key` attribute in the MO as the ID of the resource, which is
documented in the API as the UUID of the DVS port group, although in
reality it actually seems to be the MOID, which allows #201 to work
without issue right now. However, in order to guarantee that things will
be stable in the long run, we need to be sure we are using the right
values, so this update changes the ID to be the MOID of the object
itself. `key` is now being exported as a computed attribute of the same
name.