### PR TITLE
r/virtual_machine: Fix NIC device offset misalignment crashes

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -743,27 +743,3 @@ func scsiControllerListString(ctlrs []types.BaseVirtualSCSIController) string {
 	}
 	return DeviceListString(l)
 }
-
-// unitRange calculates a range of units given a certain VirtualDeviceList.
-// It's mainly used in network interface refresh logic to determine how many
-// subresources may end up in state.
-func unitRange(l object.VirtualDeviceList) (int, error) {
-	// No NICs means no range
-	if len(l) < 1 {
-		return 0, nil
-	}
-	var low, high *int32
-	for _, v := range l {
-		d := v.GetVirtualDevice()
-		if d.UnitNumber == nil {
-			return 0, fmt.Errorf("device at key %d has no unit number", d.Key)
-		}
-		if low == nil || *d.UnitNumber < *low {
-			low = d.UnitNumber
-		}
-		if high == nil || *d.UnitNumber > *high {
-			high = d.UnitNumber
-		}
-	}
-	return int(*high - *low + 1), nil
-}

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource_test.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource_test.go
@@ -1,0 +1,117 @@
+package virtualdevice
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/structure"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestNicUnitRange(t *testing.T) {
+	cases := []struct {
+		name     string
+		devices  object.VirtualDeviceList
+		expected int
+	}{
+		{
+			name: "basic",
+			devices: object.VirtualDeviceList{
+				&types.VirtualVmxnet3{
+					VirtualVmxnet: types.VirtualVmxnet{
+						VirtualEthernetCard: types.VirtualEthernetCard{
+							VirtualDevice: types.VirtualDevice{
+								UnitNumber: structure.Int32Ptr(7),
+							},
+						},
+					},
+				},
+				&types.VirtualE1000{
+					VirtualEthernetCard: types.VirtualEthernetCard{
+						VirtualDevice: types.VirtualDevice{
+							UnitNumber: structure.Int32Ptr(8),
+						},
+					},
+				},
+				&types.VirtualE1000{
+					VirtualEthernetCard: types.VirtualEthernetCard{
+						VirtualDevice: types.VirtualDevice{
+							UnitNumber: structure.Int32Ptr(9),
+						},
+					},
+				},
+			},
+			expected: 3,
+		},
+		{
+			name: "single NIC not at first offset",
+			devices: object.VirtualDeviceList{
+				&types.VirtualVmxnet3{
+					VirtualVmxnet: types.VirtualVmxnet{
+						VirtualEthernetCard: types.VirtualEthernetCard{
+							VirtualDevice: types.VirtualDevice{
+								UnitNumber: structure.Int32Ptr(8),
+							},
+						},
+					},
+				},
+			},
+			expected: 2,
+		},
+		{
+			name: "hole in middle",
+			devices: object.VirtualDeviceList{
+				&types.VirtualVmxnet3{
+					VirtualVmxnet: types.VirtualVmxnet{
+						VirtualEthernetCard: types.VirtualEthernetCard{
+							VirtualDevice: types.VirtualDevice{
+								UnitNumber: structure.Int32Ptr(7),
+							},
+						},
+					},
+				},
+				&types.VirtualE1000{
+					VirtualEthernetCard: types.VirtualEthernetCard{
+						VirtualDevice: types.VirtualDevice{
+							UnitNumber: structure.Int32Ptr(9),
+						},
+					},
+				},
+			},
+			expected: 3,
+		},
+		{
+			name: "hole in middle and not starting at first offset",
+			devices: object.VirtualDeviceList{
+				&types.VirtualVmxnet3{
+					VirtualVmxnet: types.VirtualVmxnet{
+						VirtualEthernetCard: types.VirtualEthernetCard{
+							VirtualDevice: types.VirtualDevice{
+								UnitNumber: structure.Int32Ptr(8),
+							},
+						},
+					},
+				},
+				&types.VirtualE1000{
+					VirtualEthernetCard: types.VirtualEthernetCard{
+						VirtualDevice: types.VirtualDevice{
+							UnitNumber: structure.Int32Ptr(10),
+						},
+					},
+				},
+			},
+			expected: 4,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := nicUnitRange(tc.devices)
+			if err != nil {
+				t.Fatalf("bad: %s", err)
+			}
+			if tc.expected != actual {
+				t.Fatalf("expected %d, got %d", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Looks like `unitRange`, a virtual device (read: virtual NIC device) helper
that helps calculate the device unit range we need to account for when
refreshing devices, and also running post-clone device modification
operations, was not behaving as intended. We were incorrectly using the
current NIC set as the source of truth for the unit floor, in addition
to correctly using it for the device ceiling). This was creating issues
where the current NIC set started at an offset that was higher than
where NIC devices start on the PCI bus.

This fix corrects that - the NIC PCI device offset constant is now what
defines the device floor, and is immutable. The only thing that gets
modified is the ceiling. Added a few unit tests to back it up.

Also renamed the function `nicUnitRange` to reflect the fact that no other
device type is using this logic right now.

Fixes #341.