### PR TITLE
Add Custom Attribute resource and data source

### DIFF
--- a/vsphere/data_source_vsphere_custom_attribute.go
+++ b/vsphere/data_source_vsphere_custom_attribute.go
@@ -1,0 +1,48 @@
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/customattribute"
+	"github.com/vmware/govmomi/object"
+)
+
+func dataSourceVSphereCustomAttribute() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereCustomAttributeRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The display name of the custom attribute.",
+				Required:    true,
+			},
+			"managed_object_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Object type for which the custom attribute is valid. If not specified, the attribute is valid for all managed object types.",
+			},
+		},
+	}
+}
+
+func dataSourceVSphereCustomAttributeRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	err := customattribute.VerifySupport(client)
+	if err != nil {
+		return err
+	}
+
+	fm, err := object.GetCustomFieldsManager(client.Client)
+	if err != nil {
+		return err
+	}
+
+	field, err := customattribute.ByName(fm, d.Get("name").(string))
+	if err != nil {
+		return err
+	}
+	d.SetId(fmt.Sprint(field.Key))
+	d.Set("managed_object_type", field.ManagedObjectType)
+	return nil
+}

--- a/vsphere/data_source_vsphere_custom_attribute_test.go
+++ b/vsphere/data_source_vsphere_custom_attribute_test.go
@@ -1,0 +1,81 @@
+package vsphere
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceVSphereCustomAttribute(t *testing.T) {
+	var tp *testing.T
+	testAccDataSourceVSphereCustomAttributeCases := []struct {
+		name     string
+		testCase resource.TestCase
+	}{
+		{
+			"basic",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataSourceVSphereCustomAttributeConfig(),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr(
+								"data.vsphere_custom_attribute.terraform-test-attribute-data",
+								"name",
+								testAccDataSourceVSphereCustomAttributeConfigName,
+							),
+							resource.TestCheckResourceAttr(
+								"data.vsphere_custom_attribute.terraform-test-attribute-data",
+								"managed_object_type",
+								testAccDataSourceVSphereCustomAttributeConfigType,
+							),
+							resource.TestCheckResourceAttrPair(
+								"data.vsphere_custom_attribute.terraform-test-attribute-data", "id",
+								"vsphere_custom_attribute.terraform-test-attribute", "id",
+							),
+						),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testAccDataSourceVSphereCustomAttributeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tp = t
+			resource.Test(t, tc.testCase)
+		})
+	}
+}
+
+const testAccDataSourceVSphereCustomAttributeConfigName = "terraform-test-attribute"
+const testAccDataSourceVSphereCustomAttributeConfigType = "VirtualMachine"
+
+func testAccDataSourceVSphereCustomAttributeConfig() string {
+	return fmt.Sprintf(`
+variable "attribute_name" {
+  default = "%s"
+}
+
+variable "attribute_type" {
+  default = "%s"
+}
+
+resource "vsphere_custom_attribute" "terraform-test-attribute" {
+  name                = "${var.attribute_name}"
+  managed_object_type = "${var.attribute_type}"
+}
+
+data "vsphere_custom_attribute" "terraform-test-attribute-data" {
+  name = "${vsphere_custom_attribute.terraform-test-attribute.name}"
+}
+`,
+		testAccDataSourceVSphereCustomAttributeConfigName,
+		testAccDataSourceVSphereCustomAttributeConfigType,
+	)
+}

--- a/vsphere/datacenter_helper.go
+++ b/vsphere/datacenter_helper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"golang.org/x/net/context"
 )
@@ -46,4 +47,14 @@ func datacenterFromID(client *govmomi.Client, id string) (*object.Datacenter, er
 		return nil, fmt.Errorf("could not find datacenter with id: %s: %s", id, err)
 	}
 	return ds.(*object.Datacenter), nil
+}
+
+func datacenterCustomAttributes(dc *object.Datacenter) (*mo.Datacenter, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	var props mo.Datacenter
+	if err := dc.Properties(ctx, dc.Reference(), []string{"customValue"}, &props); err != nil {
+		return nil, err
+	}
+	return &props, nil
 }

--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -508,6 +508,16 @@ func testGetDatastore(s *terraform.State, resAddr string) (*object.Datastore, er
 	return datastore.FromID(vars.client, vars.resourceID)
 }
 
+// testGetDatastoreProperties is a convenience method that adds an extra step
+// to testGetDatastore to get the properties of a datastore.
+func testGetDatastoreProperties(s *terraform.State, resourceName string) (*mo.Datastore, error) {
+	ds, err := testGetDatastore(s, "vsphere_vmfs_datastore."+resourceName)
+	if err != nil {
+		return nil, err
+	}
+	return datastore.Properties(ds)
+}
+
 // testAccResourceVSphereDatastoreCheckTags is a check to ensure that the
 // supplied datastore has had the tags that have been created with the supplied
 // tag resource name attached.

--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -218,6 +218,26 @@ func testGetVirtualMachineSCSIBusState(s *terraform.State, resourceName string) 
 	return virtualdevice.ReadSCSIBusState(l, count), nil
 }
 
+func testGetDatacenter(s *terraform.State, resourceName string) (*object.Datacenter, error) {
+	tVars, err := testClientVariablesForResource(s, fmt.Sprintf("vsphere_datacenter.%s", resourceName))
+	if err != nil {
+		return nil, err
+	}
+	dcName, ok := tVars.resourceAttributes["name"]
+	if !ok {
+		return nil, fmt.Errorf("Datacenter resource %q has no name", resourceName)
+	}
+	return getDatacenter(tVars.client, dcName)
+}
+
+func testGetDatacenterCustomAttributes(s *terraform.State, resourceName string) (*mo.Datacenter, error) {
+	dc, err := testGetDatacenter(s, resourceName)
+	if err != nil {
+		return nil, err
+	}
+	return datacenterCustomAttributes(dc)
+}
+
 // testPowerOffVM does an immediate power-off of the supplied virtual machine
 // resource defined by the supplied resource address name. It is used to help
 // set up a test scenarios where a VM is powered off.

--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -510,8 +510,8 @@ func testGetDatastore(s *terraform.State, resAddr string) (*object.Datastore, er
 
 // testGetDatastoreProperties is a convenience method that adds an extra step
 // to testGetDatastore to get the properties of a datastore.
-func testGetDatastoreProperties(s *terraform.State, resourceName string) (*mo.Datastore, error) {
-	ds, err := testGetDatastore(s, "vsphere_vmfs_datastore."+resourceName)
+func testGetDatastoreProperties(s *terraform.State, datastoreType string, resourceName string) (*mo.Datastore, error) {
+	ds, err := testGetDatastore(s, "vsphere_"+datastoreType+"_datastore."+resourceName)
 	if err != nil {
 		return nil, err
 	}

--- a/vsphere/internal/helper/customattribute/custom_attributes_helper.go
+++ b/vsphere/internal/helper/customattribute/custom_attributes_helper.go
@@ -1,0 +1,154 @@
+package customattribute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// ConfigKey is the string that should always be used as the
+// key for specifying custom attribute values for a resource. Various resource
+// custom attribute helpers will depend on this value being consistent across
+// resources.
+//
+// When adding custom attributes to a resource schema, the easiest way to do
+// that (for now) will be to use the following line:
+//
+//   customattribute.ConfigKey: customattribute.ConfigSchema(),
+//
+// This will ensure that the correct key and schema is used across all
+// resources.
+const ConfigKey = "custom_attributes"
+
+// ConfigSchema returns the schema for custom attribute configuration
+// for each resource that needs it.
+//
+// The key should be set to the ConfigKey constant and should be a
+// map of custom attribute ids to values.
+func ConfigSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeMap,
+		Description: "A list of custom attributes to set on this resource.",
+		Optional:    true,
+	}
+}
+
+func VerifySupport(client *govmomi.Client) error {
+	if err := viapi.ValidateVirtualCenter(client); err != nil {
+		return errors.New("Custom attributes are only supported on vCenter")
+	}
+	return nil
+}
+
+func IsSupported(client *govmomi.Client) bool {
+	return VerifySupport(client) == nil
+}
+
+func ReadFromResource(client *govmomi.Client, entity *mo.ManagedEntity, d *schema.ResourceData) {
+	customAttrs := make(map[string]interface{})
+	if len(entity.CustomValue) > 0 {
+		for _, fv := range entity.CustomValue {
+			value := fv.(*types.CustomFieldStringValue).Value
+			if value != "" {
+				customAttrs[fmt.Sprint(fv.GetCustomFieldValue().Key)] = value
+			}
+		}
+	}
+	d.Set(ConfigKey, customAttrs)
+}
+
+type CustomAttributeDiffProcessor struct {
+	// The field manager
+	fm *object.CustomFieldsManager
+
+	// Old map of custom attribute key to values
+	oldAttributes map[string]interface{}
+
+	// New map of custom attribute key to values
+	newAttributes map[string]interface{}
+}
+
+func (p *CustomAttributeDiffProcessor) clearRemovedAttributes(subject object.Reference) error {
+	for k := range p.oldAttributes {
+		_, ok := p.newAttributes[k]
+		if !ok {
+			key, err := strconv.ParseInt(k, 10, 32)
+			if err != nil {
+				return err
+			}
+			err = p.fm.Set(context.TODO(), subject.Reference(), int32(key), "")
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (p *CustomAttributeDiffProcessor) setNewAttributes(subject object.Reference) error {
+	for k, v := range p.newAttributes {
+		key, err := strconv.ParseInt(k, 10, 32)
+		if err != nil {
+			return err
+		}
+		err = p.fm.Set(context.TODO(), subject.Reference(), int32(key), v.(string))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *CustomAttributeDiffProcessor) ProcessDiff(subject object.Reference) error {
+	if err := p.clearRemovedAttributes(subject); err != nil {
+		return fmt.Errorf("error clearing removed attributes for object ID %q: %s", subject.Reference().Value, err)
+	}
+	if err := p.setNewAttributes(subject); err != nil {
+		return fmt.Errorf("error setting attributes for object ID %q: %s", subject.Reference().Value, err)
+	}
+	return nil
+}
+
+func GetDiffProcessorIfAttributesDefined(client *govmomi.Client, d *schema.ResourceData) (*CustomAttributeDiffProcessor, error) {
+	old, new := d.GetChange(ConfigKey)
+	if len(old.(map[string]interface{})) > 0 || len(new.(map[string]interface{})) > 0 {
+		if err := VerifySupport(client); err != nil {
+			return nil, err
+		}
+	} else {
+		// No custom attributes defined
+		return nil, nil
+	}
+	fm, err := object.GetCustomFieldsManager(client.Client)
+	if err != nil {
+		return nil, err
+	}
+	return &CustomAttributeDiffProcessor{
+		fm:            fm,
+		oldAttributes: old.(map[string]interface{}),
+		newAttributes: new.(map[string]interface{}),
+	}, nil
+}
+
+func ByName(fm *object.CustomFieldsManager, name string) (*types.CustomFieldDef, error) {
+	fields, err := fm.Field(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, def := range fields {
+		if def.Name == name {
+			return &def, nil
+		}
+	}
+
+	return nil, object.ErrKeyNameNotFound
+}

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -69,6 +69,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"vsphere_custom_attribute":           resourceVSphereCustomAttribute(),
 			"vsphere_datacenter":                 resourceVSphereDatacenter(),
 			"vsphere_distributed_port_group":     resourceVSphereDistributedPortGroup(),
 			"vsphere_distributed_virtual_switch": resourceVSphereDistributedVirtualSwitch(),
@@ -87,6 +88,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"vsphere_custom_attribute":           dataSourceVSphereCustomAttribute(),
 			"vsphere_datacenter":                 dataSourceVSphereDatacenter(),
 			"vsphere_datastore":                  dataSourceVSphereDatastore(),
 			"vsphere_distributed_virtual_switch": dataSourceVSphereDistributedVirtualSwitch(),

--- a/vsphere/resource_vsphere_custom_attribute.go
+++ b/vsphere/resource_vsphere_custom_attribute.go
@@ -1,0 +1,147 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/customattribute"
+	"github.com/vmware/govmomi/object"
+)
+
+func resourceVSphereCustomAttribute() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVSphereCustomAttributeCreate,
+		Read:   resourceVSphereCustomAttributeRead,
+		Update: resourceVSphereCustomAttributeUpdate,
+		Delete: resourceVSphereCustomAttributeDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceVSphereCustomAttributeImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The display name of the custom attribute.",
+				Required:    true,
+			},
+			"managed_object_type": {
+				Type:        schema.TypeString,
+				Description: "Object type for which the custom attribute is valid. If not specified, the attribute is valid for all managed object types.",
+				Optional:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceVSphereCustomAttributeCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	if err := customattribute.VerifySupport(client); err != nil {
+		return err
+	}
+
+	fm, err := object.GetCustomFieldsManager(client.Client)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	field, err := fm.Add(ctx, d.Get("name").(string), d.Get("managed_object_type").(string), nil, nil)
+	if err != nil {
+		return fmt.Errorf("could not create custom attribute: %s", err)
+	}
+
+	d.SetId(fmt.Sprint(field.Key))
+	d.Set("name", field.Name)
+	d.Set("managed_object_type", field.ManagedObjectType)
+	return nil
+}
+
+func resourceVSphereCustomAttributeRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	if err := customattribute.VerifySupport(client); err != nil {
+		return err
+	}
+
+	fm, err := object.GetCustomFieldsManager(client.Client)
+	if err != nil {
+		return err
+	}
+	key, err := strconv.ParseInt(d.Id(), 10, 32)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	fields, err := fm.Field(ctx)
+	if err != nil {
+		return err
+	}
+	field := fields.ByKey(int32(key))
+	if field == nil {
+		return fmt.Errorf("could not locate category with id %q", key)
+	}
+	d.Set("name", field.Name)
+	d.Set("managed_object_type", field.ManagedObjectType)
+	return nil
+}
+
+func resourceVSphereCustomAttributeUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	if err := customattribute.VerifySupport(client); err != nil {
+		return err
+	}
+
+	fm, err := object.GetCustomFieldsManager(client.Client)
+	if err != nil {
+		return err
+	}
+	key, err := strconv.ParseInt(d.Id(), 10, 32)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	return fm.Rename(ctx, int32(key), d.Get("name").(string))
+}
+
+func resourceVSphereCustomAttributeDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	if err := customattribute.VerifySupport(client); err != nil {
+		return err
+	}
+
+	fm, err := object.GetCustomFieldsManager(client.Client)
+	if err != nil {
+		return err
+	}
+	key, err := strconv.ParseInt(d.Id(), 10, 32)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+	defer cancel()
+	return fm.Remove(ctx, int32(key))
+}
+
+func resourceVSphereCustomAttributeImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*VSphereClient).vimClient
+	if err := customattribute.VerifySupport(client); err != nil {
+		return nil, err
+	}
+
+	fm, err := object.GetCustomFieldsManager(client.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	field, err := customattribute.ByName(fm, d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(fmt.Sprint(field.Key))
+	return []*schema.ResourceData{d}, nil
+}

--- a/vsphere/resource_vsphere_custom_attribute_test.go
+++ b/vsphere/resource_vsphere_custom_attribute_test.go
@@ -1,0 +1,216 @@
+package vsphere
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccResourceVSphereCustomAttribute(t *testing.T) {
+	var tp *testing.T
+	testAccResourceVSphereCustomAttributeCases := []struct {
+		name     string
+		testCase resource.TestCase
+	}{
+		{
+			"basic",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereCustomAttributeConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereCustomAttributeExists(true),
+							testAccResourceVSphereCustomAttributeHasName("terraform-test-attribute"),
+							testAccResourceVSphereCustomAttributeHasType(""),
+						),
+					},
+				},
+			},
+		},
+		{
+			"with type",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereCustomAttributeConfigType,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereCustomAttributeExists(true),
+							testAccResourceVSphereCustomAttributeHasName("terraform-test-attribute"),
+							testAccResourceVSphereCustomAttributeHasType("VirtualMachine"),
+						),
+					},
+				},
+			},
+		},
+		{
+			"rename",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereCustomAttributeConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereCustomAttributeExists(true),
+						),
+					},
+					{
+						Config: testAccResourceVSphereCustomAttributeConfigAltName,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereCustomAttributeExists(true),
+							testAccResourceVSphereCustomAttributeHasName("terraform-test-attribute-renamed"),
+						),
+					},
+				},
+			},
+		},
+		{
+			"change type",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereCustomAttributeConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereCustomAttributeExists(true),
+							testAccResourceVSphereCustomAttributeHasType(""),
+						),
+					},
+					{
+						Config: testAccResourceVSphereCustomAttributeConfigType,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereCustomAttributeExists(true),
+							testAccResourceVSphereCustomAttributeHasType("VirtualMachine"),
+						),
+					},
+				},
+			},
+		},
+		{
+			"import",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereCustomAttributeConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereCustomAttributeExists(true),
+						),
+					},
+					{
+						ResourceName:      "vsphere_custom_attribute.terraform-test-attribute",
+						ImportState:       true,
+						ImportStateVerify: true,
+						ImportStateIdFunc: func(s *terraform.State) (string, error) {
+							attr, err := testGetCustomAttribute(s, "terraform-test-attribute")
+							if err != nil {
+								return "", err
+							}
+							if attr == nil {
+								return "", errors.New("custom attribute does not exist")
+							}
+							return attr.Name, nil
+						},
+						Config: testAccResourceVSphereCustomAttributeConfigBasic,
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereCustomAttributeExists(true),
+						),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testAccResourceVSphereCustomAttributeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tp = t
+			resource.Test(t, tc.testCase)
+		})
+	}
+}
+
+func testAccResourceVSphereCustomAttributeExists(expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attr, err := testGetCustomAttribute(s, "terraform-test-attribute")
+		if err != nil {
+			return err
+		}
+		if attr == nil && expected {
+			return errors.New("expected custom attribute to exist")
+		} else if attr != nil && !expected {
+			return errors.New("expected custom attribute to be missing")
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereCustomAttributeHasName(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attr, err := testGetCustomAttribute(s, "terraform-test-attribute")
+		if err != nil {
+			return err
+		}
+		actual := attr.Name
+		if expected != actual {
+			return fmt.Errorf("expected name to be %q, got %q", expected, actual)
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereCustomAttributeHasType(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attr, err := testGetCustomAttribute(s, "terraform-test-attribute")
+		if err != nil {
+			return err
+		}
+		actual := attr.ManagedObjectType
+		if expected != actual {
+			return fmt.Errorf("expected managed object type to be %q, got %q", expected, actual)
+		}
+		return nil
+	}
+}
+
+const testAccResourceVSphereCustomAttributeConfigBasic = `
+resource "vsphere_custom_attribute" "terraform-test-attribute" {
+  name = "terraform-test-attribute"
+}
+`
+
+const testAccResourceVSphereCustomAttributeConfigType = `
+resource "vsphere_custom_attribute" "terraform-test-attribute" {
+  name                = "terraform-test-attribute"
+  managed_object_type = "VirtualMachine"
+}
+`
+
+const testAccResourceVSphereCustomAttributeConfigAltName = `
+resource "vsphere_custom_attribute" "terraform-test-attribute" {
+  name = "terraform-test-attribute-renamed"
+}
+`

--- a/vsphere/resource_vsphere_vmfs_datastore_test.go
+++ b/vsphere/resource_vsphere_vmfs_datastore_test.go
@@ -439,7 +439,7 @@ func testAccResourceVSphereVmfsDatastoreMatchInventoryPath(expected string) reso
 
 func testAccResourceVSphereVmfsDatastoreHasCustomAttributes() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		props, err := testGetDatastoreProperties(s, "datastore")
+		props, err := testGetDatastoreProperties(s, "vmfs", "datastore")
 		if err != nil {
 			return err
 		}

--- a/website/docs/d/custom_attribute.html.markdown
+++ b/website/docs/d/custom_attribute.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_custom_attribute"
+sidebar_current: "docs-vsphere-data-source-custom-attriubte"
+description: |-
+  Provides a vSphere custom attribute data source. This can be used to reference custom attributes not managed in Terraform.
+---
+
+# vsphere\_custom\_attribute
+
+The `vsphere_custom_attribute` data source can be used to reference custom 
+attributes that are not managed by Terraform. Its attributes are exactly the 
+same as the [`vsphere_custom_attribute` resource][resource-custom-attribute], 
+and, like importing, the data source takes a name to search on. The `id` and 
+other attributes are then populated with the data found by the search.
+
+[resource-custom-attribute]: /docs/providers/vsphere/r/custom_attribute.html
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
+
+## Example Usage
+
+```hcl
+data "vsphere_custom_attribute" "attribute" {
+  name = "terraform-test-attribute"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the custom attribute.
+
+## Attribute Reference
+
+In addition to the `id` being exported, all of the fields that are available in 
+the [`vsphere_custom_attribute` resource][resource-custom-attribute] are also 
+populated. See that page for further details.

--- a/website/docs/r/custom_attribute.html.markdown
+++ b/website/docs/r/custom_attribute.html.markdown
@@ -44,7 +44,7 @@ value to created custom attribute on it.
 [docs-virtual-machine-resource]: /docs/providers/vsphere/r/virutal_machine.html
 
 ```hcl
-  resource "vsphere_custom_attribute" "attribute" {
+resource "vsphere_custom_attribute" "attribute" {
   name                = "terraform-test-attribute"
   managed_object_type = "VirtualMachine"
 }
@@ -52,7 +52,7 @@ value to created custom attribute on it.
 resource "vpshere_virtual_machine" "web" {
   ...
 
-  custom_attributes = "${map(vsphere_custom_attribute.terraform-test-attribute.id, "value")}"
+  custom_attributes = "${map(vsphere_custom_attribute.attribute.id, "value")}"
 }
 ```
 
@@ -61,17 +61,17 @@ resource "vpshere_virtual_machine" "web" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the custom attribute.
-* `managed_object_type` - (Optional) The object type that this attribute 
-  may be applied to. If not set the custom attribute may be applied to any 
-  object type. For a full list, click [here](#managed_object_types). Forces a 
-  new custom attribute if changed.
+* `managed_object_type` - (Optional) The object type that this attribute may be
+  applied to. If not set, the custom attribute may be applied to any object
+  type. For a full list, click [here](#managed-object-types). Forces a new
+  resource if changed.
 
 ## Managed Object Types
 
 The following table will help you determine what value you need to enter for 
 the managed object type you want the attribute to apply to.
 
-Note that if you want a attribute to apply to all objects leave the type 
+Note that if you want a attribute to apply to all objects, leave the type 
 unspecified.
 
 <table>

--- a/website/docs/r/custom_attribute.html.markdown
+++ b/website/docs/r/custom_attribute.html.markdown
@@ -1,0 +1,108 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_custom_attribute"
+sidebar_current: "docs-vsphere-resource-inventory-custom-attribute"
+description: |-
+  Provides a vSphere custom attribute resource. This can be used to manage custom attributes in vSphere.
+---
+
+# vsphere\_custom\_attribute
+
+The `vsphere_custom_attribute` resource can be used to create and manage custom
+attributes, which allow users to associate user-specific meta-information with 
+vSphere managed objects. Custom attribute values must be strings and are stored 
+on the vCenter Server and not the managed object.
+
+For more information about custom attributes, click [here][ext-custom-attributes].
+
+[ext-custom-attributes]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-73606C4C-763C-4E27-A1DA-032E4C46219D.html
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
+
+## Example Usage
+
+This example creates a custom attribute named `terraform-test-attribute`. The 
+resulting custom attribute can be assigned to VMs only.
+
+```hcl
+resource "vsphere_custom_attribute" "attribute" {
+  name                = "terraform-test-attribute"
+  managed_object_type = "VirtualMachine"
+}
+```
+
+## Using Custom Attributes in a Supported Resource
+
+Custom attributes can be set on vSphere resources in Terraform via the 
+`custom_attributes` argument in any supported resource.
+
+The following example builds on the above example by creating a 
+[`vsphere_virtual_machine`][docs-virtual-machine-resource] and assigning a 
+value to created custom attribute on it.
+
+[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virutal_machine.html
+
+```hcl
+  resource "vsphere_custom_attribute" "attribute" {
+  name                = "terraform-test-attribute"
+  managed_object_type = "VirtualMachine"
+}
+
+resource "vpshere_virtual_machine" "web" {
+  ...
+
+  custom_attributes = "${map(vsphere_custom_attribute.terraform-test-attribute.id, "value")}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the custom attribute.
+* `managed_object_type` - (Optional) The object type that this attribute 
+  may be applied to. If not set the custom attribute may be applied to any 
+  object type. For a full list, click [here](#managed_object_types). Forces a 
+  new custom attribute if changed.
+
+## Managed Object Types
+
+The following table will help you determine what value you need to enter for 
+the managed object type you want the attribute to apply to.
+
+Note that if you want a attribute to apply to all objects leave the type 
+unspecified.
+
+<table>
+<tr><th>Type</th><th>Value</th></tr>
+<tr><td>Folders</td><td>`Folder`</td></tr>
+<tr><td>Clusters</td><td>`ClusterComputeResource`</td></tr>
+<tr><td>Datacenters</td><td>`Datacenter`</td></tr>
+<tr><td>Datastores</td><td>`Datastore`</td></tr>
+<tr><td>Datastore Clusters</td><td>`StoragePod`</td></tr>
+<tr><td>DVS Portgroups</td><td>`DistributedVirtualPortgroup`</td></tr>
+<tr><td>Distributed vSwitches</td><td>`DistributedVirtualSwitch`<br>`VmwareDistributedVirtualSwitch`</td></tr>
+<tr><td>Hosts</td><td>`HostSystem`</td></tr>
+<tr><td>Content Libraries</td><td>`com.vmware.content.Library`</td></tr>
+<tr><td>Content Library Items</td><td>`com.vmware.content.library.Item`</td></tr>
+<tr><td>Networks</td><td>`HostNetwork`<br>`Network`<br>`OpaqueNetwork`</td></tr>
+<tr><td>Resource Pools</td><td>`ResourcePool`</td></tr>
+<tr><td>vApps</td><td>`VirtualApp`</td></tr>
+<tr><td>Virtual Machines</td><td>`VirtualMachine`</td></tr>
+</table>
+
+## Attribute Reference
+
+This resource only exports the `id` attribute for the vSphere custom attribute.
+
+## Importing
+
+An existing custom attribute can be [imported][docs-import] into this resource 
+via its name, using the following command:
+
+[docs-import]: https://www.terraform.io/docs/import/index.html
+
+```
+terraform import vsphere_custom_attribute.attribute terraform-test-attribute
+```

--- a/website/docs/r/datacenter.html.markdown
+++ b/website/docs/r/datacenter.html.markdown
@@ -46,6 +46,16 @@ The following arguments are supported:
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.
 
+* `custom_attributes` - (Optional) Map of custom attribute ids to value 
+  strings to set for datacenter resource. See 
+  [here][docs-setting-custom-attributes] for a reference on how to set values 
+  for custom attributes.
+
+[docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
+
 ## Attribute Reference
 
 The only attribute exported is `id`, which is the name of the datacenter.

--- a/website/docs/r/distributed_port_group.html.markdown
+++ b/website/docs/r/distributed_port_group.html.markdown
@@ -159,6 +159,14 @@ specify `number_of_ports`, you may wish to set `auto_expand` to `false`.
 * `network_resource_pool_key` - (Optional) The key of a network resource pool
   to associate with this port group. The default is `-1`, which implies no
   association.
+* `custom_attributes` (Optional) Map of custom attribute ids to attribute
+  value string to set for port group. See [here][docs-setting-custom-attributes] 
+  for a reference on how to set values for custom attributes.
+
+[docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
 
 ### Policy options
 

--- a/website/docs/r/distributed_virtual_switch.html.markdown
+++ b/website/docs/r/distributed_virtual_switch.html.markdown
@@ -155,6 +155,16 @@ The following arguments are supported:
 
 ~> **NOTE:** Tagging support requires vCenter 6.0 or higher.
 
+* `custom_attributes` - (Optional) Map of custom attribute ids to attribute
+  value strings to set for virtual switch. See 
+  [here][docs-setting-custom-attributes] for a reference on how to set values 
+  for custom attributes.
+
+[docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
+
 ### Uplink arguments
 
 * `uplinks` - (Optional) A list of strings that uniquely identifies the names

--- a/website/docs/r/folder.html.markdown
+++ b/website/docs/r/folder.html.markdown
@@ -91,6 +91,15 @@ modifying the name (the part after the last `/`), your folder will be renamed.
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.
 
+* `custom_attributes` - (Optional) Map of custom attribute ids to attribute 
+  value strings to set for folder. See [here][docs-setting-custom-attributes] 
+  for a reference on how to set values for custom attributes.
+
+[docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
+
 ## Attribute Reference
 
 The only attribute that this resource exports is the `id`, which is set to the

--- a/website/docs/r/nas_datastore.html.markdown
+++ b/website/docs/r/nas_datastore.html.markdown
@@ -90,6 +90,16 @@ The following arguments are supported:
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.
 
+* `custom_attributes` - (Optional) Map of custom attribute ids to attribute 
+  value strings to set on datasource resource. See 
+  [here][docs-setting-custom-attributes] for a reference on how to set values 
+  for custom attributes.
+
+[docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
+
 ## Attribute Reference
 
 The following attributes are exported:

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -348,6 +348,16 @@ options:
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.
 
+* `custom_attributes` - (Optional) Map of custom attribute ids to attribute
+  value strings to set for virtual machine. See 
+  [here][docs-setting-custom-attributes] for a reference on how to set values 
+  for custom attributes.
+
+[docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
+
 ### CPU and memory options
 
 The following options control CPU and memory settings on the virtual machine:

--- a/website/docs/r/vmfs_datastore.html.markdown
+++ b/website/docs/r/vmfs_datastore.html.markdown
@@ -143,6 +143,16 @@ The following arguments are supported:
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.
 
+* `custom_attributes` (Optional) Map of custom attribute ids to attribute 
+   value string to set on datastore resource. See 
+   [here][docs-setting-custom-attributes] for a reference on how to set values 
+   for custom attributes.
+
+[docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
+
 ## Attribute Reference
 
 The following attributes are exported:

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-vsphere-data-source") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-data-source-custom-attribute") %>>
+              <a href="/docs/providers/vsphere/d/custom_attribute.html">vsphere_custom_attribute</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-data-source-datacenter") %>>
               <a href="/docs/providers/vsphere/d/datacenter.html">vsphere_datacenter</a>
             </li>
@@ -43,9 +46,6 @@
             <li<%= sidebar_current("docs-vsphere-data-source-vmfs-disks") %>>
               <a href="/docs/providers/vsphere/d/vmfs_disks.html">vsphere_vmfs_disks</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-data-source-custom-attribute") %>>
-              <a href="/docs/providers/vsphere/d/custom_attribute.html">vsphere_custom_attribute</a>
-            </li>
           </ul>
         </li>
 
@@ -61,6 +61,9 @@
         <li<%= sidebar_current("docs-vsphere-resource-inventory") %>>
           <a href="#">Inventory Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-resource-inventory-custom-attribute") %>>
+              <a href="/docs/providers/vsphere/r/custom_attribute.html">vsphere_custom_attribute</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-resource-inventory-datacenter") %>>
               <a href="/docs/providers/vsphere/r/datacenter.html">vsphere_datacenter</a>
             </li>
@@ -72,9 +75,6 @@
             </li>
             <li<%= sidebar_current("docs-vsphere-resource-inventory-tag-category") %>>
               <a href="/docs/providers/vsphere/r/tag_category.html">vsphere_tag_category</a>
-            </li>
-            <li<%= sidebar_current("docs-vsphere-resource-inventory-custom-attribute") %>>
-              <a href="/docs/providers/vsphere/r/custom_attribute.html">vsphere_custom_attribute</a>
             </li>
           </ul>
         </li>

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -43,6 +43,9 @@
             <li<%= sidebar_current("docs-vsphere-data-source-vmfs-disks") %>>
               <a href="/docs/providers/vsphere/d/vmfs_disks.html">vsphere_vmfs_disks</a>
             </li>
+            <li<%= sidebar_current("docs-vsphere-data-source-custom-attribute") %>>
+              <a href="/docs/providers/vsphere/d/custom_attribute.html">vsphere_custom_attribute</a>
+            </li>
           </ul>
         </li>
 
@@ -69,6 +72,9 @@
             </li>
             <li<%= sidebar_current("docs-vsphere-resource-inventory-tag-category") %>>
               <a href="/docs/providers/vsphere/r/tag_category.html">vsphere_tag_category</a>
+            </li>
+            <li<%= sidebar_current("docs-vsphere-resource-inventory-custom-attribute") %>>
+              <a href="/docs/providers/vsphere/r/custom_attribute.html">vsphere_custom_attribute</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This allows management of Custom Attributes and allows their values to be specified on VMs satisfying #120. Specifically it adds a `vsphere_custom_attribute` data source for using predefined attributes, a `vsphere_custom_attribute` resource for managing new custom attributes using Terraform, and a `custom_attributes` argument on VM resources for specifying custom attribute values.

Still need to add documentation and tests, which I can work on if you're interested in merging.