### PR TITLE
d/network: Remove vCenter requirement

### DIFF
--- a/vsphere/data_source_vsphere_network.go
+++ b/vsphere/data_source_vsphere_network.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/network"
-	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
 	"github.com/vmware/govmomi/object"
 )
 
@@ -35,9 +34,6 @@ func dataSourceVSphereNetwork() *schema.Resource {
 
 func dataSourceVSphereNetworkRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*VSphereClient).vimClient
-	if err := viapi.ValidateVirtualCenter(client); err != nil {
-		return err
-	}
 
 	name := d.Get("name").(string)
 	var dc *object.Datacenter

--- a/vsphere/data_source_vsphere_network_test.go
+++ b/vsphere/data_source_vsphere_network_test.go
@@ -20,6 +20,7 @@ func TestAccDataSourceVSphereNetwork(t *testing.T) {
 				PreCheck: func() {
 					testAccPreCheck(tp)
 					testAccDataSourceVSphereNetworkPreCheck(tp)
+					testAccSkipIfEsxi(tp)
 				},
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{
@@ -42,6 +43,7 @@ func TestAccDataSourceVSphereNetwork(t *testing.T) {
 				PreCheck: func() {
 					testAccPreCheck(tp)
 					testAccDataSourceVSphereNetworkPreCheck(tp)
+					testAccSkipIfEsxi(tp)
 				},
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{
@@ -82,6 +84,7 @@ func TestAccDataSourceVSphereNetwork(t *testing.T) {
 				PreCheck: func() {
 					testAccPreCheck(tp)
 					testAccDataSourceVSphereNetworkPreCheck(tp)
+					testAccSkipIfEsxi(tp)
 				},
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{

--- a/website/docs/d/network.html.markdown
+++ b/website/docs/d/network.html.markdown
@@ -14,9 +14,6 @@ network interface for `vsphere_virtual_machine` or any other vSphere resource
 that requires a network. This includes standard (host-based) port groups, DVS
 port groups, or opaque networks such as those managed by NSX.
 
-~> **NOTE:** This data source requires vCenter and is not available on direct
-ESXi connections.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
This resource has always functioned correctly on ESXi, and will be
required to work with virtual machines going forward, so it's important
it works on both ESXi and vCenter.

Specifically tested this on ESXi to make sure. Also added skips for all
the DVS related tests in this data source so that the host/standard port
group example is the only one that runs when conducting ESXi tests.