### PR TITLE
docs: pre-1.0.0 documentation cleanup, deprecate adapter_type in vsphere_virtual_disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ Server][vmware-vcenter] and [ESXi][vmware-esxi].
 [vmware-vcenter]: https://www.vmware.com/products/vcenter-server.html
 [vmware-esxi]: https://www.vmware.com/products/esxi-and-esx.html
 
-Coverage is currently only limited to a few resources namely surrounding virtual
-machines, but in the coming months we are planning release coverage for most
-essential vSphere workflows, including working with storage and networking
-components such as datastores, and standard and distributed vSwitches. Watch
-this space!
-
 For general information about Terraform, visit the [official
 website][tf-website] and the [GitHub project page][tf-github].
 

--- a/]
+++ b/]
@@ -1,0 +1,8 @@
+r/host_virtual_switch: Doc grammar correction for notify_switches opt
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch m-doc-updates
+# Changes to be committed:
+#	modified:   website/docs/r/host_virtual_switch.html.markdown
+#

--- a/]
+++ b/]
@@ -1,8 +1,0 @@
-r/host_virtual_switch: Doc grammar correction for notify_switches opt
-# Please enter the commit message for your changes. Lines starting
-# with '#' will be ignored, and an empty message aborts the commit.
-#
-# On branch m-doc-updates
-# Changes to be committed:
-#	modified:   website/docs/r/host_virtual_switch.html.markdown
-#

--- a/vsphere/host_network_policy_structure.go
+++ b/vsphere/host_network_policy_structure.go
@@ -82,22 +82,22 @@ func schemaHostNetworkPolicy() map[string]*schema.Schema {
 		"shaping_average_bandwidth": &schema.Schema{
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Description: "The average bandwidth in bits per second if shaping is enabled on the port.",
+			Description: "The average bandwidth in bits per second if traffic shaping is enabled.",
 		},
 		"shaping_burst_size": &schema.Schema{
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Description: "The maximum burst size allowed in bytes if shaping is enabled on the port.",
+			Description: "The maximum burst size allowed in bytes if traffic shaping is enabled.",
 		},
 		"shaping_enabled": &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: "True if the traffic shaper is enabled on the port.",
+			Description: "Enable traffic shaping on this virtual switch or port group.",
 		},
 		"shaping_peak_bandwidth": &schema.Schema{
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Description: "The peak bandwidth during bursts in bits per second if traffic shaping is enabled on the port.",
+			Description: "The peak bandwidth during bursts in bits per second if traffic shaping is enabled.",
 		},
 	}
 }

--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -61,10 +61,11 @@ func resourceVSphereVirtualDisk() *schema.Resource {
 			},
 
 			"adapter_type": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "lsiLogic",
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Default:    "lsiLogic",
+				Deprecated: "this attribute has no effect on controller types - please use scsi_type in vsphere_virtual_machine instead",
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
 					if value != "ide" && value != "busLogic" && value != "lsiLogic" {

--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -61,10 +61,11 @@ func resourceVSphereVirtualDisk() *schema.Resource {
 			},
 
 			"adapter_type": &schema.Schema{
-				Type:       schema.TypeString,
-				Optional:   true,
-				ForceNew:   true,
-				Default:    "lsiLogic",
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "lsiLogic",
+				// TODO: Move this to removed after we remove the support to specify this in later versions
 				Deprecated: "this attribute has no effect on controller types - please use scsi_type in vsphere_virtual_machine instead",
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)

--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -39,10 +39,15 @@ func resourceVSphereVirtualDisk() *schema.Resource {
 				ForceNew: true, //TODO Can this be optional (resize)?
 			},
 
+			// TODO:
+			//
+			// * Add extra lifecycles (move, rename, etc). May not be possible
+			// without breaking other resources though.
+			// * Add validation (make sure it ends in .vmdk)
 			"vmdk_path": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true, //TODO Can this be optional (move)?
+				ForceNew: true,
 			},
 
 			"type": &schema.Schema{

--- a/website/docs/d/datacenter.html.markdown
+++ b/website/docs/d/datacenter.html.markdown
@@ -27,8 +27,8 @@ data "vsphere_datacenter" "datacenter" {
 
 The following arguments are supported:
 
-* `name` - (String) The name of the datacenter. This can be a name or path.	Can
-  be omitted if there is only one datacenter in your inventory.
+* `name` - (Optional) The name of the datacenter. This can be a name or path.
+  Can be omitted if there is only one datacenter in your inventory.
 
 ~> **NOTE:** When used against ESXi, this data source _always_ fetches the
 server's "default" datacenter, which is a special datacenter unrelated to the

--- a/website/docs/d/datacenter.html.markdown
+++ b/website/docs/d/datacenter.html.markdown
@@ -37,5 +37,7 @@ Hence, the `name` attribute is completely ignored.
 
 ## Attribute Reference
 
-The only exported attribute is `id`, which is the managed object ID of this
-datacenter.
+The only exported attribute is `id`, which is the [managed object
+ID][docs-about-morefs] of this datacenter.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider

--- a/website/docs/d/distributed_virtual_switch.html.markdown
+++ b/website/docs/d/distributed_virtual_switch.html.markdown
@@ -51,10 +51,12 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the distributed virtual switch. This can be a
   name or path.
-* `datacenter_id` - (Optional) The managed object reference ID of the
-  datacenter the DVS is located in. This can be omitted if the search path used
-  in `name` is an absolute path, or if there is only one datacenter in the
-  vSphere infrastructure.
+* `datacenter_id` - (Optional) The [managed object reference
+  ID][docs-about-morefs] of the datacenter the DVS is located in. This can be
+  omitted if the search path used in `name` is an absolute path, or if there is
+  only one datacenter in the vSphere infrastructure.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ## Attribute Reference
 

--- a/website/docs/d/host.html.markdown
+++ b/website/docs/d/host.html.markdown
@@ -29,14 +29,19 @@ data "vsphere_host" "host" {
 
 The following arguments are supported:
 
-* `datacenter_id` - (Required) The managed object reference ID of a datacenter.
+* `datacenter_id` - (Required) The [managed object reference
+  ID][docs-about-morefs] of a datacenter.
 * `name` - (Optional) The name of the host. This can be a name or path. Can be
   omitted if there is only one host in your inventory.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ~> **NOTE:** When used against an ESXi host directly, this data source _always_
 fetches the server's host object ID, regardless of what is entered into `name`.
 
 ## Attribute Reference
 
-The only exported attribute is `id`, which is the managed object ID of this
-host.
+The only exported attribute is `id`, which is the [managed object
+ID][docs-about-morefs] of this host.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider

--- a/website/docs/d/host.html.markdown
+++ b/website/docs/d/host.html.markdown
@@ -30,7 +30,7 @@ data "vsphere_host" "host" {
 The following arguments are supported:
 
 * `datacenter_id` - (Required) The managed object reference ID of a datacenter.
-* `name` - (Optional) The name of the host. This can be a name or path.	Can be
+* `name` - (Optional) The name of the host. This can be a name or path. Can be
   omitted if there is only one host in your inventory.
 
 ~> **NOTE:** When used against an ESXi host directly, this data source _always_

--- a/website/docs/d/host.html.markdown
+++ b/website/docs/d/host.html.markdown
@@ -29,10 +29,9 @@ data "vsphere_host" "host" {
 
 The following arguments are supported:
 
-* `name` - (String) The name of the host. This can be a name or path.	Can be
+* `datacenter_id` - (Required) The managed object reference ID of a datacenter.
+* `name` - (Optional) The name of the host. This can be a name or path.	Can be
   omitted if there is only one host in your inventory.
-* `datacenter_id` - (String, required) The managed object reference ID of a
-  datacenter.
 
 ~> **NOTE:** When used against an ESXi host directly, this data source _always_
 fetches the server's host object ID, regardless of what is entered into `name`.

--- a/website/docs/d/network.html.markdown
+++ b/website/docs/d/network.html.markdown
@@ -35,16 +35,18 @@ data "vsphere_network" "net" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the network. This can be a name or path.
-* `datacenter_id` - (Optional) The managed object reference ID of the
-  datacenter the network is located in. This can be omitted if the search path
-  used in `name` is an absolute path, or if there is only one datacenter in the
-  vSphere infrastructure.
+* `datacenter_id` - (Optional) The [managed object reference
+  ID][docs-about-morefs] of the datacenter the network is located in. This can
+  be omitted if the search path used in `name` is an absolute path, or if there
+  is only one datacenter in the vSphere infrastructure.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ## Attribute Reference
 
 The following attributes are exported:
 
-* `id`: The managed object ID of the network in question.
+* `id`: The [managed object ID][docs-about-morefs] of the network in question.
 * `type`: The managed object type for the discovered network. This will be one
   of `DistributedVirtualPortgroup` for DVS port groups, `Network` for standard
   (host-based) port groups, or `OpaqueNetwork` for networks managed externally

--- a/website/docs/d/tag.html.markdown
+++ b/website/docs/d/tag.html.markdown
@@ -36,9 +36,8 @@ data "vsphere_tag" "tag" {
 
 The following arguments are supported:
 
-* `name` - (String, required) The name of the tag.
-* `category_id` - (String, required) The ID of the tag category the tag is
-  located in.
+* `name` - (Required) The name of the tag.
+* `category_id` - (Required) The ID of the tag category the tag is located in.
 
 ## Attribute Reference
 

--- a/website/docs/d/tag_category.html.markdown
+++ b/website/docs/d/tag_category.html.markdown
@@ -31,7 +31,7 @@ data "vsphere_tag_category" "category" {
 
 The following arguments are supported:
 
-* `name` - (String, required) The name of the tag category.
+* `name` - (Required) The name of the tag category.
 
 ## Attribute Reference
 

--- a/website/docs/d/vmfs_disks.html.markdown
+++ b/website/docs/d/vmfs_disks.html.markdown
@@ -38,13 +38,13 @@ data "vsphere_vmfs_disks" "available" {
 
 The following arguments are supported:
 
-* `host_system_id` - (String, required) The managed object ID of the host to
-  look for disks on. 
-* `rescan` - (Boolean, optional) Whether or not to rescan storage adapters
-  before searching for disks. This may lengthen the time it takes to perform
-  the search. Default: `false`.
-* `filter` - (String, optional) A regular expression to filter the disks
-  against. Only disks with canonical names that match will be included. 
+* `host_system_id` - (Required) The managed object ID of the host to look for
+  disks on. 
+* `rescan` - (Optional) Whether or not to rescan storage adapters before
+  searching for disks. This may lengthen the time it takes to perform the
+  search. Default: `false`.
+* `filter` - (Optional) A regular expression to filter the disks against. Only
+  disks with canonical names that match will be included. 
 
 ~> **NOTE:** Using a `filter` is recommended if there is any chance the host
 will have any specific storage devices added to it that may affect the order of
@@ -52,5 +52,5 @@ the output `disks` attribute below, which is lexicographically sorted.
 
 ## Attribute Reference
 
-* `disks` - (List of strings) A lexicographically sorted list of devices
-  discovered by the operation, matching the supplied `filter`, if provided.
+* `disks` - A lexicographically sorted list of devices discovered by the
+  operation, matching the supplied `filter`, if provided.

--- a/website/docs/d/vmfs_disks.html.markdown
+++ b/website/docs/d/vmfs_disks.html.markdown
@@ -38,8 +38,11 @@ data "vsphere_vmfs_disks" "available" {
 
 The following arguments are supported:
 
-* `host_system_id` - (Required) The managed object ID of the host to look for
-  disks on. 
+* `host_system_id` - (Required) The [managed object ID][docs-about-morefs] of
+  the host to look for disks on.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
+
 * `rescan` - (Optional) Whether or not to rescan storage adapters before
   searching for disks. This may lengthen the time it takes to perform the
   search. Default: `false`.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -156,6 +156,80 @@ Likewise, some Terraform resources will attempt to read event data from vSphere
 to check for certain events (such as virtual machine customization or power
 events). Ensure that your user has access to read event data.
 
+## Use of Managed Object References by the vSphere Provider
+
+Unlike the vSphere client, many resources in the vSphere Terraform provider
+take Managed Object IDs (or UUIDs when provided and practical) when referring to
+placement parameters and upstream resources. This provides a stable interface
+for providing necessary data to downstream resources, in addition to minimizing
+the bugs that can arise from the flexibility in how an individual object's name
+or inventory path can be supplied.
+
+There are several data sources (such as
+[`vsphere_datacenter`][tf-vsphere-datacenter],
+[`vsphere_host`][tf-vsphere-host],
+[`vsphere_resource_pool`][tf-vsphere-resource-pool],
+[`vsphere_datastore`][tf-vsphere-datastore], and
+[`vsphere_network`][tf-vsphere-network]) that assist with searching for a
+specific resource in Terraform. For usage details on a specific data source,
+look for the appropriate link in the sidebar. In addition, most vSphere
+resources in Terraform supply the managed object ID (or UUID, when it makes
+more sense) as the `id` attribute, which can be supplied to downstream
+resources that should depend on the parent.
+
+[tf-vsphere-host]: /docs/providers/vsphere/d/host.html
+
+### Locating Managed Object IDs
+
+There are certain points in time that you may need to locate the managed object
+ID of a specific vSphere resource yourself. A couple of methods are documented
+below.
+
+#### Via `govc`
+
+[govc][docs-govc] is an vSphere CLI built on [govmomi][docs-govmomi], the
+vSphere Go SDK. It has a robust inventory browser command that can also be used
+to list managed object IDs.
+
+To get all the necessary data in a single output, use `govc ls -l -i PATH`.
+Sample output is below:
+
+```
+$ govc ls -l -i /dc1/vm
+VirtualMachine:vm-123 /dc1/vm/foobar
+Folder:group-v234 /dc1/vm/subfolder
+```
+
+To do a reverse search, supply the `-L` switch:
+
+```
+$ govc ls -i -l -L VirtualMachine:vm-123
+VirtualMachine:vm-123 /dc1/vm/foobar
+```
+
+For details on setting up govc, see the [homepage][docs-govc].
+
+[docs-govc]: https://github.com/vmware/govmomi/tree/master/govc
+[docs-govmomi]: https://github.com/vmware/govmomi
+
+
+#### Via the vSphere Managed Object Browser (MOB)
+
+The Managed Object Browser (MOB) allows one to browse the entire vSphere
+inventory as it's presented to the API. It's normally accessed via
+`https://VSPHERE_SERVER/mob`. For more information, see
+[here][vsphere-docs-using-mob].
+
+[vsphere-docs-using-mob]: https://code.vmware.com/doc/preview?id=4205#/doc/PG_Appx_Using_MOB.21.2.html#994699
+
+~> **NOTE:** The MOB also offers API method invocation capabilities, and for
+security reasons should be used sparingly. Modern vSphere installations may
+have the MOB disabled by default, at the very least on ESXi systems. For more
+information on current security best practices related to the MOB on ESXi,
+click [here][vsphere-docs-esxi-mob].
+
+[vsphere-docs-esxi-mob]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.security.doc/GUID-0EF83EA7-277C-400B-B697-04BDC9173EA3.html
+
 ## Bug Reports and Contributing
 
 For more information how how to submit bug reports, feature requests, or

--- a/website/docs/r/distributed_port_group.html.markdown
+++ b/website/docs/r/distributed_port_group.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_distributed_port_group"
-sidebar_current: "docs-vsphere-resource-network-distributed-port-group"
+sidebar_current: "docs-vsphere-resource-networking-distributed-port-group"
 description: |-
   Provides a vSphere distributed virtual portgroup resource. This can be used to create and manage portgroups on a distributed virtual switch.
 ---

--- a/website/docs/r/distributed_port_group.html.markdown
+++ b/website/docs/r/distributed_port_group.html.markdown
@@ -210,13 +210,16 @@ group can be overridden on the individual port:
 
 The following attributes are exported:
 
-* `id`: The managed object reference ID of the created port group.
+* `id`: The [managed object reference ID][docs-about-morefs] of the created
+  port group.
 * `key`: The generated UUID of the portgroup.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ~> **NOTE:** While `id` and `key` may look the same in state, they are
 documented differently in the vSphere API and come from different fields in the
-port group object. If you are asked to supply an managed object reference ID to
-another resource, be sure to use the `id` field.
+port group object. If you are asked to supply an [managed object reference
+ID][docs-about-morefs] to another resource, be sure to use the `id` field.
 
 * `config_version`: The current version of the port group configuration,
   incremented by subsequent updates to the port group.

--- a/website/docs/r/distributed_virtual_switch.html.markdown
+++ b/website/docs/r/distributed_virtual_switch.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_distributed_virtual_switch"
-sidebar_current: "docs-vsphere-resource-network-distributed-virtual-switch"
+sidebar_current: "docs-vsphere-resource-networking-distributed-virtual-switch"
 description: |-
   Provides a vSphere distributed virtual switch resource. This can be used to create and manage DVS resources in vCenter.
 ---

--- a/website/docs/r/file.html.markdown
+++ b/website/docs/r/file.html.markdown
@@ -8,13 +8,22 @@ description: |-
 
 # vsphere\_file
 
-Provides a VMware vSphere virtual machine file resource. This can be used to upload files (e.g. vmdk disks) from the Terraform host machine to a remote vSphere.  The file resource can also be used to copy files within vSphere.  Files can be copied between Datacenters and/or Datastores.
+The `vsphere_file` resource can be used to upload files (such as virtual disk
+files) from the host machine that Terraform is running on to a target
+datastore.  The resource can also be used to copy files between datastores, or
+from one location to another on the same datastore.
 
-Updates to file resources will handle moving a file to a new destination (datacenter and/or datastore and/or destination_file).  If any source parameter (e.g. `source_datastore`, `source_datacenter` or `source_file`) are changed, this results in a new resource (new file uploaded or copied and old one being deleted).
+Updates to destination parameters such as `datacenter`, `datastore`, or
+`destination_file` will move the managed file a new destination based on the
+values of the new settings.  If any source parameter is changed, such as
+`source_datastore`, `source_datacenter` or `source_file`), the resource will be
+re-created. Depending on if destination parameters are being changed as well,
+this may result in the destination file either being overwritten or deleted at
+the old location.
 
 ## Example Usages
 
-**Upload file to vSphere:**
+### Uploading a file
 
 ```hcl
 resource "vsphere_file" "ubuntu_disk_upload" {
@@ -25,7 +34,7 @@ resource "vsphere_file" "ubuntu_disk_upload" {
 }
 ```
 
-**Copy file within vSphere:**
+### Copying a file
 
 ```hcl
 resource "vsphere_file" "ubuntu_disk_copy" {
@@ -40,14 +49,29 @@ resource "vsphere_file" "ubuntu_disk_copy" {
 
 ## Argument Reference
 
-If `source_datacenter` and `source_datastore` are not provided, the file resource will upload the file from Terraform host.  If either `source_datacenter` or `source_datastore` are provided, the file resource will copy from within specified locations in vSphere.
+If `source_datacenter` and `source_datastore` are not provided, the file
+resource will upload the file from the host that Terraform is running on. If
+either `source_datacenter` or `source_datastore` are provided, the resource
+will copy from within specified locations in vSphere.
 
 The following arguments are supported:
 
-* `source_file` - (Required) The path to the file being uploaded from the Terraform host to vSphere or copied within vSphere.
-* `destination_file` - (Required) The path to where the file should be uploaded or copied to on vSphere.
-* `source_datacenter` - (Optional) The name of a Datacenter in which the file will be copied from.
-* `datacenter` - (Optional) The name of a Datacenter in which the file will be uploaded to.
-* `source_datastore` - (Optional) The name of the Datastore in which file will be copied from.
-* `datastore` - (Required) The name of the Datastore in which to upload the file to.
-* `create_directories` - (Optional) Create directories in `destination_file` path parameter if any missing for copy operation.  *Note: Directories are not deleted on destroy operation.
+* `source_file` - (Required) The path to the file being uploaded from the
+  Terraform host to vSphere or copied within vSphere. Forces a new resource if
+  changed.
+* `destination_file` - (Required) The path to where the file should be uploaded
+  or copied to on vSphere.
+* `source_datacenter` - (Optional) The name of a datacenter in which the file
+  will be copied from. Forces a new resource if changed.
+* `datacenter` - (Optional) The name of a datacenter in which the file will be
+  uploaded to.
+* `source_datastore` - (Optional) The name of the datastore in which file will
+  be copied from. Forces a new resource if changed.
+* `datastore` - (Required) The name of the datastore in which to upload the
+  file to.
+* `create_directories` - (Optional) Create directories in `destination_file`
+  path parameter if any missing for copy operation. 
+  
+~> **NOTE:** Any directory created as part of the operation when
+`create_directories` is enabled will not be deleted when the resource is
+destroyed.

--- a/website/docs/r/folder.html.markdown
+++ b/website/docs/r/folder.html.markdown
@@ -94,7 +94,9 @@ requires vCenter 6.0 or higher.
 ## Attribute Reference
 
 The only attribute that this resource exports is the `id`, which is set to the
-managed object ID of the folder.
+[managed object ID][docs-about-morefs] of the folder.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ## Importing
 

--- a/website/docs/r/host_port_group.html.markdown
+++ b/website/docs/r/host_port_group.html.markdown
@@ -94,14 +94,16 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the port group.  Forces a new resource if
   changed.
-* `host_system_id` - (Required) The managed object ID of the host to set the
-  port group up on. Forces a new resource if changed.
+* `host_system_id` - (Required) The [managed object ID][docs-about-morefs] of
+  the host to set the port group up on. Forces a new resource if changed.
 * `virtual_switch_name` - (Required) The name of the virtual switch to bind
   this port group to. Forces a new resource if changed.
 * `vlan_id` - (Optional) The VLAN ID/trunk mode for this port group.  An ID of
   `0` denotes no tagging, an ID of `1`-`4094` tags with the specific ID, and an
   ID of `4095` enables trunk mode, allowing the guest to manage its own
   tagging. Default: `0`.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ### Policy Options
 

--- a/website/docs/r/host_port_group.html.markdown
+++ b/website/docs/r/host_port_group.html.markdown
@@ -92,14 +92,15 @@ resource "vsphere_host_port_group" "pg" {
 
 The following arguments are supported:
 
-* `name` - (String, required, forces new resource) The name of the port group.
-* `host_system_id` - (String, required, forces new resource) The managed object
-  ID of the host to set the port group up on. 
-* `virtual_switch_name` - (String, required, forces new resource) The name of
-  the virtual switch to bind this port group to.
-* `vlan_id` - (Integer, optional) The VLAN ID/trunk mode for this port group.
-  An ID of `0` denotes no tagging, an ID of `1`-`4094` tags with the specific ID, and
-  an ID of `4095` enables trunk mode, allowing the guest to manage its own
+* `name` - (Required) The name of the port group.  Forces a new resource if
+  changed.
+* `host_system_id` - (Required) The managed object ID of the host to set the
+  port group up on. Forces a new resource if changed.
+* `virtual_switch_name` - (Required) The name of the virtual switch to bind
+  this port group to. Forces a new resource if changed.
+* `vlan_id` - (Optional) The VLAN ID/trunk mode for this port group.  An ID of
+  `0` denotes no tagging, an ID of `1`-`4094` tags with the specific ID, and an
+  ID of `4095` enables trunk mode, allowing the guest to manage its own
   tagging. Default: `0`.
 
 ### Policy Options

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -83,12 +83,14 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the virtual switch. Forces a new resource if
   changed.
-* `host_system_id` - (Required) The managed object ID of the host to set the
-  virtual switch up on. Forces a new resource if changed.
+* `host_system_id` - (Required) The [managed object ID][docs-about-morefs] of
+  the host to set the virtual switch up on. Forces a new resource if changed.
 * `mtu` - (Optional) The maximum transmission unit (MTU) for the virtual
   switch. Default: `1500`.
 * `number_of_ports` - (Optional) The number of ports to create with this
   virtual switch. Default: `128`.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ~> **NOTE:** Changing the port count requires a reboot of the host. Terraform
 will not restart the host for you.

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -136,9 +136,9 @@ probing (configured with [`check_beacon`](#check_beacon)).
 * `teaming_policy` - (Optional) The network adapter teaming policy. Can be one
   of `loadbalance_ip`, `loadbalance_srcmac`, `loadbalance_srcid`, or
   `failover_explicit`. Default: `loadbalance_srcid`.
-* `notify_switches` - (Optional) If `true`, the teaming policy will notify the
-  broadcast network of a NIC failover, triggering cache updates.  Default:
-  `true`.
+* `notify_switches` - (Optional) If set to `true`, the teaming policy will
+  notify the broadcast network of a NIC failover, triggering cache updates.
+  Default: `true`.
 * `failback` - (Optional) If `true`, the teaming policy will re-activate failed
   interfaces higher in precedence when they come back up.  Default: `true`.
 

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -81,13 +81,14 @@ resource "vsphere_host_virtual_switch" "switch" {
 
 The following arguments are supported:
 
-* `name` - (String, required, forces new resource) The name of the virtual switch.
-* `host_system_id` - (String, required, forces new resource) The managed object
-  ID of the host to set the virtual switch up on. 
-* `mtu` - (Integer, optional) The maximum transmission unit (MTU) for the virtual
+* `name` - (Required) The name of the virtual switch. Forces a new resource if
+  changed.
+* `host_system_id` - (Required) The managed object ID of the host to set the
+  virtual switch up on. Forces a new resource if changed.
+* `mtu` - (Optional) The maximum transmission unit (MTU) for the virtual
   switch. Default: `1500`.
-* `number_of_ports` - (Integer, optional) The number of ports to create with
-  this virtual switch. Default: `128`.
+* `number_of_ports` - (Optional) The number of ports to create with this
+  virtual switch. Default: `128`.
 
 ~> **NOTE:** Changing the port count requires a reboot of the host. Terraform
 will not restart the host for you.
@@ -97,16 +98,14 @@ will not restart the host for you.
 The following arguments are related to how the virtual switch binds to physical
 NICs:
 
-* `network_adapters` - (Array of strings, required) The network interfaces to
-  bind to the bridge.
-* `beacon_interval` - (Integer, optional) The interval, in seconds, that a NIC
-  beacon packet is sent out. This can be used with
-  [`check_beacon`](#check_beacon) to offer link failure capability beyond link
-  status only. Default: `1`.
-* `link_discovery_operation` - (String, optional) Whether to `advertise` or
-  `listen` for link discovery traffic. Default: `listen`.
-* `link_discovery_protocol` - (String, optional) The discovery protocol type.
-  Valid types are `cpd` and `lldp`. Default: `cdp`.
+* `network_adapters` - (Required) The network interfaces to bind to the bridge.
+* `beacon_interval` - (Optional) The interval, in seconds, that a NIC beacon
+  packet is sent out. This can be used with [`check_beacon`](#check_beacon) to
+  offer link failure capability beyond link status only. Default: `1`.
+* `link_discovery_operation` - (Optional) Whether to `advertise` or `listen`
+  for link discovery traffic. Default: `listen`.
+* `link_discovery_protocol` - (Optional) The discovery protocol type.  Valid
+  types are `cpd` and `lldp`. Default: `cdp`.
 
 ### Policy Options
 
@@ -126,46 +125,44 @@ or if the NIC is not a valid NIC in `network_adapters`.
 ~> **NOTE:** VMware recommends using a minimum of 3 NICs when using beacon
 probing (configured with [`check_beacon`](#check_beacon)).
 
-* `active_nics` - (Array of strings, required) The list of active network
-  adapters used for load balancing.
-* `standby_nics` - (Array of strings, required) The list of standby network
-  adapters used for failover.
-* `check_beacon` - (Boolean, optional) Enable beacon probing - this requires
-  that the [`beacon_interval`](#beacon_interval) option has been set in the
-  bridge options. If this is false, only link status is used to check for
-  failed NICs. Default: `false`.
-* `teaming_policy` - (String, optional) The network adapter teaming policy. Can
-  be one of `loadbalance_ip`, `loadbalance_srcmac`, `loadbalance_srcid`, or
+* `active_nics` - (Required) The list of active network adapters used for load
+  balancing.
+* `standby_nics` - (Required) The list of standby network adapters used for
+  failover.
+* `check_beacon` - (Optional) Enable beacon probing - this requires that the
+  [`beacon_interval`](#beacon_interval) option has been set in the bridge
+  options. If this is false, only link status is used to check for failed NICs.
+  Default: `false`.
+* `teaming_policy` - (Optional) The network adapter teaming policy. Can be one
+  of `loadbalance_ip`, `loadbalance_srcmac`, `loadbalance_srcid`, or
   `failover_explicit`. Default: `loadbalance_srcid`.
-* `notify_switches` - (Boolean, optional) If `true`, the teaming policy will
-  notify the broadcast network of a NIC failover, triggering cache updates.
-  Default: `true`.
-* `failback` - (Boolean, optional) If `true`, the teaming policy will
-  re-activate failed interfaces higher in precedence when they come back up.
-  Default: `true`.
+* `notify_switches` - (Optional) If `true`, the teaming policy will notify the
+  broadcast network of a NIC failover, triggering cache updates.  Default:
+  `true`.
+* `failback` - (Optional) If `true`, the teaming policy will re-activate failed
+  interfaces higher in precedence when they come back up.  Default: `true`.
 
 #### Security Policy Options
 
-* `allow_promiscuous` - (Boolean, optional) Enable promiscuous mode on the
-  network. This flag indicates whether or not all traffic is seen on a given
-  port. Default: `false`.
-* `allow_forged_transmits` - (Boolean, optional) Controls whether or not the
-  virtual network adapter is allowed to send network traffic with a different
-  MAC address than that of its own. Default: `true`.
-* `allow_mac_changes` - (Boolean, optional) Controls whether or not the Media
-  Access Control (MAC) address can be changed. Default: `true`.
+* `allow_promiscuous` - (Optional) Enable promiscuous mode on the network. This
+  flag indicates whether or not all traffic is seen on a given port. Default:
+  `false`.
+* `allow_forged_transmits` - (Optional) Controls whether or not the virtual
+  network adapter is allowed to send network traffic with a different MAC
+  address than that of its own. Default: `true`.
+* `allow_mac_changes` - (Optional) Controls whether or not the Media Access
+  Control (MAC) address can be changed. Default: `true`.
 
 #### Traffic Shaping Options
 
-* `shaping_enabled` - (Boolean, optional) `true` if the traffic shaper is
-  enabled on the port. Default: `false`.
-* `shaping_average_bandwidth` - (Integer, optional) The average bandwidth in
-  bits per second if shaping is enabled on the port. Default: `0`
-* `shaping_peak_bandwidth` - (Integer, optional) The peak bandwidth during
-  bursts in bits per second if traffic shaping is enabled on the port. Default:
-  `0`
-* `shaping_burst_size` - (Integer, optional) The maximum burst size allowed in
-  bytes if shaping is enabled on the port. Default: `0`
+* `shaping_enabled` - (Optional) `true` if the traffic shaper is enabled on the
+  port. Default: `false`.
+* `shaping_average_bandwidth` - (Optional) The average bandwidth in bits per
+  second if shaping is enabled on the port. Default: `0`
+* `shaping_peak_bandwidth` - (Optional) The peak bandwidth during bursts in
+  bits per second if traffic shaping is enabled on the port. Default: `0`
+* `shaping_burst_size` - (Optional) The maximum burst size allowed in bytes if
+  shaping is enabled on the port. Default: `0`
 
 ## Attribute Reference
 

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -139,8 +139,9 @@ probing (configured with [`check_beacon`](#check_beacon)).
 * `notify_switches` - (Optional) If set to `true`, the teaming policy will
   notify the broadcast network of a NIC failover, triggering cache updates.
   Default: `true`.
-* `failback` - (Optional) If `true`, the teaming policy will re-activate failed
-  interfaces higher in precedence when they come back up.  Default: `true`.
+* `failback` - (Optional) If set to `true`, the teaming policy will re-activate
+  failed interfaces higher in precedence when they come back up.  Default:
+  `true`.
 
 #### Security Policy Options
 

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -156,14 +156,14 @@ probing (configured with [`check_beacon`](#check_beacon)).
 
 #### Traffic Shaping Options
 
-* `shaping_enabled` - (Optional) `true` if the traffic shaper is enabled on the
-  port. Default: `false`.
+* `shaping_enabled` - (Optional) Set to `true` to enable the traffic shaper for
+  ports managed by this virtual switch. Default: `false`.
 * `shaping_average_bandwidth` - (Optional) The average bandwidth in bits per
-  second if shaping is enabled on the port. Default: `0`
+  second if traffic shaping is enabled. Default: `0`
 * `shaping_peak_bandwidth` - (Optional) The peak bandwidth during bursts in
-  bits per second if traffic shaping is enabled on the port. Default: `0`
+  bits per second if traffic shaping is enabled. Default: `0`
 * `shaping_burst_size` - (Optional) The maximum burst size allowed in bytes if
-  shaping is enabled on the port. Default: `0`
+  shaping is enabled. Default: `0`
 
 ## Attribute Reference
 

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -131,8 +131,8 @@ probing (configured with [`check_beacon`](#check_beacon)).
   failover.
 * `check_beacon` - (Optional) Enable beacon probing - this requires that the
   [`beacon_interval`](#beacon_interval) option has been set in the bridge
-  options. If this is false, only link status is used to check for failed NICs.
-  Default: `false`.
+  options. If this is set to `false`, only link status is used to check for
+  failed NICs.  Default: `false`.
 * `teaming_policy` - (Optional) The network adapter teaming policy. Can be one
   of `loadbalance_ip`, `loadbalance_srcmac`, `loadbalance_srcid`, or
   `failover_explicit`. Default: `loadbalance_srcid`.

--- a/website/docs/r/nas_datastore.html.markdown
+++ b/website/docs/r/nas_datastore.html.markdown
@@ -58,8 +58,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the datastore. Forces a new resource if
   changed.
-* `host_system_ids` - (Required) The managed object IDs of the hosts to mount
-  the datastore on.
+* `host_system_ids` - (Required) The [managed object IDs][docs-about-morefs] of
+  the hosts to mount the datastore on.
 * `type` - (Optional) The type of NAS volume. Can be one of `NFS` (to denote
   v3) or `NFS41` (to denote NFS v4.1). Default: `NFS`. Forces a new resource if
   changed.
@@ -85,6 +85,7 @@ The following arguments are supported:
   [here][docs-applying-tags] for a reference on how to apply tags.
 
 [docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.
@@ -93,7 +94,7 @@ requires vCenter 6.0 or higher.
 
 The following attributes are exported:
 
-* `id` - The managed object reference ID of the datastore.
+* `id` - The [managed object reference ID][docs-about-morefs] of the datastore.
 * `accessible` - The connectivity status of the datastore. If this is `false`,
   some other computed attributes may be out of date.
 * `capacity` - Maximum capacity of the datastore, in megabytes.

--- a/website/docs/r/nas_datastore.html.markdown
+++ b/website/docs/r/nas_datastore.html.markdown
@@ -56,33 +56,33 @@ resource "vsphere_nas_datastore" "datastore" {
 
 The following arguments are supported:
 
-* `name` - (String, required, forces new resource) The name of the datastore.
-* `host_system_ids` - (List of strings, required) The managed object
-  IDs of the hosts to mount the datastore on.
-* `folder` - (String, optional) The relative path to a folder to put this
-  datastore in. This is a path relative to the datacenter you are deploying the
-  datastore to. Example: for the `dc1` datacenter, and a provided `folder` of
-  `foo/bar`, Terraform will place a datastore named `terraform-test` in a
-  datastore folder located at `/dc1/datastore/foo/bar`, with the final
-  inventory path being `/dc1/datastore/foo/bar/terraform-test`.
-* `type` - (String, optional, forces new resource) The type of NAS volume. Can
-  be one of `NFS` (to denote v3) or `NFS41` (to denote NFS v4.1). Default:
-  `NFS`.
-* `remote_hosts` - (List of strings, required, forces new resource) The
-  hostnames or IP addresses of the remote server or servers. Only one element
-  should be present for NFS v3 but multiple can be present for NFS v4.1.
-* `remote_path` - (String, required, forces new resource) The remote path of
-  the mount point.
-* `access_mode` - (String, optional, forces new resource) Access mode for the
-  mount point. Can be one of `readOnly` or `readWrite`. Note that `readWrite`
-  does not necessarily mean that the datastore will be read-write depending on
-  the permissions of the actual share. Default: `readWrite`.
-* `security_type` - (String, optional, forces new resource) The security type
-  to use when using NFS v4.1. Can be one of `AUTH_SYS`, `SEC_KRB5`, or
-  `SEC_KRB5I`.
-* `tags` - (List of strings, optional) The IDs of any tags to attach to this
-  resource. See [here][docs-applying-tags] for a reference on how to apply
-  tags.
+* `name` - (Required) The name of the datastore. Forces a new resource if
+  changed.
+* `host_system_ids` - (Required) The managed object IDs of the hosts to mount
+  the datastore on.
+* `type` - (Optional) The type of NAS volume. Can be one of `NFS` (to denote
+  v3) or `NFS41` (to denote NFS v4.1). Default: `NFS`. Forces a new resource if
+  changed.
+* `remote_hosts` - (Required) The hostnames or IP addresses of the remote
+  server or servers. Only one element should be present for NFS v3 but multiple
+  can be present for NFS v4.1. Forces a new resource if changed.
+* `remote_path` - (Required) The remote path of the mount point. Forces a new
+  resource if changed.
+* `access_mode` - (Optional) Access mode for the mount point. Can be one of
+  `readOnly` or `readWrite`. Note that `readWrite` does not necessarily mean
+  that the datastore will be read-write depending on the permissions of the
+  actual share. Default: `readWrite`. Forces a new resource if changed.
+* `security_type` - (Optional) The security type to use when using NFS v4.1.
+  Can be one of `AUTH_SYS`, `SEC_KRB5`, or `SEC_KRB5I`. Forces a new resource
+  if changed.
+* `folder` - (Optional) The relative path to a folder to put this datastore in.
+  This is a path relative to the datacenter you are deploying the datastore to.
+  Example: for the `dc1` datacenter, and a provided `folder` of `foo/bar`,
+  Terraform will place a datastore named `terraform-test` in a datastore folder
+  located at `/dc1/datastore/foo/bar`, with the final inventory path being
+  `/dc1/datastore/foo/bar/terraform-test`.
+* `tags` - (Optional) The IDs of any tags to attach to this resource. See
+  [here][docs-applying-tags] for a reference on how to apply tags.
 
 [docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
 

--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -99,11 +99,11 @@ resource "vsphere_virtual_machine" "web" {
 
 The following arguments are supported:
 
-* `name` - (String, required) The display name of the tag. The name must be
-  unique within its category.
-* `category_id` - (String, required, forces new resource) The unique identifier
-  of the parent category in which this tag will be created.
-* `description` - (String, optional) A description for the tag.
+* `name` - (Required) The display name of the tag. The name must be unique
+  within its category.
+* `category_id` - (Required) The unique identifier of the parent category in
+  which this tag will be created. Forces a new resource if changed.
+* `description` - (Optional) A description for the tag.
 
 ## Attribute Reference
 

--- a/website/docs/r/tag_category.html.markdown
+++ b/website/docs/r/tag_category.html.markdown
@@ -46,15 +46,15 @@ resource "vsphere_tag_category" "category" {
 
 The following arguments are supported:
 
-* `name` - (String, required) The name of the category.
-* `description` - (String, optional) A description for the category.
-* `cardinality` - (String, required, forces new resource) The number of tags
-  that can be assigned from this category to a single object at once. Can be
-  one of `SINGLE` (object can only be assigned one tag in this category), to
-  `MULTIPLE` (object can be assigned multiple tags in this category).
-* `associable_types` - (List of strings, required) A list object types that
-  this category is valid to be assigned to. For a full list, click
+* `name` - (Required) The name of the category.
+* `cardinality` - (Required) The number of tags that can be assigned from this
+  category to a single object at once. Can be one of `SINGLE` (object can only
+  be assigned one tag in this category), to `MULTIPLE` (object can be assigned
+  multiple tags in this category). Forces a new resource if changed.
+* `associable_types` - (Required) A list object types that this category is
+  valid to be assigned to. For a full list, click
   [here](#associable-object-types).
+* `description` - (Optional) A description for the category.
 
 ~> **NOTE:** You can add associable types to a category, but you cannot remove
 them. Attempting to do so will result in an error.

--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -8,18 +8,24 @@ description: |-
 
 # vsphere\_virtual\_disk
 
-Provides a VMware virtual disk resource.  This can be used to create and delete virtual disks.
+The `vsphere_virtual_disk` resource can be used to create virtual disks
+external to any [`vsphere_virtual_machine`][docs-vsphere-virtual-machine]
+resource. These disks can be attached to a virtual machine by creating a disk
+sub-resource with the [`attach`][docs-vsphere-virtual-machine-disk-attach]
+parameter.
+
+[docs-vsphere-virtual-machine]: /docs/providers/vsphere/r/virtual_machine.html
+[docs-vsphere-virtual-machine-disk-attach]: /docs/providers/vsphere/r/virtual_machine.html#attach
 
 ## Example Usage
 
 ```hcl
 resource "vsphere_virtual_disk" "myDisk" {
-  size	     	= 2
-  vmdk_path  	= "myDisk.vmdk"
-  datacenter 	= "Datacenter"
-  datastore  	= "local"
-  type       	= "thin"
-  adapter_type  = "lsiLogic"
+  size         = 2
+  vmdk_path    = "myDisk.vmdk"
+  datacenter   = "Datacenter"
+  datastore    = "local"
+  type         = "thin"
 }
 ```
 
@@ -27,9 +33,27 @@ resource "vsphere_virtual_disk" "myDisk" {
 
 The following arguments are supported:
 
+~> **NOTE:** All fields in the `vsphere_virtual_disk` resource are currently
+immutable and force a new resource if changed.
+
+* `vmdk_path` - (Required) The path, including filename, of the virtual disk to
+  be created.  This should end with `.vmdk`.
+* `datastore` - (Required) The name of the datastore in which to create the
+  disk.
 * `size` - (Required) Size of the disk (in GB).
-* `vmdk_path` - (Required) The path, including filename, of the virtual disk to be created.  This should end with '.vmdk'.
-* `type` - (Optional) 'eagerZeroedThick' (the default), 'lazy', or 'thin' are supported options.
-* `adapter_type` - (Optional) set adapter type, 'ide' (the default), 'lsiLogic', or 'busLogic' are supported options.
-* `datacenter` - (Optional) The name of a Datacenter in which to create the disk.
-* `datastore` - (Required) The name of the Datastore in which to create the disk.
+* `datacenter` - (Optional) The name of the datacenter in which to create the
+  disk. Can be omitted when when ESXi or if there is only one datacenter in
+  your infrastructure.
+* `type` - (Optional) The type of disk to create. Can be one of
+  `eagerZeroedThick`, `lazy`, or `thin`. Default: `eagerZeroedThick`.
+* `adapter_type` - (Optional) The adapter type for this virtual disk. Can be
+  one of `ide`, `lsiLogic`, or `busLogic`.  Default: `lsiLogic`.
+
+~> **NOTE:** `adapter_type` is **deprecated**: it does not dictate the type of
+controller that the virtual disk will be attached to on the virtual machine.
+Please see the [`scsi_type`][docs-vsphere-virtual-machine-scsi-type] parameter
+in the `vsphere_virtual_machine` resource for information on how to control
+disk controller types. This parameter will be removed in future versions of the
+vSphere provider.
+
+[docs-vsphere-virtual-machine-scsi-type]: /docs/providers/vsphere/r/virtual_machine.html#scsi_type

--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # vsphere\_virtual\_disk
 
 The `vsphere_virtual_disk` resource can be used to create virtual disks
-external to any [`vsphere_virtual_machine`][docs-vsphere-virtual-machine]
+outside of any given [`vsphere_virtual_machine`][docs-vsphere-virtual-machine]
 resource. These disks can be attached to a virtual machine by creating a disk
 sub-resource with the [`attach`][docs-vsphere-virtual-machine-disk-attach]
 parameter.
@@ -37,7 +37,7 @@ The following arguments are supported:
 immutable and force a new resource if changed.
 
 * `vmdk_path` - (Required) The path, including filename, of the virtual disk to
-  be created.  This should end with `.vmdk`.
+  be created.  This needs to end in `.vmdk`.
 * `datastore` - (Required) The name of the datastore in which to create the
   disk.
 * `size` - (Required) Size of the disk (in GB).
@@ -45,7 +45,12 @@ immutable and force a new resource if changed.
   disk. Can be omitted when when ESXi or if there is only one datacenter in
   your infrastructure.
 * `type` - (Optional) The type of disk to create. Can be one of
-  `eagerZeroedThick`, `lazy`, or `thin`. Default: `eagerZeroedThick`.
+  `eagerZeroedThick`, `lazy`, or `thin`. Default: `eagerZeroedThick`. For
+  information on what each kind of disk provisioning policy means, click
+  [here][docs-vmware-vm-disk-provisioning].
+
+[docs-vmware-vm-disk-provisioning]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-4C0F4D73-82F2-4B81-8AA7-1DD752A8A5AC.html
+
 * `adapter_type` - (Optional) The adapter type for this virtual disk. Can be
   one of `ide`, `lsiLogic`, or `busLogic`.  Default: `lsiLogic`.
 

--- a/website/docs/r/virtual_machine_snapshot.html.markdown
+++ b/website/docs/r/virtual_machine_snapshot.html.markdown
@@ -23,7 +23,7 @@ have been attached via the [attach][docs-vsphere-virtual-machine-disk-attach]
 parameter to the `vsphere_virtual_machine` `disk` sub-resource), and even the
 configuration of the virtual machine at the time of the snapshot. Virtual
 machine, disk activity, and configuration changes post-snapshot are not
-included in the original state. Use this resource with care! VMware nor
+included in the original state. Use this resource with care! Neither VMware nor
 HashiCorp recommends retaining snapshots for a extended period of time and does
 NOT recommend using them as as backup feature. For more information on the
 limitation of virtual machine snapshots, see [here][ext-vm-snap-limitations].

--- a/website/docs/r/virtual_machine_snapshot.html.markdown
+++ b/website/docs/r/virtual_machine_snapshot.html.markdown
@@ -69,4 +69,6 @@ are immutable and force a new resource if changed.
 ## Attribute Reference
 
 The only attribute this resource exports is the resource `id`, which is set to
-the managed object reference of the snapshot.
+the [managed object reference ID][docs-about-morefs] of the snapshot.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider

--- a/website/docs/r/virtual_machine_snapshot.html.markdown
+++ b/website/docs/r/virtual_machine_snapshot.html.markdown
@@ -16,16 +16,19 @@ For more information on managing snapshots and how they work in VMware, see
 
 [ext-vm-snapshot-management]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-CA948C69-7F58-4519-AEB1-739545EA94E5.html
 
-~> **NOTE:** A snapshot in VMware differs from traditional disk snapshots in
-that the actual running state of the virtual machine can be taken with the
-snapshot as well, all non-independent disks are included in the snapshot
-(including any disks that have been attached externally but are not
-independent), and VM and disk activity post-snapshot is not included in the
-original state. Use this resource with care! VMware nor HashiCorp recommends
-retaining snapshots for a extended period of time and does NOT recommend using
-them as as backup feature. For more information on the limitation of virtual
-machine snapshots, see [here][ext-vm-snap-limitations].
+~> **NOTE:** A snapshot in VMware differs from traditional disk snapshots, and
+can contain the actual running state of the virtual machine, data for all disks
+that have not been set to be independent from the snapshot (including ones that
+have been attached via the [attach][docs-vsphere-virtual-machine-disk-attach]
+parameter to the `vsphere_virtual_machine` `disk` sub-resource), and even the
+configuration of the virtual machine at the time of the snapshot. Virtual
+machine, disk activity, and configuration changes post-snapshot are not
+included in the original state. Use this resource with care! VMware nor
+HashiCorp recommends retaining snapshots for a extended period of time and does
+NOT recommend using them as as backup feature. For more information on the
+limitation of virtual machine snapshots, see [here][ext-vm-snap-limitations].
 
+[docs-vsphere-virtual-machine-disk-attach]: /docs/providers/vsphere/r/virtual_machine.html#attach
 [ext-vm-snap-limitations]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-53F65726-A23B-4CF0-A7D5-48E584B88613.html
 
 ## Example Usage
@@ -45,6 +48,9 @@ resource "vsphere_virtual_machine_snapshot" "demo1" {
 ## Argument Reference
 
 The following arguments are supported:
+
+~> **NOTE:** All attributes in the `vsphere_virtual_machine_snapshot` resource
+are immutable and force a new resource if changed.
 
 * `virtual_machine_uuid` - (Required) The virtual machine UUID.
 * `snapshot_name` - (Required) The name of the snapshot.

--- a/website/docs/r/vmfs_datastore.html.markdown
+++ b/website/docs/r/vmfs_datastore.html.markdown
@@ -49,7 +49,7 @@ reduce the size of the datastore, the resource needs to be re-created - run
 
 ## Example Usage
 
-**Addition of local disks on a single host**
+### Addition of local disks on a single host
 
 The following example uses the default datacenter and default host to add a
 datastore with local disks to a single ESXi server.
@@ -80,7 +80,7 @@ resource "vsphere_vmfs_datastore" "datastore" {
 }
 ```
 
-**Auto-detection of disks via `vsphere_vmfs_disks`**
+### Auto-detection of disks via `vsphere_vmfs_disks`
 
 The following example makes use of the
 [`vsphere_vmfs_disks`][data-source-vmfs-disks] data source to auto-detect
@@ -120,27 +120,27 @@ resource "vsphere_vmfs_datastore" "datastore" {
 
 The following arguments are supported:
 
-* `name` - (String, required, forces new resource) The name of the datastore.
-* `host_system_id` - (String, required, forces new resource) The managed object
-  ID of the host to set the datastore up on. Note that this is not necessarily
-  the only host that the datastore will be set up on - see
-  [here](#auto-mounting-of-datastores-within-vcenter) for more info.
-* `folder` - (String, optional) The relative path to a folder to put this
-  datastore in. This is a path relative to the datacenter you are deploying the
-  datastore to. Example: for the `dc1` datacenter, and a provided `folder` of
-  `foo/bar`, Terraform will place a datastore named `terraform-test` in a
-  datastore folder located at `/dc1/datastore/foo/bar`, with the final
-  inventory path being `/dc1/datastore/foo/bar/terraform-test`.
-* `disks` - (List of strings, required) The disks to use with the datastore.
-* `tags` - (List of strings, optional) The IDs of any tags to attach to this
-  resource. See [here][docs-applying-tags] for a reference on how to apply
-  tags.
+* `name` - (Required) The name of the datastore. Forces a new resource if
+  changed.
+* `host_system_id` - (Required) The managed object ID of the host to set the
+  datastore up on. Note that this is not necessarily the only host that the
+  datastore will be set up on - see
+  [here](#auto-mounting-of-datastores-within-vcenter) for more info. Forces a
+  new resource if changed.
+* `disks` - (Required) The disks to use with the datastore.
+* `folder` - (Optional) The relative path to a folder to put this datastore in.
+  This is a path relative to the datacenter you are deploying the datastore to.
+  Example: for the `dc1` datacenter, and a provided `folder` of `foo/bar`,
+  Terraform will place a datastore named `terraform-test` in a datastore folder
+  located at `/dc1/datastore/foo/bar`, with the final inventory path being
+  `/dc1/datastore/foo/bar/terraform-test`.
+* `tags` - (Optional) The IDs of any tags to attach to this resource. See
+  [here][docs-applying-tags] for a reference on how to apply tags.
 
 [docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
 
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.
-
 
 ## Attribute Reference
 

--- a/website/docs/r/vmfs_datastore.html.markdown
+++ b/website/docs/r/vmfs_datastore.html.markdown
@@ -122,9 +122,9 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the datastore. Forces a new resource if
   changed.
-* `host_system_id` - (Required) The managed object ID of the host to set the
-  datastore up on. Note that this is not necessarily the only host that the
-  datastore will be set up on - see
+* `host_system_id` - (Required) The [managed object ID][docs-about-morefs] of
+  the host to set the datastore up on. Note that this is not necessarily the
+  only host that the datastore will be set up on - see
   [here](#auto-mounting-of-datastores-within-vcenter) for more info. Forces a
   new resource if changed.
 * `disks` - (Required) The disks to use with the datastore.
@@ -138,6 +138,7 @@ The following arguments are supported:
   [here][docs-applying-tags] for a reference on how to apply tags.
 
 [docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
 ~> **NOTE:** Tagging support is unsupported on direct ESXi connections and
 requires vCenter 6.0 or higher.
@@ -146,7 +147,7 @@ requires vCenter 6.0 or higher.
 
 The following attributes are exported:
 
-* `id` - The managed object reference ID of the datastore.
+* `id` - The [managed object reference ID][docs-about-morefs] of the datastore.
 * `accessible` - The connectivity status of the datastore. If this is `false`,
   some other computed attributes may be out of date.
 * `capacity` - Maximum capacity of the datastore, in megabytes.

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -103,7 +103,7 @@
             <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-disk") %>>
               <a href="/docs/providers/vsphere/r/virtual_disk.html">vsphere_virtual_disk</a>
             </li>
-            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-machine") %>>
+            <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-machine-resource") %>>
               <a href="/docs/providers/vsphere/r/virtual_machine.html">vsphere_virtual_machine</a>
             </li>
             <li<%= sidebar_current("docs-vsphere-resource-vm-virtual-machine-snapshot") %>>


### PR DESCRIPTION
This PR does various documentation cleanup tasks and what not that I wanted to take care of pre-v1.0.0.

Contained herein:

* Normalize parameter documentation style. This is basically a distinction between what is required and what is optional, no parameter type (implied instead by the notes in the parameter docs), and an English sentence at the end of `ForceNew` attributes.
* Updated the doc index page with a new example, removal of "this is a WIP", and a shortening of some of the information, designed to ensure the index ages and scales well. Most contributing information has now been removed with a referral to the provider repo instead.
* Some grammar fixes and extra explanations where they have been warranted.

As part of the documentation efforts is deprecating `adapter_type` in `vsphere_virtual_disk` - the option has not been removed, but we have added a `Deprecated` notice to the schema and extra docs mentioning that this option has no effect on what the disk actually gets added as when it's attached to a VM.