### PR TITLE
docs: Free ESXi is not supported

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -20,6 +20,9 @@ datastores, and more.
 Use the navigation on the left to read about the various resources and data
 sources supported by the provider.
 
+~> **NOTE:** This provider requires API write access and hence is not supported
+on a free ESXi license.
+
 ## Example Usage
 
 The following abridged example demonstrates a current basic usage of the


### PR DESCRIPTION
This is something that has potentially come up, had to do a bit of
looking into it myself as it's been a while since I've used free ESXi
and sure enough API "write" operations are not supported, hence the
provider is not really usable on such environments.