### PR TITLE
Small post-release ESXi fixes

### DIFF
--- a/vsphere/data_source_vsphere_resource_pool.go
+++ b/vsphere/data_source_vsphere_resource_pool.go
@@ -16,7 +16,7 @@ func dataSourceVSphereResourcePool() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The name or path of the resource pool.",
-				Required:    true,
+				Optional:    true,
 			},
 			"datacenter_id": {
 				Type:        schema.TypeString,

--- a/vsphere/data_source_vsphere_resource_pool.go
+++ b/vsphere/data_source_vsphere_resource_pool.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/resourcepool"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
 	"github.com/vmware/govmomi/object"
 )
 
@@ -31,6 +32,12 @@ func dataSourceVSphereResourcePoolRead(d *schema.ResourceData, meta interface{})
 	client := meta.(*VSphereClient).vimClient
 
 	name := d.Get("name").(string)
+	if err := viapi.ValidateVirtualCenter(client); err == nil {
+		if name == "" {
+			return fmt.Errorf("name cannot be empty when using vCenter")
+		}
+	}
+
 	var dc *object.Datacenter
 	if dcID, ok := d.GetOk("datacenter_id"); ok {
 		var err error

--- a/vsphere/data_source_vsphere_resource_pool_test.go
+++ b/vsphere/data_source_vsphere_resource_pool_test.go
@@ -72,6 +72,28 @@ func TestAccDataSourceVSphereResourcePool(t *testing.T) {
 				},
 			},
 		},
+		{
+			"empty name on vCenter, should error",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccDataSourceVSphereResourcePoolPreCheck(tp)
+					testAccSkipIfEsxi(tp)
+				},
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config:      testAccDataSourceVSphereResourcePoolConfigDefault,
+						ExpectError: regexp.MustCompile("name cannot be empty when using vCenter"),
+						PlanOnly:    true,
+					},
+					{
+						Config: testAccResourceVSphereEmpty,
+						Check:  resource.ComposeTestCheckFunc(),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testAccDataSourceVSphereResourcePoolCases {

--- a/vsphere/data_source_vsphere_resource_pool_test.go
+++ b/vsphere/data_source_vsphere_resource_pool_test.go
@@ -21,6 +21,7 @@ func TestAccDataSourceVSphereResourcePool(t *testing.T) {
 				PreCheck: func() {
 					testAccPreCheck(tp)
 					testAccDataSourceVSphereResourcePoolPreCheck(tp)
+					testAccSkipIfEsxi(tp)
 				},
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{
@@ -39,6 +40,7 @@ func TestAccDataSourceVSphereResourcePool(t *testing.T) {
 				PreCheck: func() {
 					testAccPreCheck(tp)
 					testAccDataSourceVSphereResourcePoolPreCheck(tp)
+					testAccSkipIfEsxi(tp)
 				},
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{
@@ -46,6 +48,25 @@ func TestAccDataSourceVSphereResourcePool(t *testing.T) {
 						Config: testAccDataSourceVSphereResourcePoolConfigAbsolutePath(),
 						Check: resource.ComposeTestCheckFunc(
 							resource.TestMatchResourceAttr("data.vsphere_resource_pool.pool", "id", regexp.MustCompile("^resgroup-")),
+						),
+					},
+				},
+			},
+		},
+		{
+			"default resource pool for ESXi",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccDataSourceVSphereResourcePoolPreCheck(tp)
+					testAccSkipIfNotEsxi(tp)
+				},
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccDataSourceVSphereResourcePoolConfigDefault,
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestMatchResourceAttr("data.vsphere_resource_pool.pool", "id", regexp.MustCompile("^ha-root-pool$")),
 						),
 					},
 				},
@@ -125,3 +146,7 @@ data "vsphere_resource_pool" "pool" {
 		os.Getenv("VSPHERE_RESOURCE_POOL"),
 	)
 }
+
+const testAccDataSourceVSphereResourcePoolConfigDefault = `
+data "vsphere_resource_pool" "pool" {}
+`

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -59,6 +59,26 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 			},
 		},
 		{
+			"ESXi-only test",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+					testAccSkipIfNotEsxi(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigBasicESXiOnly(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+						),
+					},
+				},
+			},
+		},
+		{
 			"shutdown OK",
 			resource.TestCase{
 				PreCheck: func() {
@@ -1806,6 +1826,54 @@ resource "vsphere_virtual_machine" "vm" {
 `,
 		os.Getenv("VSPHERE_DATACENTER"),
 		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
+		os.Getenv("VSPHERE_DATASTORE"),
+	)
+}
+
+func testAccResourceVSphereVirtualMachineConfigBasicESXiOnly() string {
+	return fmt.Sprintf(`
+variable "network_label" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinux64Guest"
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    name = "terraform-test.vmdk"
+    size = 20
+  }
+}
+`,
 		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
 		os.Getenv("VSPHERE_DATASTORE"),
 	)

--- a/website/docs/d/resource_pool.html.markdown
+++ b/website/docs/d/resource_pool.html.markdown
@@ -54,8 +54,8 @@ data "vsphere_resource_pool" "pool" {}
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the resource pool. This can be a name or
-  path.
+* `name` - (Optional) The name of the resource pool. This can be a name or
+  path. This is required when using vCenter.
 * `datacenter_id` - (Optional) The [managed object reference
   ID][docs-about-morefs] of the datacenter the resource pool is located in.
   This can be omitted if the search path used in `name` is an absolute path.


### PR DESCRIPTION
Looks like there are a couple of issues with the release that are currently blocking its use on ESXi:

* The documented `vsphere_resource_pool` data source usage for ESXi was not working - `name` was required and the helper was not auto-locating the standalone ESXi datacenter properly,
* The `vsphere_virtual_machine` resource now uses folder functionality out of our folder helper, which was normally restricted to vCenter-only scenarios before. This loosens those requirements just enough so that the VM resource can get the root folder from the standalone ESXi "inventory" to create the VMs in.

