### PR TITLE
Use subresourceTypeCdrom for cdrom schema update

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -369,7 +369,7 @@ func CdromPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object
 
 	log.Printf("[DEBUG] CdromPostCloneOperation: Post-clone final resource list: %s", subresourceListString(updates))
 	// We are now done! Return the updated device list and config spec. Save updates as well.
-	if err := d.Set(subresourceTypeNetworkInterface, updates); err != nil {
+	if err := d.Set(subresourceTypeCdrom, updates); err != nil {
 		return nil, nil, err
 	}
 	log.Printf("[DEBUG] CdromPostCloneOperation: Device list at end of operation: %s", DeviceListString(l))


### PR DESCRIPTION
While creating a virtual CDROM and attaching it, I was getting a handful of errors that seemed unrelated to the network_interface:

```
* vsphere_virtual_machine.orchestrator-2: 1 error(s) occurred:

* vsphere_virtual_machine.orchestrator-2: Invalid address to set: []string{"network_interface", "0", "path"}

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

Digging through the code, I found a schema update that was using the `subresourceTypeNetworkInterface` type instead of `subresourceTypeCdrom`. After using this newly built provider plugin, I'm able to create the instance without issue