### PR TITLE
docs: Clarify the use of cluster/host root resource pool

### DIFF
--- a/website/docs/d/resource_pool.html.markdown
+++ b/website/docs/d/resource_pool.html.markdown
@@ -23,16 +23,17 @@ data "vsphere_datacenter" "datacenter" {
 }
 
 data "vsphere_resource_pool" "pool" {
-  name          = "cluster1/Resources/resource-pool-1"
+  name          = "resource-pool-1"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 ```
 
-### Specifying the default resource pool for a cluster
+### Specifying the root resource pool for a cluster or standalone host
 
-If you don't have any resource pools in your cluster, or you want to use the
-parent resource pool for a cluster, you can just specify the `Resources` named
-default in your path for the resource pool:
+All clusters and standalone hosts have a resource pool, even if one has not
+been explicitly created. This resource pool is referred to as the _root
+resource pool_ and can be looked up by specifying the path as per the example
+below:
 
 ```
 data "vsphere_resource_pool" "pool" {
@@ -40,6 +41,11 @@ data "vsphere_resource_pool" "pool" {
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 ```
+
+For more information on the root resource pool, see [Managing Resource
+Pools][vmware-docs-resource-pools] in the vSphere documentation.
+
+[vmware-docs-resource-pools]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-60077B40-66FF-4625-934A-641703ED7601.html
 
 ## Argument Reference
 
@@ -57,7 +63,7 @@ The following arguments are supported:
 
 ~> **Note when using with standalone ESXi:** When using ESXi without vCenter,
 you don't have to specify either attribute to use this data source. An empty
-declaration will load the default resource pool.
+declaration will load the host's root resource pool.
 
 ## Attribute Reference
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -297,6 +297,15 @@ options:
 
 [docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
 
+~> **NOTE:** All clusters and standalone hosts have a resource pool, even if
+one has not been explicitly created. For more information, see the section on
+[specifying the root resource pool for a cluster or standalone
+host][docs-resource-pool-cluster-default] in the `vsphere_resource_pool` data
+source documentation. This resource does not take a cluster or standalone host
+resource directly.
+
+[docs-resource-pool-cluster-default]: /docs/providers/vsphere/d/resource_pool.html#specifying-the-default-resource-pool-for-a-cluster
+
 * `datastore_id` - (Required) The [managed object reference
   ID][docs-about-morefs] of the virtual machine's datastore. The virtual
   machine configuration is placed here, along with any virtual disks that are


### PR DESCRIPTION
There has been some confusion surrounding the fact that the
`vsphere_virtual_machine` resource now only takes a resource pool ID with
users that do not make use of resource pools, opting to just put virtual
machines in the root-level cluster or standalone host. This actually
places those virtual machines in a root resource pool that represents
all of the compute power of a particular host or set of hosts.  This
pool is normally invisible to the user and can only be seen generally by
using a tool that can browse the inventory off the CLI, like `govc`.

There are no plans to complicate the VM resource's implementation by
adding parameters like `compute_resource_id` - there is no point as they
would ultimately be looking up a resource pool anyway. Future plans may
see the development of data sources like `vsphere_cluster` and
`vsphere_standalone_host`, which could possibly have `resource_pool_id`
exported which would reference the root resource pool for that specific
resource. These may be developed along with their resource counterparts,
which are planned for a future release.

To back up the above, this commit adds a bit of clarification in the VM
resource on why only a resource pool is accepted - this can be expanded
on after we add the cluster and standalone host data sources. I've also
rephrased the explanation in the `vsphere_resource_pool` documentation so
that it's bit more clear what the root resource pool is and that this
logic also applies to standalone hosts. Also, the language has been
changed from using "default" to using "root", so that it's in line with
the vSphere official docs.

Fixes #326. 