### PR TITLE
d/network: Update govmomi, fix network absolute path searching issues

### DIFF
--- a/vendor/github.com/vmware/govmomi/find/recurser.go
+++ b/vendor/github.com/vmware/govmomi/find/recurser.go
@@ -190,7 +190,7 @@ func (r recurser) List(ctx context.Context, s *spec, root list.Element, parts []
 		}
 
 		if !matched {
-			matched = strings.HasSuffix(e.Path, path.Join(all...))
+			matched = strings.HasSuffix(e.Path, "/"+path.Join(all...))
 			if matched {
 				// name contains a '/'
 				out = append(out, e)

--- a/vendor/github.com/vmware/govmomi/object/custom_fields_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/custom_fields_manager.go
@@ -102,7 +102,9 @@ func (m CustomFieldsManager) Set(ctx context.Context, entity types.ManagedObject
 	return err
 }
 
-func (m CustomFieldsManager) Field(ctx context.Context) ([]types.CustomFieldDef, error) {
+type CustomFieldDefList []types.CustomFieldDef
+
+func (m CustomFieldsManager) Field(ctx context.Context) (CustomFieldDefList, error) {
 	var fm mo.CustomFieldsManager
 
 	err := m.Properties(ctx, m.Reference(), []string{"field"}, &fm)
@@ -113,23 +115,32 @@ func (m CustomFieldsManager) Field(ctx context.Context) ([]types.CustomFieldDef,
 	return fm.Field, nil
 }
 
-func (m CustomFieldsManager) FindKey(ctx context.Context, key string) (int32, error) {
+func (m CustomFieldsManager) FindKey(ctx context.Context, name string) (int32, error) {
 	field, err := m.Field(ctx)
 	if err != nil {
 		return -1, err
 	}
 
 	for _, def := range field {
-		if def.Name == key {
+		if def.Name == name {
 			return def.Key, nil
 		}
 	}
 
-	k, err := strconv.Atoi(key)
+	k, err := strconv.Atoi(name)
 	if err == nil {
 		// assume literal int key
 		return int32(k), nil
 	}
 
 	return -1, ErrKeyNameNotFound
+}
+
+func (l CustomFieldDefList) ByKey(key int32) *types.CustomFieldDef {
+	for _, def := range l {
+		if def.Key == key {
+			return &def
+		}
+	}
+	return nil
 }

--- a/vendor/github.com/vmware/govmomi/object/virtual_device_list.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_device_list.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import (
 
 // Type values for use in BootOrder
 const (
+	DeviceTypeNone     = "-"
 	DeviceTypeCdrom    = "cdrom"
 	DeviceTypeDisk     = "disk"
 	DeviceTypeEthernet = "ethernet"
@@ -754,6 +755,9 @@ func (l VirtualDeviceList) PrimaryMacAddress() string {
 
 // convert a BaseVirtualDevice to a BaseVirtualMachineBootOptionsBootableDevice
 var bootableDevices = map[string]func(device types.BaseVirtualDevice) types.BaseVirtualMachineBootOptionsBootableDevice{
+	DeviceTypeNone: func(types.BaseVirtualDevice) types.BaseVirtualMachineBootOptionsBootableDevice {
+		return &types.VirtualMachineBootOptionsBootableDevice{}
+	},
 	DeviceTypeCdrom: func(types.BaseVirtualDevice) types.BaseVirtualMachineBootOptionsBootableDevice {
 		return &types.VirtualMachineBootOptionsBootableCdromDevice{}
 	},
@@ -773,17 +777,23 @@ var bootableDevices = map[string]func(device types.BaseVirtualDevice) types.Base
 }
 
 // BootOrder returns a list of devices which can be used to set boot order via VirtualMachine.SetBootOptions.
-// The order can any of "ethernet", "cdrom", "floppy" or "disk" or by specific device name.
+// The order can be any of "ethernet", "cdrom", "floppy" or "disk" or by specific device name.
+// A value of "-" will clear the existing boot order on the VC/ESX side.
 func (l VirtualDeviceList) BootOrder(order []string) []types.BaseVirtualMachineBootOptionsBootableDevice {
 	var devices []types.BaseVirtualMachineBootOptionsBootableDevice
 
 	for _, name := range order {
 		if kind, ok := bootableDevices[name]; ok {
+			if name == DeviceTypeNone {
+				// Not covered in the API docs, nor obvious, but this clears the boot order on the VC/ESX side.
+				devices = append(devices, new(types.VirtualMachineBootOptionsBootableDevice))
+				continue
+			}
+
 			for _, device := range l {
 				if l.Type(device) == name {
 					devices = append(devices, kind(device))
 				}
-
 			}
 			continue
 		}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -685,131 +685,131 @@
 			"checksumSHA1": "aqeInPjyAcytMRrpn9KWIBr0+tA=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "yGQUs1dMRLCvrv7q4EOmSa+MXlM=",
 			"path": "github.com/vmware/govmomi/event",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
-			"checksumSHA1": "hb70n+hgA6nsrZWYQQT+aRgvye0=",
+			"checksumSHA1": "gbBQ5Tfb0tUR6R9ylLQBtFYFmvA=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/find",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z",
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z",
 			"tree": true
 		},
 		{
 			"checksumSHA1": "dDLuXgczvfoF+xMurGMKvFy4Mb8=",
 			"path": "github.com/vmware/govmomi/license",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "J3JrwZagGYMX6oNMkdsUFf8hHo8=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/list",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "rgAG0tTJnKBgCX2qFMFZ3/15R4s=",
 			"path": "github.com/vmware/govmomi/nfc",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
-			"checksumSHA1": "gPGitf6hvmdh0TvFKUK4LnOJKY4=",
+			"checksumSHA1": "J+940zw0E3P2bAoT9NshX3l2YcE=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/object",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "zB+5BDLfpbNfTwxX6eBRBr32vVg=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/property",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "eqoHqcnyVN3klOJ89N7xmJhRgu0=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/session",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "FQR3yNgiShaqUiJREkeqQCKYJ84=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/task",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "Z6i/BdS9A2NZnvOAz9gvzu5oLAI=",
 			"path": "github.com/vmware/govmomi/view",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "zLg5y/6xx/yr8swoqdyxISyQfoU=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/vim25",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "xLvppq0NUD6Hv2GIx1gh75xUzyM=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/vim25/debug",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "0bHwl55AeUPZ4Jom+K3BHlxVlZA=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/vim25/methods",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "kiVMrAiW8EBFQvhDMHdE9SFe3N4=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/vim25/mo",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "tN9fHudMKhR3LjGw/V0fM4xXUJw=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/vim25/progress",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
-			"checksumSHA1": "aiV6wdCCgijnyoQTAq4uFIN7OUo=",
+			"checksumSHA1": "PSt0tq59P0fFSKvTw/Pn4Ml6u+U=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/vim25/soap",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "SPTCH8wQxDD8AHvNVUgBV35SBZY=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/vim25/types",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "6XLRzLEvncx5ORtvBjp41KfRTjc=",
 			"comment": "v0.15.0",
 			"path": "github.com/vmware/govmomi/vim25/xml",
-			"revision": "43587eb038787c35cf5da58e84f561841f43e048",
-			"revisionTime": "2017-09-28T01:34:05Z"
+			"revision": "d68562200280ff2ad2110719b06496c9e9526118",
+			"revisionTime": "2017-10-13T00:55:03Z"
 		},
 		{
 			"checksumSHA1": "jxajBXMRa5ObHWsnT1ANtYvpMAQ=",

--- a/vsphere/data_source_vsphere_network.go
+++ b/vsphere/data_source_vsphere_network.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/vmware/govmomi/object"
 )
 
 func dataSourceVSphereNetwork() *schema.Resource {
@@ -37,9 +38,13 @@ func dataSourceVSphereNetworkRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	name := d.Get("name").(string)
-	dc, err := datacenterFromID(client, d.Get("datacenter_id").(string))
-	if err != nil {
-		return fmt.Errorf("cannot locate datacenter: %s", err)
+	var dc *object.Datacenter
+	if dcID, ok := d.GetOk("datacenter_id"); ok {
+		var err error
+		dc, err = datacenterFromID(client, dcID.(string))
+		if err != nil {
+			return fmt.Errorf("cannot locate datacenter: %s", err)
+		}
 	}
 	net, err := networkFromPath(client, name, dc)
 	if err != nil {


### PR DESCRIPTION
This fixes a couple of things:

* Datacenter was not being skipped properly when it was not specified in
config, causing the data source to try to look up an empty string for
the DC. This fix will need to be applied to the
`vsphere_distributed_virtual_switch` data source too.

* govmomi has been updated, this addresses vmware/govmomi#875, which
affects this resource and also indirectly #10 (although the
`vsphere_virtual_machine` resource has its own problems with absolute
paths that are not going to be fixed until the refactor).