### PR TITLE
r/virtual_machine: Validate exact disk type when using linked_clone

### DIFF
--- a/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_clone_subresource.go
@@ -84,7 +84,8 @@ func ValidateVirtualMachineClone(d *schema.ResourceDiff, c *govmomi.Client) erro
 	}
 	// If linked clone is enabled, check to see if we have a snapshot. There need
 	// to be a single snapshot on the template for it to be eligible.
-	if d.Get("clone.0.linked_clone").(bool) {
+	linked := d.Get("clone.0.linked_clone").(bool)
+	if linked {
 		log.Printf("[DEBUG] ValidateVirtualMachineClone: Checking snapshots on %s for linked clone eligibility", tUUID)
 		if err := validateCloneSnapshots(vprops); err != nil {
 			return err
@@ -94,7 +95,7 @@ func ValidateVirtualMachineClone(d *schema.ResourceDiff, c *govmomi.Client) erro
 	// in the configuration. This is in the virtual device package, so pass off
 	// to that now.
 	l := object.VirtualDeviceList(vprops.Config.Hardware.Device)
-	if err := virtualdevice.DiskCloneValidateOperation(d, c, l); err != nil {
+	if err := virtualdevice.DiskCloneValidateOperation(d, c, l, linked); err != nil {
 		return err
 	}
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -965,7 +965,9 @@ both the resource configuration and source template:
   this.
 * The `size` of a virtual disk must be at least the same size as its
   counterpart disk in the template.
-* When using `linked_clone`, the `size` has to be an exact match.
+* When using `linked_clone`, the `size`, `thin_provisioned`, and
+  `eagerly_scrub` settings for each disk must be an exact match to the
+  individual disk's counterpart in the source template.
 * The [`scsi_controller_count`](#scsi_controller_count) setting should be
   configured as necessary to cover all of the disks on the template. For best
   results, only configure this setting for the amount of controllers you will


### PR DESCRIPTION
A VM that's cloned with `linked_clone` and different disk mode options
that what is set on the source template will end up with inconsistent
settings post-clone, causing a read-update failure that will leave the
VM in a state that is irrecoverable to Terraform - the only way to
rectify the situation is to delete the VM and start over with a new
state.

This adds extra validation to make sure that `thin_provisioned` and
`eagerly_scrub` are set to the same settings as the source template's
counterpart disk, along with validating that the disk is the exact same
size (something that wasn't done yet).

Fixes #275.

-----

PS: There will be a larger-ish PR (mainly because of adjustments to tests) that will follow this one to add `thin_provisioned` and `eagerly_scrub` attributes to the `vsphere_virtual_machine` data source. This will help ensure that these can be fetched in the same way we have the data source fetching `disk_sizes` currently.