### PR TITLE
Connect virtual cdrom on boot

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -411,6 +411,7 @@ func (r *CdromSubresource) Create(l object.VirtualDeviceList) ([]types.BaseVirtu
 		return nil, err
 	}
 	device = l.InsertIso(device, dsPath.String())
+	l.Connect(device)
 
 	// Done here. Save IDs, push the device to the new device list and return.
 	if err := r.SaveDevIDs(device, ctlr); err != nil {
@@ -490,6 +491,7 @@ func (r *CdromSubresource) Update(l object.VirtualDeviceList) ([]types.BaseVirtu
 	}
 
 	device = l.InsertIso(device, dsPath.String())
+	l.Connect(device)
 
 	spec, err := object.VirtualDeviceList{device}.ConfigSpec(types.VirtualDeviceConfigSpecOperationEdit)
 	if err != nil {


### PR DESCRIPTION
When cloning a VM, and specifying a virtual cdrom device, it doesn't boot with it connected. 

I'm not sure if this PR is the appropriate approach -- maybe it should be a config parameter, however as it currently stands the virtual cdrom functionality does not mimic what was previously in 0.4.x, where it would automatically be connected.