### PR TITLE
r/virtual_machine: Device cull range fix, and handle zero-NIC templates

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -354,15 +354,17 @@ func CdromPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object
 
 	// Any other device past the end of the CDROM devices listed in config needs
 	// to be removed.
-	for i, si := range srcSet[len(curSet):] {
-		sm := si.(map[string]interface{})
-		r := NewCdromSubresource(c, d, sm, nil, i+len(curSet))
-		dspec, err := r.Delete(l)
-		if err != nil {
-			return nil, nil, fmt.Errorf("%s: %s", r.Addr(), err)
+	if len(curSet) < len(srcSet) {
+		for i, si := range srcSet[len(curSet):] {
+			sm := si.(map[string]interface{})
+			r := NewCdromSubresource(c, d, sm, nil, i+len(curSet))
+			dspec, err := r.Delete(l)
+			if err != nil {
+				return nil, nil, fmt.Errorf("%s: %s", r.Addr(), err)
+			}
+			l = applyDeviceChange(l, dspec)
+			spec = append(spec, dspec...)
 		}
-		l = applyDeviceChange(l, dspec)
-		spec = append(spec, dspec...)
 	}
 
 	log.Printf("[DEBUG] CdromPostCloneOperation: Post-clone final resource list: %s", subresourceListString(updates))

--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -748,6 +748,10 @@ func scsiControllerListString(ctlrs []types.BaseVirtualSCSIController) string {
 // It's mainly used in network interface refresh logic to determine how many
 // subresources may end up in state.
 func unitRange(l object.VirtualDeviceList) (int, error) {
+	// No NICs means no range
+	if len(l) < 1 {
+		return 0, nil
+	}
 	var low, high *int32
 	for _, v := range l {
 		d := v.GetVirtualDevice()

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -613,6 +613,26 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 			},
 		},
 		{
+			"clone, multi-nic (template should have one)",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigCloneMultiNIC(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							resource.TestCheckResourceAttr("vsphere_virtual_machine.vm", "default_ip_address", os.Getenv("VSPHERE_IPV4_ADDRESS")),
+						),
+					},
+				},
+			},
+		},
+		{
 			"clone with different timezone",
 			resource.TestCase{
 				PreCheck: func() {
@@ -3131,6 +3151,130 @@ resource "vsphere_virtual_machine" "vm" {
 	)
 }
 
+func testAccResourceVSphereVirtualMachineConfigCloneMultiNIC() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "ipv4_address" {
+  default = "%s"
+}
+
+variable "ipv4_netmask" {
+  default = "%s"
+}
+
+variable "ipv4_gateway" {
+  default = "%s"
+}
+
+variable "dns_server" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+variable "template" {
+  default = "%s"
+}
+
+variable "linked_clone" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = "${var.template}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    name = "terraform-test.vmdk"
+    size = "${data.vsphere_virtual_machine.template.disk_sizes[0]}"
+  }
+
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    linked_clone  = "${var.linked_clone != "" ? "true" : "false" }"
+
+    customize {
+      linux_options {
+        host_name = "terraform-test"
+        domain    = "test.internal"
+      }
+
+      network_interface {
+        ipv4_address = "${var.ipv4_address}"
+        ipv4_netmask = "${var.ipv4_netmask}"
+      }
+
+      network_interface {}
+
+      ipv4_gateway    = "${var.ipv4_gateway}"
+      dns_server_list = ["${var.dns_server}"]
+      dns_suffix_list = ["test.internal"]
+    }
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL"),
+		os.Getenv("VSPHERE_IPV4_ADDRESS"),
+		os.Getenv("VSPHERE_IPV4_PREFIX"),
+		os.Getenv("VSPHERE_IPV4_GATEWAY"),
+		os.Getenv("VSPHERE_DNS"),
+		os.Getenv("VSPHERE_DATASTORE"),
+		os.Getenv("VSPHERE_TEMPLATE"),
+		os.Getenv("VSPHERE_USE_LINKED_CLONE"),
+	)
+}
 func testAccResourceVSphereVirtualMachineConfigCloneTimeZone(zone string) string {
 	return fmt.Sprintf(`
 variable "datacenter" {


### PR DESCRIPTION
There was some issues with our device culling/ranging logic in certain
scenarios:

* On templates with no NICs, unitRange was not producing a proper
result. This was the result of these values being pointers because we
work with the unit number value directly in the virtual device, which is
a pointer. This fixes things so that if a zero-length device list is
passed to unit range, we return 0 immediately (as there are no devices
to range over).
* On templates where the NIC count was less than the amount of NICs
needed by configuration, the device cull range expression (which is used
to handle the exact opposite scenario) was running into out-of-range
issues. This has been fixed by asserting that the old device list is
indeed longer than the new device list so that there's no way that
referencing old[len(new):] will fail. This has been extended to CD
devices too, which has the same logic, even though it's currently masked
by the fact that we only allow one cdrom device.

Fixes #267.