### PR TITLE
Add Windows VM configuration options to resource_vsphere_virtual_machine

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -1140,7 +1140,7 @@ resource "vsphere_virtual_machine" "vm" {
     type = "lazy"
     name = "${var.disk_name_lazy}"
   }
-  
+
 	disk {
     size = 1
     type = "thin"
@@ -1762,7 +1762,14 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   windows_opt_config {
-    admin_password = "VMw4re"
+    admin_password     = "VMw4re"
+    auto_logon_enabled = true
+    auto_logon_count   = 100
+    full_name          = "terraform1"
+    org_name           = "terraform1"
+    run_once           = [
+      "date /T",
+    ]
   }
 
   linked_clone = "${var.linked_clone != "" ? "true" : "false" }"

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -167,11 +167,20 @@ The `windows_opt_config` block supports:
   installed using a volume-licensed CD.
 * `admin_password` - (Optional) The password for the new `administrator`
   account. Omit for passwordless admin (using `""` does not work).
+* `auto_logon_count` - (Optional) The number of times to auto-logon as local
+  administrator, if enabled. Defaults to "1"
+* `auto_logon_enabled` - (Optional) Set to 'true' to make windows auto-logon
+  using the local administrator. Defaults to "false"
 * `domain` - (Optional) Domain that the new machine will be placed into. If
   `domain`, `domain_user`, and `domain_user_password` are not all set, all
   three will be ignored.
 * `domain_user` - (Optional) User that is a member of the specified domain.
 * `domain_user_password` - (Optional) Password for domain user, in plain text.
+* `fullname` - (Optional) Registered owner name for machine. Defaults to
+  "terraform"
+* `org_name` - (Optional) Registered organization name for machine. Defaults
+  to "terraform"
+* `run_once` - (Optional) List of command-line commands to run on first logon.
 
 <a id="disks"></a>
 ## Disks


### PR DESCRIPTION
I have added options for the AutoLogon and FirstLogonCommands for Windows guest customization. 
I also made the registered user and organization configurable.
I was going to add in the ChangeSID option, but it seems to always change the SID whether the option is passed or not, and whether a True or False are passed, so I left it out.

I would like to clean up the code at 2340 of `vsphere/resource_vsphere_virtual_machine.go` but I couldn't find a way to not pass in the `guiRunOnce` with no passed in `run_once` commands and not have it fail.  Passing an empty array to `CustomizationSysprep.GuiRunOnce`  fails on the vSphere side. Any tips to fix that workaround would be appreciated.