### PR TITLE
r/virtual_machine: Do not delete disks at same address as existing disk

### DIFF
--- a/vsphere/internal/helper/datastore/datastore_helper.go
+++ b/vsphere/internal/helper/datastore/datastore_helper.go
@@ -2,7 +2,9 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"path"
 
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
@@ -87,4 +89,91 @@ func MoveToFolderRelativeHostSystemID(client *govmomi.Client, ds *object.Datasto
 		return err
 	}
 	return folder.MoveObjectTo(ds.Reference(), f)
+}
+
+// Browser returns the HostDatastoreBrowser for a certain datastore. This is a
+// convenience method that exists to abstract the context.
+func Browser(ds *object.Datastore) (*object.HostDatastoreBrowser, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	return ds.Browser(ctx)
+}
+
+// SearchDatastore searches a datastore using the supplied HostDatastoreBrowser
+// and a supplied path. The current implementation only returns the basic
+// information, so all FileQueryFlags set, but not any flags for specific types
+// of files.
+func SearchDatastore(ds *object.Datastore, name string) ([]*types.FileInfo, error) {
+	result, err := searchDatastore(ds, name)
+	if err != nil {
+		return nil, err
+	}
+	var files []*types.FileInfo
+	for _, bfi := range result.File {
+		files = append(files, bfi.GetFileInfo())
+	}
+	return files, nil
+}
+
+func searchDatastore(ds *object.Datastore, name string) (*types.HostDatastoreBrowserSearchResults, error) {
+	browser, err := Browser(ds)
+	if err != nil {
+		return nil, err
+	}
+	var p, m string
+
+	switch {
+	case path.Dir(name) == ".":
+		fallthrough
+	case path.Base(name) == "":
+		p = name
+		m = "*"
+	default:
+		p = path.Dir(name)
+		m = path.Base(name)
+	}
+	dp := &object.DatastorePath{
+		Datastore: ds.Name(),
+		Path:      p,
+	}
+	spec := &types.HostDatastoreBrowserSearchSpec{
+		MatchPattern: []string{m},
+		Details: &types.FileQueryFlags{
+			FileType:     true,
+			FileSize:     true,
+			FileOwner:    types.NewBool(true),
+			Modification: true,
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	task, err := browser.SearchDatastore(ctx, dp.String(), spec)
+	if err != nil {
+		return nil, err
+	}
+	tctx, tcancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer tcancel()
+	info, err := task.WaitForResult(tctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	r := info.Result.(types.HostDatastoreBrowserSearchResults)
+	return &r, nil
+}
+
+// FileExists takes a path in the datastore and checks to see if it exists.
+//
+// The path should be a bare path, not a datastore path. Globs are not allowed.
+func FileExists(ds *object.Datastore, name string) (bool, error) {
+	files, err := SearchDatastore(ds, name)
+	if err != nil {
+		return false, err
+	}
+	if len(files) > 1 {
+		return false, fmt.Errorf("multiple results returned for %q in datastore %q, use a more specific search", name, ds)
+	}
+	if len(files) < 1 {
+		return false, nil
+	}
+	return path.Base(name) == files[0].Path, nil
 }

--- a/vsphere/internal/helper/structure/structure_helper.go
+++ b/vsphere/internal/helper/structure/structure_helper.go
@@ -390,3 +390,13 @@ func NormalizeValue(v interface{}) interface{} {
 	}
 	return v
 }
+
+// LogCond takes a boolean (which can be passed in as a bool or as a
+// conditional), and returns either the first value if true, and the second if
+// false. It's designed to be a "ternary" operator of sorts for logging.
+func LogCond(c bool, t, f interface{}) interface{} {
+	if c {
+		return t
+	}
+	return f
+}

--- a/vsphere/internal/helper/virtualdisk/virtual_disk_helper.go
+++ b/vsphere/internal/helper/virtualdisk/virtual_disk_helper.go
@@ -1,0 +1,123 @@
+package virtualdisk
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path"
+
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/provider"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/structure"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// DatastorePathFromString is a convenience method that returns a
+// fully-populated DatastorePath from a string containing a datastore path. A
+// flag indicating a successful parsing is also returned.
+func DatastorePathFromString(p string) (*object.DatastorePath, bool) {
+	dp := new(object.DatastorePath)
+	success := dp.FromString(p)
+	log.Printf("[DEBUG] DatastorePathFromString: success: %t, path: %q", success, p)
+	return dp, success
+}
+
+// IsVmdkDatastorePath ensures that a string can be parsed as a datastore path
+// pointing to a virtual disk. This only checks the validity of the path, not
+// whether or not the file exists.
+func IsVmdkDatastorePath(p string) bool {
+	dp, success := DatastorePathFromString(p)
+	if !success {
+		log.Printf("[DEBUG] IsVmdkDatastorePath: %q is not a datastore path", p)
+		return false
+	}
+	isVMDK := dp.IsVMDK()
+	log.Printf("[DEBUG] IsVmdkDatastorePath: %q %s a datastore path", p, structure.LogCond(isVMDK, "is", "is not"))
+	return isVMDK
+}
+
+// Move moves a virtual disk from one location to another. The move is not
+// forced.
+//
+// srcPath needs to be a datastore path (ie: "[datastore1] vm/vm.vmdk"),
+// however the destination path (dstPath) can be a simple path - if it is, the
+// source datastore is used and dstDC is ignored. Further, if dstPath has no
+// directory, the directory of srcPath is used. dstDC can be nil if the
+// destination datastore is in the same datacenter.
+//
+// The new datastore path is returned along with any error, to avoid the need
+// to re-calculate the path separately.
+func Move(client *govmomi.Client, srcPath string, srcDC *object.Datacenter, dstPath string, dstDC *object.Datacenter) (string, error) {
+	vdm := object.NewVirtualDiskManager(client.Client)
+	if srcDC == nil {
+		return "", fmt.Errorf("source datacenter cannot be nil")
+	}
+	if !IsVmdkDatastorePath(srcPath) {
+		return "", fmt.Errorf("path %q is not a datastore path", srcPath)
+	}
+	if !IsVmdkDatastorePath(dstPath) {
+		ddp := dstDataStorePathFromLocalSrc(srcPath, dstPath)
+		// One more validation
+		if !IsVmdkDatastorePath(ddp) {
+			return "", fmt.Errorf("path %q is not a valid destination path", dstPath)
+		}
+		dstPath = ddp
+		dstDC = nil
+	}
+	log.Printf("[DEBUG] Moving virtual disk from %q in datacenter %s to destination %s%s",
+		srcPath,
+		srcDC,
+		dstPath,
+		structure.LogCond(dstDC != nil, fmt.Sprintf("in datacenter %s", dstDC), ""),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	task, err := vdm.MoveVirtualDisk(ctx, srcPath, srcDC, dstPath, dstDC, false)
+	if err != nil {
+		return "", err
+	}
+	tctx, tcancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer tcancel()
+	if err := task.Wait(tctx); err != nil {
+		return "", err
+	}
+	log.Printf("[DEBUG] Virtual disk %q in datacenter %s successfully moved to destination %s%s",
+		srcPath,
+		srcDC,
+		dstPath,
+		structure.LogCond(dstDC != nil, fmt.Sprintf("in datacenter %s", dstDC), ""),
+	)
+	return dstPath, nil
+}
+
+// QueryDiskType queries the disk type of the specified virtual disk.
+func QueryDiskType(client *govmomi.Client, name string, dc *object.Datacenter) (types.VirtualDiskType, error) {
+	vdm := object.NewVirtualDiskManager(client.Client)
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	di, err := vdm.QueryVirtualDiskInfo(ctx, name, dc, false)
+	if err != nil {
+		return types.VirtualDiskType(""), err
+	}
+	t := di[0].DiskType
+	log.Printf("[DEBUG] QueryDiskType: Disk %q is of type %q", name, t)
+	return types.VirtualDiskType(t), nil
+}
+
+func dstDataStorePathFromLocalSrc(src, dst string) string {
+	ddpTmp, success := DatastorePathFromString(dst)
+	if success {
+		dst = ddpTmp.Path
+	}
+	dstDP, success := DatastorePathFromString(src)
+	if !success {
+		panic(fmt.Errorf("dstDataStorePathFromLocalSrc: Expected valid source, got %q", src))
+	}
+	if path.Dir(dst) == "." {
+		dstDP.Path = path.Join(path.Dir(dstDP.Path), dst)
+	} else {
+		dstDP.Path = dst
+	}
+	return dstDP.String()
+}

--- a/vsphere/internal/helper/virtualdisk/virtual_disk_helper_test.go
+++ b/vsphere/internal/helper/virtualdisk/virtual_disk_helper_test.go
@@ -1,0 +1,124 @@
+package virtualdisk
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vmware/govmomi/object"
+)
+
+func TestDatastorePathFromString(t *testing.T) {
+	cases := []struct {
+		name     string
+		subject  string
+		expected *object.DatastorePath
+		success  bool
+	}{
+		{
+			name:     "standard",
+			subject:  "[datastore1] foo/bar.vmdk",
+			expected: &object.DatastorePath{Datastore: "datastore1", Path: "foo/bar.vmdk"},
+			success:  true,
+		},
+		{
+			name:     "no datastore",
+			subject:  "foo/bar.vmdk",
+			expected: &object.DatastorePath{},
+			success:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, success := DatastorePathFromString(tc.subject)
+			if !reflect.DeepEqual(tc.expected, actual) {
+				t.Fatalf("expected %+v, got %+v", tc.expected, actual)
+			}
+			if tc.success != success {
+				t.Fatalf("expected success to be %t, got %t", tc.success, success)
+			}
+		})
+	}
+}
+
+func TestIsVmdkDatastorePath(t *testing.T) {
+	cases := []struct {
+		name     string
+		subject  string
+		expected bool
+	}{
+		{
+			name:     "correct",
+			subject:  "[datastore1] foo/bar.vmdk",
+			expected: true,
+		},
+		{
+			name:     "incorrect - no datastore",
+			subject:  "foo/bar.vmdk",
+			expected: false,
+		},
+		{
+			name:     "incorrect - does not end in .vmdk",
+			subject:  "[datastore1] foo/bar",
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := IsVmdkDatastorePath(tc.subject)
+			if tc.expected != actual {
+				t.Fatalf("expected %t, got %t", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestDstDataStorePathFromLocalSrc(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		dst      string
+		expected string
+	}{
+		{
+			name:     "local path, no dir",
+			src:      "[datastore1] foo/bar.vmdk",
+			dst:      "baz.vmdk",
+			expected: "[datastore1] foo/baz.vmdk",
+		},
+		{
+			name:     "same datastore, full dir",
+			src:      "[datastore1] foo/bar.vmdk",
+			dst:      "bar/baz.vmdk",
+			expected: "[datastore1] bar/baz.vmdk",
+		},
+		{
+			name:     "different datastore, no dir (should override datastore)",
+			src:      "[datastore1] foo/bar.vmdk",
+			dst:      "[datastore2] baz.vmdk",
+			expected: "[datastore1] foo/baz.vmdk",
+		},
+		{
+			name:     "bad path, no dir (should still go thru)",
+			src:      "[datastore1] foo/bar.vmdk",
+			dst:      "baz",
+			expected: "[datastore1] foo/baz",
+		},
+		{
+			name:     "bad path, full dir (should still go thru)",
+			src:      "[datastore1] foo/bar.vmdk",
+			dst:      "baz/qux",
+			expected: "[datastore1] baz/qux",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := dstDataStorePathFromLocalSrc(tc.src, tc.dst)
+			if tc.expected != actual {
+				t.Fatalf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/computeresource"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/datastore"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/resourcepool"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/structure"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/virtualdevice"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -612,6 +614,43 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 						Check: resource.ComposeTestCheckFunc(
 							testAccResourceVSphereVirtualMachineCheckExists(true),
 							testAccResourceVSphereVirtualMachineCheckTags("terraform-test-tags-alt"),
+						),
+					},
+				},
+			},
+		},
+		{
+			"orphaned (renamed) disk in place of existing",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigBasic(),
+						Check: resource.ComposeTestCheckFunc(
+							copyStatePtr(&state),
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+						),
+					},
+					{
+						PreConfig: func() {
+							if err := testRenameVMFirstDisk(state, "vm", "foobar.vmdk"); err != nil {
+								panic(err)
+							}
+						},
+						Config: testAccResourceVSphereVirtualMachineConfigBasic(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							// The only real way we can check to see if this is actually
+							// functional in the current test framework is by checking that
+							// the file we renamed to was not deleted (this is due to a lack
+							// of ability to check diff in the test framework right now).
+							testCheckVMDiskFileExists("terraform-test.vmdk"),
+							testCheckVMDiskFileExists("foobar.vmdk"),
 						),
 					},
 				},
@@ -1967,6 +2006,50 @@ func testAccResourceVSphereVirtualMachineCheckNICCount(expected int) resource.Te
 	}
 }
 
+// testCheckVMDiskFileExists takes a VMDK filename and checks to see if it
+// exists within the same directory as the virtual machine's VMX file.
+func testCheckVMDiskFileExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tVars, err := testClientVariablesForResource(s, "vsphere_virtual_machine.vm")
+		if err != nil {
+			return err
+		}
+		vm, err := testGetVirtualMachine(s, "vm")
+		if err != nil {
+			return err
+		}
+		props, err := testGetVirtualMachineProperties(s, "vm")
+		if err != nil {
+			return err
+		}
+		vmxPath, success := virtualdisk.DatastorePathFromString(props.Config.Files.VmPathName)
+		if !success {
+			return fmt.Errorf("could not parse VMX path %q", props.Config.Files.VmPathName)
+		}
+		dcp, err := folder.RootPathParticleVM.SplitDatacenter(vm.InventoryPath)
+		if err != nil {
+			return err
+		}
+		dc, err := getDatacenter(tVars.client, dcp)
+		if err != nil {
+			return err
+		}
+		ds, err := datastore.FromPath(tVars.client, vmxPath.Datastore, dc)
+		if err != nil {
+			return err
+		}
+		p := path.Join(path.Dir(vmxPath.Path), name)
+		exists, err := datastore.FileExists(ds, p)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("file %q does not exist in datastore %q", p, ds.Name())
+		}
+		return nil
+	}
+}
+
 func testAccResourceVSphereVirtualMachineConfigBasic() string {
 	return fmt.Sprintf(`
 variable "datacenter" {
@@ -2012,7 +2095,7 @@ resource "vsphere_virtual_machine" "vm" {
   num_cpus = 2
   memory   = 2048
   guest_id = "other3xLinux64Guest"
-
+	
   network_interface {
     network_id = "${data.vsphere_network.network.id}"
   }

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -653,6 +653,18 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 							testCheckVMDiskFileExists("foobar.vmdk"),
 						),
 					},
+					// The last step is a cleanup step. This assumes the test is
+					// functional as the orphaned disk will be now detached and not
+					// deleted when the VM is destroyed.
+					{
+						PreConfig: func() {
+							if err := testDeleteVMDisk(state, "vm", "foobar.vmdk"); err != nil {
+								panic(err)
+							}
+						},
+						Config: testAccResourceVSphereVirtualMachineConfigBasic(),
+						Check:  resource.ComposeTestCheckFunc(),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This is the re-incarnation of #304.

-----

There are certain situations where the filename on a disk can get lost,
namely associated with snapshots, and storage vMotion on VMs that have
been created from linked clones or when a virtual machine has been
renamed.

In light of this, long-term we are planning on transitioning away from
being able to control the name of virtual disks that are not attached
externally. This stop-gap ensures that the disk is kept in situations
like this - where we actually find a disk recognized at a specific
location that we are tracking, versus just deleting the disk because the
logic does not consider it "orphaned".