### PR TITLE
r/virtual_machine: Network allocation settings require vSphere >= 6.0

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -482,6 +482,11 @@ func resourceVSphereVirtualMachineCustomizeDiff(d *schema.ResourceDiff, meta int
 		}
 	}
 
+	// Validate network device sub-resources
+	if err := virtualdevice.NetworkInterfaceDiffOperation(d, client); err != nil {
+		return err
+	}
+
 	// Validate and normalize disk sub-resources
 	if err := virtualdevice.DiskDiffOperation(d, client); err != nil {
 		return err


### PR DESCRIPTION
These are not default settings so this only comes up if you try to set
them, but they should be restricted anyway. Oddly they are settable on
vCenter 5.5 update 3f, and the settings take, but they do not seem to be
visible in the MOB. The docs say that the settings are not available
until vSphere 6 anyway.

Fixes #286.