### PR TITLE
r/virtual_machine: Post-merge, pre-release changes

### DIFF
--- a/vsphere/internal/helper/computeresource/compute_resource_helper.go
+++ b/vsphere/internal/helper/computeresource/compute_resource_helper.go
@@ -137,11 +137,6 @@ func BasePropertiesFromReference(client *govmomi.Client, ref types.ManagedObject
 
 // DefaultDevicesFromReference fetches the default virtual device list for a
 // specific compute resource from a supplied managed object reference.
-//
-// The current implementation of this method takes a single guest ID, which
-// ultimately filters down to a QueryConfigOptionEx call with only the single
-// guest ID set. This ensures that the VirtaulDeviceList returned matches a
-// default set best suited for the guest type that is being created.
 func DefaultDevicesFromReference(client *govmomi.Client, ref types.ManagedObjectReference, guest string) (object.VirtualDeviceList, error) {
 	log.Printf("[DEBUG] Fetching default device list for object reference %q for OS type %q", ref.Value, guest)
 	props, err := BasePropertiesFromReference(client, ref)
@@ -151,7 +146,7 @@ func DefaultDevicesFromReference(client *govmomi.Client, ref types.ManagedObject
 	b := envbrowse.NewEnvironmentBrowser(client.Client, *props.EnvironmentBrowser)
 	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
 	defer cancel()
-	return b.DefaultDevices(ctx, []string{guest}, "", nil)
+	return b.DefaultDevices(ctx, "", nil)
 }
 
 // OSFamily uses the compute resource's environment browser to get the OS family

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -94,7 +94,7 @@ func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string
 			return family, nil
 		}
 	}
-	return "", fmt.Errorf("could not find guest ID %s", guest)
+	return "", fmt.Errorf("could not find guest ID %q", guest)
 }
 
 // QueryConfigOptionDescriptor returns a list the list of ConfigOption keys

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -32,17 +32,17 @@ func NewEnvironmentBrowser(c *vim25.Client, ref types.ManagedObjectReference) *E
 }
 
 // DefaultDevices loads a satisfactory default device list for the optionally
-// supplied guest ID list, host, and descriptor key. The result is returned as
-// a higher-level VirtualDeviceList object. This can be used as an initial
-// VirtualDeviceList when building a device list and VirtualDeviceConfigSpec
-// list for new virtual machines.
+// supplied host and descriptor key. The result is returned as a higher-level
+// VirtualDeviceList object. This can be used as an initial VirtualDeviceList
+// when building a device list and VirtualDeviceConfigSpec list for new virtual
+// machines.
 //
 // Appropriate options for key can be loaded by running
 // QueryConfigOptionDescriptor, which will return a list of
 // VirtualMachineConfigOptionDescriptor which will contain the appropriate key
-// to use under key. If no key is supplied, the results generally reflect the
-// most recent VM hardware version.
-func (b *EnvironmentBrowser) DefaultDevices(ctx context.Context, guests []string, key string, host *object.HostSystem) (object.VirtualDeviceList, error) {
+// for the virtual machine version needed. If no key is supplied, the results
+// generally reflect the most recent VM hardware version.
+func (b *EnvironmentBrowser) DefaultDevices(ctx context.Context, key string, host *object.HostSystem) (object.VirtualDeviceList, error) {
 	var eb mo.EnvironmentBrowser
 
 	err := b.Properties(ctx, b.Reference(), nil, &eb)
@@ -50,18 +50,15 @@ func (b *EnvironmentBrowser) DefaultDevices(ctx context.Context, guests []string
 		return nil, err
 	}
 
-	req := types.QueryConfigOptionEx{
+	req := types.QueryConfigOption{
 		This: b.Reference(),
-		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
-			Key:     key,
-			GuestId: guests,
-		},
+		Key:  key,
 	}
 	if host != nil {
 		ref := host.Reference()
-		req.Spec.Host = &ref
+		req.Host = &ref
 	}
-	res, err := methods.QueryConfigOptionEx(ctx, b.Client(), &req)
+	res, err := methods.QueryConfigOption(ctx, b.Client(), &req)
 	if err != nil {
 		return nil, err
 	}
@@ -80,28 +77,24 @@ func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string
 		return "", err
 	}
 
-	req := types.QueryConfigOptionEx{
+	req := types.QueryConfigOption{
 		This: b.Reference(),
-		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
-			GuestId: []string{guest},
-		},
 	}
-	res, err := methods.QueryConfigOptionEx(ctx, b.Client(), &req)
+	res, err := methods.QueryConfigOption(ctx, b.Client(), &req)
 	if err != nil {
 		return "", err
 	}
 	if res.Returnval == nil {
 		return "", errors.New("no config options were found for the supplied criteria")
 	}
-	if len(res.Returnval.GuestOSDescriptor) < 1 {
-		return "", errors.New("no guest OS descriptors were found")
+	for _, osd := range res.Returnval.GuestOSDescriptor {
+		if osd.Id == guest {
+			family := res.Returnval.GuestOSDescriptor[0].Family
+			log.Printf("[DEBUG] OSFamily: family for %q is %q", guest, family)
+			return family, nil
+		}
 	}
-	if len(res.Returnval.GuestOSDescriptor) > 1 {
-		return "", fmt.Errorf("multiple OS descriptors were found for guest ID %s", guest)
-	}
-	family := res.Returnval.GuestOSDescriptor[0].Family
-	log.Printf("[DEBUG] OSFamily: family for %q is %q", guest, family)
-	return family, nil
+	return "", fmt.Errorf("could not find guest ID %s", guest)
 }
 
 // QueryConfigOptionDescriptor returns a list the list of ConfigOption keys

--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -89,7 +89,7 @@ func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string
 	}
 	for _, osd := range res.Returnval.GuestOSDescriptor {
 		if osd.Id == guest {
-			family := res.Returnval.GuestOSDescriptor[0].Family
+			family := osd.Family
 			log.Printf("[DEBUG] OSFamily: family for %q is %q", guest, family)
 			return family, nil
 		}

--- a/vsphere/internal/helper/folder/folder_helper.go
+++ b/vsphere/internal/helper/folder/folder_helper.go
@@ -192,6 +192,8 @@ func folderFromObject(client *govmomi.Client, obj interface{}, folderType RootPa
 		p, err = RootPathParticleHost.PathFromNewRoot(o.InventoryPath, folderType, relative)
 	case *object.ResourcePool:
 		p, err = RootPathParticleHost.PathFromNewRoot(o.InventoryPath, folderType, relative)
+	case *object.VirtualMachine:
+		p, err = RootPathParticleVM.PathFromNewRoot(o.InventoryPath, folderType, relative)
 	default:
 		return nil, fmt.Errorf("unsupported object type %T", o)
 	}

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -974,7 +974,8 @@ func (r *DiskSubresource) Read(l object.VirtualDeviceList) error {
 	r.Set("write_through", b.WriteThrough)
 
 	// Only use disk_sharing if we are on vSphere 6.0 and higher
-	if viapi.ParseVersionFromClient(r.client).Major >= 6 {
+	version := viapi.ParseVersionFromClient(r.client)
+	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
 		r.Set("disk_sharing", b.Sharing)
 	}
 
@@ -1281,7 +1282,8 @@ func (r *DiskSubresource) expandDiskSettings(disk *types.VirtualDisk) error {
 	b.WriteThrough = structure.BoolPtr(r.GetWithRestart("write_through").(bool))
 
 	// Only use disk_sharing if we are on vSphere 6.0 and higher
-	if viapi.ParseVersionFromClient(r.client).Major >= 6 {
+	version := viapi.ParseVersionFromClient(r.client)
+	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
 		b.Sharing = r.GetWithRestart("disk_sharing").(string)
 	}
 

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1196,6 +1196,14 @@ func (r *DiskSubresource) NormalizeDiff() error {
 		return fmt.Errorf("virtual disk %q: %s", name, err)
 	}
 
+	// Block certain options from being set depending on the vSphere version.
+	version := viapi.ParseVersionFromClient(r.client)
+	if r.Get("disk_sharing").(string) != string(types.VirtualDiskSharingSharingNone) {
+		if version.Older(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
+			return fmt.Errorf("multi-writer disk_sharing is only supported on vSphere 6 and higher")
+		}
+	}
+
 	log.Printf("[DEBUG] %s: Diff normalization complete", r)
 	return nil
 }

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -375,7 +375,7 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return fmt.Errorf("error fetching VM properties: %s", err)
 	}
-	spec, changed := expandVirtualMachineConfigSpecChanged(d, vprops.Config)
+	spec, changed := expandVirtualMachineConfigSpecChanged(d, client, vprops.Config)
 	devices := object.VirtualDeviceList(vprops.Config.Hardware.Device)
 	if spec.DeviceChange, err = applyVirtualDevices(d, client, devices); err != nil {
 		return err
@@ -596,7 +596,7 @@ func resourceVSphereVirtualMachineCreateBare(d *schema.ResourceData, meta interf
 	}
 
 	// Ready to start making the VM here. First expand our main config spec.
-	spec := expandVirtualMachineConfigSpec(d)
+	spec := expandVirtualMachineConfigSpec(d, client)
 
 	// Set the datastore for the VM.
 	ds, err := datastore.FromID(client, d.Get("datastore_id").(string))
@@ -689,7 +689,7 @@ func resourceVSphereVirtualMachineCreateClone(d *schema.ResourceData, meta inter
 	// configuration of the newly cloned VM. This is basically a subset of update
 	// with the stipulation that there is currently no state to help move this
 	// along.
-	cfgSpec := expandVirtualMachineConfigSpec(d)
+	cfgSpec := expandVirtualMachineConfigSpec(d, client)
 
 	// To apply device changes, we need the current devicecfgSpec from the config
 	// info. We then filter this list through the same apply process we did for

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -460,6 +460,32 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 			},
 		},
 		{
+			"move to folder",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigBasic(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+						),
+					},
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigInFolder(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							testAccResourceVSphereVirtualMachineCheckFolder("terraform-test-vms"),
+						),
+					},
+				},
+			},
+		},
+		{
 			"static mac",
 			resource.TestCase{
 				PreCheck: func() {

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -263,8 +263,8 @@ func expandVirtualMachineBootOptions(d *schema.ResourceData, client *govmomi.Cli
 	}
 	// Only set EFI secure boot if we are on vSphere 6.5 and higher
 	version := viapi.ParseVersionFromClient(client)
-	if version.Newer(viapi.VSphereVersion{Major: 6, Minor: 5}) {
-		obj.EfiSecureBootEnabled = structure.GetBool(d, "efi_secure_boot_enabled")
+	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 5}) {
+		obj.EfiSecureBootEnabled = getBoolWithRestart(d, "efi_secure_boot_enabled")
 	}
 	return obj
 }

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/structure"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
+	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -253,12 +255,16 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 
 // expandVirtualMachineBootOptions reads certain ResourceData keys and
 // returns a VirtualMachineBootOptions.
-func expandVirtualMachineBootOptions(d *schema.ResourceData) *types.VirtualMachineBootOptions {
+func expandVirtualMachineBootOptions(d *schema.ResourceData, client *govmomi.Client) *types.VirtualMachineBootOptions {
 	obj := &types.VirtualMachineBootOptions{
-		BootDelay:            int64(d.Get("boot_delay").(int)),
-		EfiSecureBootEnabled: structure.GetBool(d, "efi_secure_boot_enabled"),
-		BootRetryEnabled:     structure.GetBool(d, "boot_retry_enabled"),
-		BootRetryDelay:       int64(d.Get("boot_retry_delay").(int)),
+		BootDelay:        int64(d.Get("boot_delay").(int)),
+		BootRetryEnabled: structure.GetBool(d, "boot_retry_enabled"),
+		BootRetryDelay:   int64(d.Get("boot_retry_delay").(int)),
+	}
+	// Only set EFI secure boot if we are on vSphere 6.5 and higher
+	version := viapi.ParseVersionFromClient(client)
+	if version.Newer(viapi.VSphereVersion{Major: 6, Minor: 5}) {
+		obj.EfiSecureBootEnabled = structure.GetBool(d, "efi_secure_boot_enabled")
 	}
 	return obj
 }
@@ -563,7 +569,7 @@ func expandMemorySizeConfig(d *schema.ResourceData) int64 {
 
 // expandVirtualMachineConfigSpec reads certain ResourceData keys and
 // returns a VirtualMachineConfigSpec.
-func expandVirtualMachineConfigSpec(d *schema.ResourceData) types.VirtualMachineConfigSpec {
+func expandVirtualMachineConfigSpec(d *schema.ResourceData, client *govmomi.Client) types.VirtualMachineConfigSpec {
 	log.Printf("[DEBUG] %s: Building config spec", resourceVSphereVirtualMachineIDString(d))
 	obj := types.VirtualMachineConfigSpec{
 		Name:                d.Get("name").(string),
@@ -582,7 +588,7 @@ func expandVirtualMachineConfigSpec(d *schema.ResourceData) types.VirtualMachine
 		MemoryAllocation:    expandVirtualMachineResourceAllocation(d, "memory"),
 		ExtraConfig:         expandExtraConfig(d),
 		SwapPlacement:       getWithRestart(d, "swap_placement_policy").(string),
-		BootOptions:         expandVirtualMachineBootOptions(d),
+		BootOptions:         expandVirtualMachineBootOptions(d, client),
 		Firmware:            getWithRestart(d, "firmware").(string),
 		NestedHVEnabled:     getBoolWithRestart(d, "nested_hv_enabled"),
 		VPMCEnabled:         getBoolWithRestart(d, "cpu_performance_counters_enabled"),
@@ -642,7 +648,7 @@ func flattenVirtualMachineConfigInfo(d *schema.ResourceData, obj *types.VirtualM
 // It does this be creating a fake ResourceData off of the VM resource schema,
 // flattening the config info into that, and then expanding both ResourceData
 // instances and comparing the resultant ConfigSpecs.
-func expandVirtualMachineConfigSpecChanged(d *schema.ResourceData, info *types.VirtualMachineConfigInfo) (types.VirtualMachineConfigSpec, bool) {
+func expandVirtualMachineConfigSpecChanged(d *schema.ResourceData, client *govmomi.Client, info *types.VirtualMachineConfigInfo) (types.VirtualMachineConfigSpec, bool) {
 	// Create the fake ResourceData from the VM resource
 	oldData := resourceVSphereVirtualMachine().Data(&terraform.InstanceState{})
 	oldData.SetId(d.Id())
@@ -654,9 +660,9 @@ func expandVirtualMachineConfigSpecChanged(d *schema.ResourceData, info *types.V
 	// Get both specs. Silence the logging for oldSpec to suppress fake
 	// reboot_required log messages.
 	log.SetOutput(ioutil.Discard)
-	oldSpec := expandVirtualMachineConfigSpec(oldData)
+	oldSpec := expandVirtualMachineConfigSpec(oldData, client)
 	logging.SetOutput()
-	newSpec := expandVirtualMachineConfigSpec(d)
+	newSpec := expandVirtualMachineConfigSpec(d, client)
 	// Return the new spec and compare
 	return newSpec, !reflect.DeepEqual(oldSpec, newSpec)
 }

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -339,8 +339,7 @@ The following options control boot settings on the virtual machine:
 * `efi_secure_boot_enabled` - (Optional) When the `firmware` type is set to is
   `efi`, this enables EFI secure boot. Default: `false`.
 
-~> **NOTE:** EFI secure boot is only available on vSphere 6.5 and higher. This
-option is ignored on earlier versions.
+~> **NOTE:** EFI secure boot is only available on vSphere 6.5 and higher.
 
 * `boot_retry_delay` - (Optional) The number of milliseconds to wait before
   retrying the boot sequence. This only valid if `boot_retry_enabled` is true.
@@ -510,8 +509,7 @@ The options are:
 * `disk_sharing` - (Optional) The sharing mode of this virtual disk. Can be one
   of `sharingMultiWriter` or `sharingNone`. Default: `sharingNone`.
 
-~> **NOTE:** Disk sharing is only available on vSphere 6.0 and higher. This
-option is ignored on earlier versions.
+~> **NOTE:** Disk sharing is only available on vSphere 6.0 and higher.
 
 * `write_through` - (Optional) If `true`, writes for this disk are sent
   directly to the filesystem immediately instead of being buffered. Default:

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -505,6 +505,10 @@ The options are:
   [picking a disk type](#picking-a-disk-type). Default: `true`. 
 * `disk_sharing` - (Optional) The sharing mode of this virtual disk. Can be one
   of `sharingMultiWriter` or `sharingNone`. Default: `sharingNone`.
+
+~> **NOTE:** Disk sharing is only available on vSphere 6.0 and higher. This
+option is ignored on earlier versions.
+
 * `write_through` - (Optional) If `true`, writes for this disk are sent
   directly to the filesystem immediately instead of being buffered. Default:
   `false`.

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -338,6 +338,10 @@ The following options control boot settings on the virtual machine:
   the boot sequence. The default is no delay.
 * `efi_secure_boot_enabled` - (Optional) When the `firmware` type is set to is
   `efi`, this enables EFI secure boot. Default: `false`.
+
+~> **NOTE:** EFI secure boot is only available on vSphere 6.5 and higher. This
+option is ignored on earlier versions.
+
 * `boot_retry_delay` - (Optional) The number of milliseconds to wait before
   retrying the boot sequence. This only valid if `boot_retry_enabled` is true.
   Default: `10000` (10 seconds).


### PR DESCRIPTION
This PR comprises the changes that are in #257 and #258, and a couple of more commits on top of those. Will be closing the other two PRs shortly.

The fixes are:

* Backwards compatibility fixes: EFI secure boot is only available on vSphere >= 6.5, and disk sharing is only available on vSphere >= 6.0.
* Moved `EnvironmentBrowser` helper methods to use `QueryConfigOption` instead of `QueryConfigOptionEx`, ensuring the helpers can be used on vSphere 5.5 as well.
* Looks like a "move to folder" test was missed, and it turns out this was not fully functional yet. Added the support in to make this work.

Smoke tested EFI secure boot and disk sharing options on our lab to make sure they both still took effect on vSphere 6.5. Will be re-running full test suite tonight and will paste the results in here.
