### PR TITLE
helper/envbrowse: QueryConfigOptionEx -> QueryConfigOption

### DIFF
--- a/vsphere/internal/helper/computeresource/compute_resource_helper.go
+++ b/vsphere/internal/helper/computeresource/compute_resource_helper.go
@@ -137,11 +137,6 @@ func BasePropertiesFromReference(client *govmomi.Client, ref types.ManagedObject
 
 // DefaultDevicesFromReference fetches the default virtual device list for a
 // specific compute resource from a supplied managed object reference.
-//
-// The current implementation of this method takes a single guest ID, which
-// ultimately filters down to a QueryConfigOptionEx call with only the single
-// guest ID set. This ensures that the VirtaulDeviceList returned matches a
-// default set best suited for the guest type that is being created.
 func DefaultDevicesFromReference(client *govmomi.Client, ref types.ManagedObjectReference, guest string) (object.VirtualDeviceList, error) {
 	log.Printf("[DEBUG] Fetching default device list for object reference %q for OS type %q", ref.Value, guest)
 	props, err := BasePropertiesFromReference(client, ref)
@@ -151,7 +146,7 @@ func DefaultDevicesFromReference(client *govmomi.Client, ref types.ManagedObject
 	b := envbrowse.NewEnvironmentBrowser(client.Client, *props.EnvironmentBrowser)
 	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
 	defer cancel()
-	return b.DefaultDevices(ctx, []string{guest}, "", nil)
+	return b.DefaultDevices(ctx, "", nil)
 }
 
 // OSFamily uses the compute resource's environment browser to get the OS family

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -32,17 +32,17 @@ func NewEnvironmentBrowser(c *vim25.Client, ref types.ManagedObjectReference) *E
 }
 
 // DefaultDevices loads a satisfactory default device list for the optionally
-// supplied guest ID list, host, and descriptor key. The result is returned as
-// a higher-level VirtualDeviceList object. This can be used as an initial
-// VirtualDeviceList when building a device list and VirtualDeviceConfigSpec
-// list for new virtual machines.
+// supplied host and descriptor key. The result is returned as a higher-level
+// VirtualDeviceList object. This can be used as an initial VirtualDeviceList
+// when building a device list and VirtualDeviceConfigSpec list for new virtual
+// machines.
 //
 // Appropriate options for key can be loaded by running
 // QueryConfigOptionDescriptor, which will return a list of
 // VirtualMachineConfigOptionDescriptor which will contain the appropriate key
-// to use under key. If no key is supplied, the results generally reflect the
-// most recent VM hardware version.
-func (b *EnvironmentBrowser) DefaultDevices(ctx context.Context, guests []string, key string, host *object.HostSystem) (object.VirtualDeviceList, error) {
+// for the virtual machine version needed. If no key is supplied, the results
+// generally reflect the most recent VM hardware version.
+func (b *EnvironmentBrowser) DefaultDevices(ctx context.Context, key string, host *object.HostSystem) (object.VirtualDeviceList, error) {
 	var eb mo.EnvironmentBrowser
 
 	err := b.Properties(ctx, b.Reference(), nil, &eb)
@@ -50,18 +50,15 @@ func (b *EnvironmentBrowser) DefaultDevices(ctx context.Context, guests []string
 		return nil, err
 	}
 
-	req := types.QueryConfigOptionEx{
+	req := types.QueryConfigOption{
 		This: b.Reference(),
-		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
-			Key:     key,
-			GuestId: guests,
-		},
+		Key:  key,
 	}
 	if host != nil {
 		ref := host.Reference()
-		req.Spec.Host = &ref
+		req.Host = &ref
 	}
-	res, err := methods.QueryConfigOptionEx(ctx, b.Client(), &req)
+	res, err := methods.QueryConfigOption(ctx, b.Client(), &req)
 	if err != nil {
 		return nil, err
 	}
@@ -80,28 +77,24 @@ func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string
 		return "", err
 	}
 
-	req := types.QueryConfigOptionEx{
+	req := types.QueryConfigOption{
 		This: b.Reference(),
-		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
-			GuestId: []string{guest},
-		},
 	}
-	res, err := methods.QueryConfigOptionEx(ctx, b.Client(), &req)
+	res, err := methods.QueryConfigOption(ctx, b.Client(), &req)
 	if err != nil {
 		return "", err
 	}
 	if res.Returnval == nil {
 		return "", errors.New("no config options were found for the supplied criteria")
 	}
-	if len(res.Returnval.GuestOSDescriptor) < 1 {
-		return "", errors.New("no guest OS descriptors were found")
+	for _, osd := range res.Returnval.GuestOSDescriptor {
+		if osd.Id == guest {
+			family := res.Returnval.GuestOSDescriptor[0].Family
+			log.Printf("[DEBUG] OSFamily: family for %q is %q", guest, family)
+			return family, nil
+		}
 	}
-	if len(res.Returnval.GuestOSDescriptor) > 1 {
-		return "", fmt.Errorf("multiple OS descriptors were found for guest ID %s", guest)
-	}
-	family := res.Returnval.GuestOSDescriptor[0].Family
-	log.Printf("[DEBUG] OSFamily: family for %q is %q", guest, family)
-	return family, nil
+	return "", fmt.Errorf("could not find guest ID %s", guest)
 }
 
 // QueryConfigOptionDescriptor returns a list the list of ConfigOption keys

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -89,7 +89,7 @@ func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string
 	}
 	for _, osd := range res.Returnval.GuestOSDescriptor {
 		if osd.Id == guest {
-			family := res.Returnval.GuestOSDescriptor[0].Family
+			family := osd.Family
 			log.Printf("[DEBUG] OSFamily: family for %q is %q", guest, family)
 			return family, nil
 		}


### PR DESCRIPTION
QueryConfigOptionEx is not available on vSphere 5.5, hence releasing
with our environment browser implementation using this call would have
effectively deprecated/terminated support for this version of vSphere.

* For default devices, using guest ID does nothing - it was wrongly
assumed that this helped give back a hardware list specific to a guest
OS type, but it just restricts the guest OS descriptors returned. The
Key parameter has been retained as it's a part of the QueryConfigOption
parameter list as an optional field.
* For looking up Guest OS families by Guest ID (example: ubuntu64Guest ->
Linux, windows9Server64Guest -> Windows), rather than using
QueryConfigOptionEx to filter the results, we just iterate through the
whole descriptor list returned by QueryConfigOption until we find our
guest ID. This helps get rid of some length assertion code as well.

Reference: #243 

Will paste acceptance tests when done.