### PR TITLE
r/virtual_machine: New disk device naming and tracking behaviour

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,7 +14,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 180m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 240m
 
 debugacc: fmtcheck
 	TF_ACC=1 dlv test $(TEST) -- -test.v $(TESTARGS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,6 +16,9 @@ test: fmtcheck
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 180m
 
+debugacc: fmtcheck
+	TF_ACC=1 dlv test $(TEST) -- -test.v $(TESTARGS)
+
 vet:
 	@echo "go vet ."
 	@go vet $$(go list ./... | grep -v vendor/) ; if [ $$? -eq 1 ]; then \

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1424,7 +1424,7 @@ func (r *DiskSubresource) blockRelocateAttachedDisks() error {
 		return nil
 	}
 	if attach.(bool) {
-		return fmt.Errorf("externally attached disk %q cannot be migrated", r.Get("name"))
+		return fmt.Errorf("externally attached disk %q cannot be migrated", diskPathOrName(r.data))
 	}
 	return nil
 }

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -296,7 +296,7 @@ func diskApplyOperationDelete(
 		if name, err = diskLabelOrName(newData); err != nil {
 			return err
 		}
-		if name == diskDeletedName || name == diskDetachedName && oldData["uuid"] == newData["uuid"] {
+		if (name == diskDeletedName || name == diskDetachedName) && oldData["uuid"] == newData["uuid"] {
 			didx = ni
 			break
 		}
@@ -1320,6 +1320,9 @@ func (r *DiskSubresource) Diff() error {
 		if r.Get("size").(int) < 1 {
 			return fmt.Errorf("size for disk %q: required option not set", name)
 		}
+		// Carry forward path when attach is not set
+		opath, _ := r.GetChange("path")
+		r.Set("path", opath.(string))
 	}
 
 	// Set the datastore if it's missing as we infer this from the default

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1022,8 +1022,9 @@ func DiskImportOperation(d *schema.ResourceData, c *govmomi.Client, l object.Vir
 		}
 		m := make(map[string]interface{})
 		// Save information so that the next DiskRefreshOperation can pick this
-		// disk up as a new and not attempt to try and line up UUIDs. We use a key
-		// < 1 for this reason, in addition to assigning the device address.
+		// disk up as if it was newly added and not attempt to try and line up
+		// UUIDs. We use a negative key for this reason, in addition to assigning
+		// the device address.
 		m["key"] = (i + 1) * -1
 		m["device_address"] = addr
 		// Assign a computed label. This label *needs* be the label this disk is

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -89,11 +89,24 @@ func DiskSubresourceSchema() map[string]*schema.Schema {
 		},
 		"name": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "The file name of the disk. This can be either a name or path relative to the root of the datastore. If simply a name, the disk is located with the virtual machine.",
 			ValidateFunc: func(v interface{}, _ string) ([]string, []error) {
 				if path.Ext(v.(string)) != ".vmdk" {
 					return nil, []error{fmt.Errorf("disk name %s must end in .vmdk", v.(string))}
+				}
+				return nil, nil
+			},
+			Deprecated: "The name attribute for virtual disks will be removed in favor of \"label\" in future releases. To transition existing disks, rename the \"name\" attribute to \"label\". The name must stay the same, however this is not a requirement for new disks.",
+		},
+		"path": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "The full path of the virtual disk. This can only be provided if attach is set to true, otherwise it is a read-only value.",
+			ValidateFunc: func(v interface{}, _ string) ([]string, []error) {
+				if path.Ext(v.(string)) != ".vmdk" {
+					return nil, []error{fmt.Errorf("disk path %s must end in .vmdk", v.(string))}
 				}
 				return nil, nil
 			},
@@ -130,6 +143,11 @@ func DiskSubresourceSchema() map[string]*schema.Schema {
 			Default:     false,
 			Description: "If true, writes for this disk are sent directly to the filesystem immediately instead of being buffered.",
 		},
+		"uuid": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The UUID of the virtual disk.",
+		},
 
 		// StorageIOAllocationInfo
 		"io_limit": {
@@ -161,12 +179,19 @@ func DiskSubresourceSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.IntAtLeast(0),
 		},
 
-		// VirtualDisk/Other complex stuff
+		// VirtualDisk
 		"size": {
 			Type:         schema.TypeInt,
 			Optional:     true,
 			Description:  "The size of the disk, in GB.",
 			ValidateFunc: validation.IntAtLeast(1),
+		},
+
+		// Complex terraform-local things
+		"label": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "A unique label for this disk.",
 		},
 		"unit_number": {
 			Type:         schema.TypeInt,
@@ -238,26 +263,11 @@ func DiskApplyOperation(d *schema.ResourceData, c *govmomi.Client, l object.Virt
 	// Our old and new sets now have an accurate description of devices that may
 	// have been added, removed, or changed. Look for removed devices first.
 	log.Printf("[DEBUG] DiskApplyOperation: Looking for resources to delete")
-nextOld:
 	for oi, oe := range ods {
 		om := oe.(map[string]interface{})
-		for _, ne := range nds {
-			nm := ne.(map[string]interface{})
-			if nm["name"] == diskDeletedName || nm["name"] == diskDetachedName {
-				// This is a "dummy" deleted resource and should be skipped over
-				continue
-			}
-			if om["key"] == nm["key"] {
-				continue nextOld
-			}
+		if err := diskApplyOperationDelete(oi, om, nds, c, d, &l, &spec); err != nil {
+			return nil, nil, err
 		}
-		r := NewDiskSubresource(c, d, om, nil, oi)
-		dspec, err := r.Delete(l)
-		if err != nil {
-			return nil, nil, fmt.Errorf("%s: %s", r.Addr(), err)
-		}
-		l = applyDeviceChange(l, dspec)
-		spec = append(spec, dspec...)
 	}
 
 	// Now check for creates and updates.  The results of this operation are
@@ -266,51 +276,11 @@ nextOld:
 	var updates []interface{}
 	log.Printf("[DEBUG] DiskApplyOperation: Looking for resources to create or update")
 	log.Printf("[DEBUG] DiskApplyOperation: Resources not being changed: %s", subresourceListString(updates))
-nextNew:
 	for ni, ne := range nds {
 		nm := ne.(map[string]interface{})
-		if nm["name"] == diskDeletedName || nm["name"] == diskDetachedName {
-			// This is a "dummy" deleted resource and should be skipped over
-			continue
+		if err := diskApplyOperationCreateUpdate(ni, nm, ods, c, d, &l, &spec, &updates); err != nil {
+			return nil, nil, err
 		}
-		for _, oe := range ods {
-			om := oe.(map[string]interface{})
-			if nm["key"] == om["key"] {
-				// This is an update
-				r := NewDiskSubresource(c, d, nm, om, ni)
-				// If the only thing changing here is the datastore, or keep_on_remove,
-				// this is a no-op as far as a device change is concerned. Datastore
-				// changes are handled during storage vMotion later on during the
-				// update phase. keep_on_remove is a Terraform-only attribute and only
-				// needs to be committed to state.
-				omc, err := copystructure.Copy(om)
-				if err != nil {
-					return nil, nil, fmt.Errorf("%s: error generating copy of old disk data: %s", r.Addr(), err)
-				}
-				omc.(map[string]interface{})["datastore_id"] = nm["datastore_id"]
-				omc.(map[string]interface{})["keep_on_remove"] = nm["keep_on_remove"]
-				if reflect.DeepEqual(omc, nm) {
-					updates = append(updates, r.Data())
-					continue nextNew
-				}
-				uspec, err := r.Update(l)
-				if err != nil {
-					return nil, nil, fmt.Errorf("%s: %s", r.Addr(), err)
-				}
-				l = applyDeviceChange(l, uspec)
-				spec = append(spec, uspec...)
-				updates = append(updates, r.Data())
-				continue nextNew
-			}
-		}
-		r := NewDiskSubresource(c, d, nm, nil, ni)
-		cspec, err := r.Create(l)
-		if err != nil {
-			return nil, nil, fmt.Errorf("%s: %s", r.Addr(), err)
-		}
-		l = applyDeviceChange(l, cspec)
-		spec = append(spec, cspec...)
-		updates = append(updates, r.Data())
 	}
 
 	log.Printf("[DEBUG] DiskApplyOperation: Post-apply final resource list: %s", subresourceListString(updates))
@@ -322,6 +292,108 @@ nextNew:
 	log.Printf("[DEBUG] DiskApplyOperation: Device config operations from apply: %s", DeviceChangeString(spec))
 	log.Printf("[DEBUG] DiskApplyOperation: Apply complete, returning updated spec")
 	return l, spec, nil
+}
+
+// diskApplyOperationDelete is an inner-loop helper for disk deletion
+// operations.
+func diskApplyOperationDelete(
+	index int,
+	oldData map[string]interface{},
+	newDataSet []interface{},
+	c *govmomi.Client,
+	d *schema.ResourceData,
+	l *object.VirtualDeviceList,
+	spec *[]types.BaseVirtualDeviceConfigSpec,
+) error {
+	didx := -1
+	for ni, ne := range newDataSet {
+		newData := ne.(map[string]interface{})
+		var name string
+		var err error
+		if name, err = diskLabelOrName(newData); err != nil {
+			return err
+		}
+		if name == diskDeletedName || name == diskDetachedName && oldData["uuid"] == newData["uuid"] {
+			didx = ni
+			break
+		}
+	}
+	if didx < 0 {
+		// Deleted entry not found
+		return nil
+	}
+	r := NewDiskSubresource(c, d, oldData, nil, index)
+	dspec, err := r.Delete(*l)
+	if err != nil {
+		return fmt.Errorf("%s: %s", r.Addr(), err)
+	}
+	*l = applyDeviceChange(*l, dspec)
+	*spec = append(*spec, dspec...)
+	return nil
+}
+
+// diskApplyOperationCreateUpdate is an inner-loop helper for disk creation and
+// update operations.
+func diskApplyOperationCreateUpdate(
+	index int,
+	newData map[string]interface{},
+	oldDataSet []interface{},
+	c *govmomi.Client,
+	d *schema.ResourceData,
+	l *object.VirtualDeviceList,
+	spec *[]types.BaseVirtualDeviceConfigSpec,
+	updates *[]interface{},
+) error {
+	var name string
+	var err error
+	if name, err = diskLabelOrName(newData); err != nil {
+		return err
+	}
+	if name == diskDeletedName || name == diskDetachedName {
+		// This is a "dummy" deleted resource and should be skipped over
+		return nil
+	}
+	for _, oe := range oldDataSet {
+		oldData := oe.(map[string]interface{})
+		if newData["uuid"] == oldData["uuid"] {
+			// This is an update
+			r := NewDiskSubresource(c, d, newData, oldData, index)
+			// If the only thing changing here is the datastore, or keep_on_remove,
+			// this is a no-op as far as a device change is concerned. Datastore
+			// changes are handled during storage vMotion later on during the
+			// update phase. keep_on_remove is a Terraform-only attribute and only
+			// needs to be committed to state.
+			omc, err := copystructure.Copy(oldData)
+			if err != nil {
+				return fmt.Errorf("%s: error generating copy of old disk data: %s", r.Addr(), err)
+			}
+			oldCopy := omc.(map[string]interface{})
+			oldCopy["datastore_id"] = newData["datastore_id"]
+			oldCopy["keep_on_remove"] = newData["keep_on_remove"]
+			if reflect.DeepEqual(oldCopy, newData) {
+				*updates = append(*updates, r.Data())
+				return nil
+			}
+			uspec, err := r.Update(*l)
+			if err != nil {
+				return fmt.Errorf("%s: %s", r.Addr(), err)
+			}
+			*l = applyDeviceChange(*l, uspec)
+			*spec = append(*spec, uspec...)
+			*updates = append(*updates, r.Data())
+			return nil
+		}
+	}
+	// New data was not found - this is a create operation
+	r := NewDiskSubresource(c, d, newData, nil, index)
+	cspec, err := r.Create(*l)
+	if err != nil {
+		return fmt.Errorf("%s: %s", r.Addr(), err)
+	}
+	*l = applyDeviceChange(*l, cspec)
+	*spec = append(*spec, cspec...)
+	*updates = append(*updates, r.Data())
+	return nil
 }
 
 // DiskRefreshOperation processes a refresh operation for all of the disks in
@@ -378,8 +450,8 @@ func DiskRefreshOperation(d *schema.ResourceData, c *govmomi.Client, l object.Vi
 				// Skip any of these keys as we won't be matching any of those anyway here
 				continue
 			}
-			if device.GetVirtualDevice().Key != int32(m["key"].(int)) {
-				// Skip any device that doesn't match key as well
+			if !diskUUIDMatch(device, m["uuid"].(string)) {
+				// Skip any device that doesn't match UUID
 				continue
 			}
 			// We should have our device -> resource match, so read now.
@@ -400,7 +472,7 @@ func DiskRefreshOperation(d *schema.ResourceData, c *govmomi.Client, l object.Vi
 	// Finally, any device that is still here is orphaned. They should be added
 	// as new devices.
 	log.Printf("[DEBUG] DiskRefreshOperation: Adding orphaned devices")
-	for _, device := range devices {
+	for i, device := range devices {
 		m := make(map[string]interface{})
 		vd := device.GetVirtualDevice()
 		ctlr := l.FindByKey(vd.ControllerKey)
@@ -420,6 +492,8 @@ func DiskRefreshOperation(d *schema.ResourceData, c *govmomi.Client, l object.Vi
 		if err := r.Read(l); err != nil {
 			return fmt.Errorf("%s: %s", r.Addr(), err)
 		}
+		// Add a generic label indicating that this disk is orphaned.
+		r.Set("label", fmt.Sprintf("orphaned_disk_%d", i))
 		newSet = append(newSet, r.Data())
 	}
 
@@ -467,38 +541,6 @@ func DiskDestroyOperation(d *schema.ResourceData, c *govmomi.Client, l object.Vi
 	return spec, nil
 }
 
-// protectDiskDeleteRename is a fail-safe to prevent a VM rename operation from
-// accidentally deleting any disks that may be based on the previous name of
-// the virtual machine. This scenario is plausible when using a common variable
-// to help name both the virtual machine and the disks associated with it.
-func protectDiskDeleteRename(d *schema.ResourceDiff, old, new []interface{}) error {
-	o, n := d.GetChange("name")
-	oldVMName := o.(string)
-	newVMName := n.(string)
-
-	var deletedDisks []string
-
-	for i, ov := range old {
-		om := ov.(map[string]interface{})
-		oldDiskName := om["name"].(string)
-		if i >= len(new) {
-			break
-		}
-		if !strings.Contains(oldDiskName, oldVMName) {
-			continue
-		}
-		nm := new[i].(map[string]interface{})
-		newDiskName := nm["name"].(string)
-		if newDiskName == diskDeletedName || newDiskName == diskDetachedName {
-			deletedDisks = append(deletedDisks, oldDiskName)
-		}
-	}
-	if len(deletedDisks) > 0 {
-		return fmt.Errorf(diskDeleteRenameError, oldVMName, newVMName, strings.Join(deletedDisks, "\n"))
-	}
-	return nil
-}
-
 // DiskDiffOperation performs operations relevant to managing the diff on disk
 // sub-resources.
 //
@@ -516,41 +558,47 @@ func DiskDiffOperation(d *schema.ResourceDiff, c *govmomi.Client) error {
 	log.Printf("[DEBUG] DiskDiffOperation: Beginning disk diff customization")
 	o, n := d.GetChange(subresourceTypeDisk)
 	// Some global validation first. We handle individual validation later.
-	log.Printf("[DEBUG] DiskDiffOperation: Beginning diff validation (indexes aligned to new config)")
+	log.Printf("[DEBUG] DiskDiffOperation: Beginning collective diff validation (indexes aligned to new config)")
 	names := make(map[string]struct{})
+	attachments := make(map[string]struct{})
 	units := make(map[int]struct{})
 	if len(n.([]interface{})) < 1 {
 		return errors.New("there must be at least one disk specified")
 	}
 	for ni, ne := range n.([]interface{}) {
 		nm := ne.(map[string]interface{})
-		// Because we support long and short-form paths, we don't support duplicate
-		// file names right now, even if they are in a different path. This makes
-		// things slightly more inflexible but hopefully not enough to be seriously
-		// cumbersome to the use of the resource.
-		name := path.Base(nm["name"].(string))
+		name, err := diskLabelOrName(nm)
+		if err != nil {
+			return fmt.Errorf("disk.%d: %s", ni, err)
+		}
 		if _, ok := names[name]; ok {
 			return fmt.Errorf("disk: duplicate name %s", name)
 		}
+		// If attach is set, we need to validate that there's no other duplicate paths.
+		if nm["attach"].(bool) {
+			path := diskPathOrName(nm)
+			if path == "" {
+				return fmt.Errorf("disk.%d: path or name cannot be empty when using attach", ni)
+			}
+			if _, ok := attachments[path]; ok {
+				return fmt.Errorf("disk: multiple entries trying to attach external disk %s", path)
+			}
+			attachments[path] = struct{}{}
+		}
+
 		if _, ok := units[nm["unit_number"].(int)]; ok {
 			return fmt.Errorf("disk: duplicate unit_number %d", nm["unit_number"].(int))
 		}
 		names[name] = struct{}{}
 		units[nm["unit_number"].(int)] = struct{}{}
-		// Run the resource through an individual validate function. This performs
-		// field validation for things we don't need to know the state of other
-		// resources for.
-		r := NewDiskSubresource(c, d, nm, nil, ni)
-		if err := r.ValidateDiff(); err != nil {
-			return fmt.Errorf("%s: %s", r.Addr(), err)
-		}
+		// Run the resource through a pre-validate function. This does some single-value validation that is required before
 	}
 	if _, ok := units[0]; !ok {
 		return errors.New("at least one disk must have a unit_number of 0")
 	}
 
 	// Perform the normalization here.
-	log.Printf("[DEBUG] DiskDiffOperation: Beginning diff normalization (indexes aligned to old state)")
+	log.Printf("[DEBUG] DiskDiffOperation: Beginning diff validation and normalization (indexes aligned to old state)")
 	ods := o.([]interface{})
 	nds := n.([]interface{})
 
@@ -560,13 +608,18 @@ nextNew:
 		nm := ne.(map[string]interface{})
 		for oi, oe := range ods {
 			om := oe.(map[string]interface{})
-			// We extrapolate using the name as a "primary key" of sorts. Since we
-			// support both long-form and short-form paths, and don't support using
-			// same file name regardless of if you are using a long-from path, we
-			// just check the short-form and do the comparison from there.
-			if path.Base(nm["name"].(string)) == path.Base(om["name"].(string)) {
+			var oname, nname string
+			var err error
+			if oname, err = diskLabelOrName(om); err != nil {
+				return fmt.Errorf("disk.%d: %s", oi, err)
+			}
+			if nname, err = diskLabelOrName(nm); err != nil {
+				return fmt.Errorf("disk.%d: %s", oi, err)
+			}
+			// We extrapolate using the label as a "primary key" of sorts.
+			if nname == oname {
 				r := NewDiskSubresource(c, d, nm, om, oi)
-				if err := r.NormalizeDiff(); err != nil {
+				if err := r.Diff(); err != nil {
 					return fmt.Errorf("%s: %s", r.Addr(), err)
 				}
 				normalized[oi] = r.Data()
@@ -575,16 +628,17 @@ nextNew:
 		}
 		// We didn't find a match for this resource, it could be a new resource or
 		// significantly altered. Put it back on the list in the same form we got
-		// it in, but delete the key and device address first, just in case it was
-		// in a position previously occupied by an existing resource.
+		// it in, but all computed data first, just in case it was in a position
+		// previously occupied by an existing resource.
 		nm["key"] = 0
 		nm["device_address"] = ""
+		nm["uuid"] = ""
 		normalized = append(normalized, nm)
 	}
 
 	// Go thru the new list, and replace any nils with a "deleted" copy of the
 	// old resource. This is basically a copy of the old entry with <deleted> in
-	// place of the name, so it shows up nicely in the diff.
+	// place of the label, so it shows up nicely in the diff.
 	for ni, ne := range normalized {
 		if ne != nil {
 			continue
@@ -594,25 +648,18 @@ nextNew:
 			return fmt.Errorf("disk.%d: error making updated diff of deleted entry: %s", ni, err)
 		}
 		nm := nv.(map[string]interface{})
+		// Clear out the name. We put the message in label now, even if name was
+		// the item defined.  TODO: Remove this after 2.0.
+		nm["name"] = ""
 		switch {
 		case nm["keep_on_remove"].(bool):
 			fallthrough
 		case nm["attach"].(bool):
-			nm["name"] = diskDetachedName
+			nm["label"] = diskDetachedName
 		default:
-			nm["name"] = diskDeletedName
+			nm["label"] = diskDeletedName
 		}
 		normalized[ni] = nm
-	}
-
-	// Guard against an accidental deletion scenario that can reasonably come up
-	// when the name of the virtual machine and the logic for naming disks share
-	// a common variable. This can lead to issues when the variable is changed to
-	// rename the virtual machine.
-	if d.HasChange("name") {
-		if err := protectDiskDeleteRename(d, ods, normalized); err != nil {
-			return err
-		}
 	}
 
 	// All done. We can end the customization off by setting the new, normalized diff.
@@ -677,19 +724,14 @@ func DiskCloneValidateOperation(d *schema.ResourceDiff, c *govmomi.Client, l obj
 		// Load the target resource to do a few comparisons for correctness in config.
 		targetM := curSet[i].(map[string]interface{})
 		tr := NewDiskSubresource(c, d, targetM, nil, i)
-		// Ensure that the file names match. vSphere does not allow you to choose
-		// the name of existing disks during a clone and will rename them according
-		// to the standard convention of <name>.vmdk, <name>_1.vmdk, etc.  Hence we
-		// need to enforce this on all created VMs as well.
-		name := d.Get("name").(string)
-		expected := standardDiskName(name, i)
-		if tr.Get("name").(string) != expected {
-			return fmt.Errorf("%s: invalid disk name %q for cloning. Please rename this disk to %q", tr.Addr(), tr.Get("name").(string), expected)
-		}
 
 		// Do some pre-clone validation. This is mainly to make sure that the disks
 		// clone in a way that is consistent with configuration.
-		targetName := tr.Get("name").(string)
+		targetName, err := diskLabelOrName(tr.Data())
+		if err != nil {
+			return fmt.Errorf("%s: %s", tr.Addr(), err)
+		}
+		targetPath := r.Get("path").(string)
 		sourceSize := r.Get("size").(int)
 		targetSize := tr.Get("size").(int)
 		targetThin := tr.Get("thin_provisioned").(bool)
@@ -723,10 +765,10 @@ func DiskCloneValidateOperation(d *schema.ResourceDiff, c *govmomi.Client, l obj
 		// back an error if we see one of those.
 		ct, _, _, err := splitDevAddr(r.DevAddr())
 		if err != nil {
-			return fmt.Errorf("%s: error parsing device address after reading disk %q: %s", tr.Addr(), r.Get("name").(string), err)
+			return fmt.Errorf("%s: error parsing device address after reading disk %q: %s", tr.Addr(), targetPath, err)
 		}
 		if ct != SubresourceControllerTypeSCSI {
-			return fmt.Errorf("%s: unsupported controller type %s for disk %q. Please use a template with SCSI disks only", tr.Addr(), ct, tr.Get("name").(string))
+			return fmt.Errorf("%s: unsupported controller type %s for disk %q. Please use a template with SCSI disks only", tr.Addr(), ct, targetPath)
 		}
 	}
 	log.Printf("[DEBUG] DiskCloneValidateOperation: All disks in source validated successfully")
@@ -745,18 +787,22 @@ func DiskMigrateRelocateOperation(d *schema.ResourceData, c *govmomi.Client, l o
 	// We are only concerned with resources that would normally be updated, as
 	// incoming or outgoing disks obviously won't need migrating. Hence, this is
 	// a simplified subset of the normal apply logic.
-nextDisk:
 	for ni, ne := range nds.([]interface{}) {
 		nm := ne.(map[string]interface{})
-		if nm["name"] == diskDeletedName || nm["name"] == diskDetachedName {
+		var name string
+		var err error
+		if name, err = diskLabelOrName(nm); err != nil {
+			return nil, fmt.Errorf("disk.%d: %s", ni, err)
+		}
+		if name == diskDeletedName || name == diskDetachedName {
 			continue
 		}
 		for _, oe := range ods.([]interface{}) {
 			om := oe.(map[string]interface{})
-			if nm["key"] == om["key"] {
+			if nm["uuid"] == om["uuid"] {
 				// No change in datastore is a no-op, unless we are changing default datastores
 				if nm["datastore_id"] == om["datastore_id"] && !d.HasChange("datastore_id") {
-					continue nextDisk
+					break
 				}
 				r := NewDiskSubresource(c, d, nm, om, ni)
 				relocator, err := r.Relocate(l)
@@ -765,7 +811,7 @@ nextDisk:
 				}
 				if d.Get("datastore_id").(string) == relocator.Datastore.Value {
 					log.Printf("[DEBUG] %s: Datastore in spec is same as default, dropping in favor of implicit relocation", r.Addr())
-					continue nextDisk
+					break
 				}
 				relocators = append(relocators, relocator)
 			}
@@ -783,11 +829,11 @@ nextDisk:
 //
 // This differs from a regular storage vMotion in that we have no existing
 // devices in the resource to work off of - the disks in the source virtual
-// machine is purely our source of truth. These disks are assigned to our disk
+// machine is our source of truth. These disks are assigned to our disk
 // sub-resources in config and the relocate specs are generated off of the
-// filename and backing data defined in config, taking on these filenames when
-// cloned. After the clone is complete, natural re-configuration happens to
-// bring the disk configurations fully in sync with that is defined.
+// backing data defined in config, taking on these filenames when cloned. After
+// the clone is complete, natural re-configuration happens to bring the disk
+// configurations fully in sync with what is defined.
 func DiskCloneRelocateOperation(d *schema.ResourceData, c *govmomi.Client, l object.VirtualDeviceList) ([]types.VirtualMachineRelocateSpecDiskLocator, error) {
 	log.Printf("[DEBUG] DiskCloneRelocateOperation: Generating full disk relocate spec list")
 	devices := selectDisks(l, d.Get("scsi_controller_count").(int))
@@ -891,9 +937,10 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 			return nil, nil, fmt.Errorf("error copying current device state for disk at unit_number %d: %s", src["unit_number"].(int), err)
 		}
 		for k, v := range src {
-			// Skip name, datastore_id, and share count if share level isn't custom
+			// Skip label, name, datastore_id, and share count if share level isn't custom
+			// TODO: Remove "name" after 2.0
 			switch k {
-			case "name", "datastore_id":
+			case "label", "name", "datastore_id":
 				continue
 			case "io_share_count":
 				if src["io_share_level"] != string(types.SharesLevelCustom) {
@@ -937,41 +984,71 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 }
 
 // DiskImportOperation validates the disk configuration of the virtual
-// machine's VirtualDeviceList to ensure it will be imported properly.
+// machine's VirtualDeviceList to ensure it will be imported properly, and also
+// saves device addresses into state for disks defined in config. Both the
+// imported device list and the list of disks in config are sorted by their
+// respective unit numbers on the SCSI bus.
 func DiskImportOperation(d *schema.ResourceData, c *govmomi.Client, l object.VirtualDeviceList) error {
-	log.Printf("[DEBUG] DiskImportOperation: Performing disk import validation")
+	log.Printf("[DEBUG] DiskImportOperation: Performing pre-read import and validation of virtual disks")
 	devices := selectDisks(l, d.Get("scsi_controller_count").(int))
-	log.Printf("[DEBUG] DiskImportOperation: Disk devices located: %s", DeviceListString(devices))
+	// Sort the device list, in case it's not sorted already.
+	devSort := virtualDeviceListSorter{
+		Sort:       devices,
+		DeviceList: l,
+	}
+	log.Printf("[DEBUG] DiskImportOperation: Disk devices order before sort: %s", DeviceListString(devices))
+	sort.Sort(devSort)
+	devices = devSort.Sort
+	log.Printf("[DEBUG] DiskImportOperation: Disk devices order after sort: %s", DeviceListString(devices))
+	// Do the same for our listed disks.
+	curSet := d.Get(subresourceTypeDisk).([]interface{})
+	log.Printf("[DEBUG] DiskImportOperation: Current resource set: %s", subresourceListString(curSet))
+	sort.Sort(virtualDiskSubresourceSorter(curSet))
+	log.Printf("[DEBUG] DiskImportOperation: Resource set order after sort: %s", subresourceListString(curSet))
 
 	// Read in the disks. We don't do anything with the results here other than
 	// validate that the disks are SCSI disks. The read operation validates the rest.
-	log.Printf("[DEBUG] DiskImportOperation: Validating disks")
+	log.Printf("[DEBUG] DiskImportOperation: Validating disk type and saving ")
 	for i, device := range devices {
-		m := make(map[string]interface{})
+		if i >= len(curSet) {
+			break
+		}
+		m := curSet[i].(map[string]interface{})
 		vd := device.GetVirtualDevice()
 		ctlr := l.FindByKey(vd.ControllerKey)
 		if ctlr == nil {
 			return fmt.Errorf("could not find controller with key %d", vd.Key)
 		}
-		m["key"] = int(vd.Key)
-		var err error
-		m["device_address"], err = computeDevAddr(vd, ctlr.(types.BaseVirtualController))
+		addr, err := computeDevAddr(vd, ctlr.(types.BaseVirtualController))
 		if err != nil {
 			return fmt.Errorf("error computing device address: %s", err)
 		}
-		r := NewDiskSubresource(c, d, m, nil, i)
-		if err := r.Read(l); err != nil {
-			return fmt.Errorf("%s: %s", r.Addr(), err)
-		}
-		ct, _, _, err := splitDevAddr(r.DevAddr())
+		ct, _, _, err := splitDevAddr(addr)
 		if err != nil {
-			return fmt.Errorf("%s: error parsing device address after reading disk %q: %s", r.Addr(), r.Get("name").(string), err)
+			return fmt.Errorf("disk.%d: error parsing device address %s: %s", i, addr, err)
 		}
 		if ct != SubresourceControllerTypeSCSI {
-			return fmt.Errorf("%s: unsupported controller type %s for disk %q. The VM resource supports SCSI disks only", r.Addr(), ct, r.Get("name").(string))
+			return fmt.Errorf("disk.%d: unsupported controller type %s for disk %s. The VM resource supports SCSI disks only", i, ct, addr)
 		}
+		// As one final validation, as we are no longer reading here, validate that
+		// this is a VMDK-backed virtual disk to make sure we aren't importing RDM
+		// disks or what not. The device should have already been validated as a
+		// virtual disk via selectDisks.
+		if _, ok := device.(*types.VirtualDisk).Backing.(*types.VirtualDiskFlatVer2BackingInfo); !ok {
+			return fmt.Errorf(
+				"disk.%d: unsupported disk type at %s (expected flat VMDK version 2, got %T)",
+				i,
+				addr,
+				device.(*types.VirtualDisk).Backing,
+			)
+		}
+		m["device_address"] = addr
+		curSet[i] = m
 	}
-	log.Printf("[DEBUG] DiskImportOperation: Disk validation complete")
+	if err := d.Set(subresourceTypeDisk, curSet); err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] DiskImportOperation: Pre-read import and validation complete")
 	return nil
 }
 
@@ -996,7 +1073,7 @@ func ReadDiskAttrsForDataSource(l object.VirtualDeviceList, count int) ([]map[st
 		disk := device.(*types.VirtualDisk)
 		backing, ok := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
 		if !ok {
-			return nil, fmt.Errorf("disk number %d has an unsupported backing type (expected flat VMDK version 2, got %T", i, disk.Backing)
+			return nil, fmt.Errorf("disk number %d has an unsupported backing type (expected flat VMDK version 2, got %T)", i, disk.Backing)
 		}
 		m := make(map[string]interface{})
 		var eager, thin bool
@@ -1060,13 +1137,9 @@ func (r *DiskSubresource) Create(l object.VirtualDeviceList) ([]types.BaseVirtua
 // to the newData layer.
 func (r *DiskSubresource) Read(l object.VirtualDeviceList) error {
 	log.Printf("[DEBUG] %s: Reading state", r)
-	device, err := r.FindVirtualDevice(l)
+	disk, err := r.findVirtualDisk(l, true)
 	if err != nil {
 		return fmt.Errorf("cannot find disk device: %s", err)
-	}
-	disk, ok := device.(*types.VirtualDisk)
-	if !ok {
-		return fmt.Errorf("device at %q is not a virtual disk", l.Name(device))
 	}
 	unit, ctlr, err := r.findControllerInfo(l, disk)
 	if err != nil {
@@ -1087,6 +1160,7 @@ func (r *DiskSubresource) Read(l object.VirtualDeviceList) error {
 	if !ok {
 		return fmt.Errorf("disk backing at %s is of an unsupported type (type %T)", r.Get("device_address").(string), disk.Backing)
 	}
+	r.Set("uuid", b.Uuid)
 	r.Set("disk_mode", b.DiskMode)
 	r.Set("write_through", b.WriteThrough)
 
@@ -1102,45 +1176,13 @@ func (r *DiskSubresource) Read(l object.VirtualDeviceList) error {
 	}
 	r.Set("datastore_id", b.Datastore.Value)
 
-	// Walk up the child disk path until we have a path that matches our actual
-	// disk name. If there is no disk name, of if we can't find a match, just
-	// save the main backing.
-	origName := r.Get("name")
-	var name string
-	if origName != nil && origName.(string) != "" && !datastorePathHasBase(b.FileName, origName.(string)) && b.Parent != nil {
-		name = walkDiskBacking(b.Parent, origName.(string))
-	}
-	if name == "" {
-		name = b.FileName
-	}
-	dp := &object.DatastorePath{}
-	if ok := dp.FromString(name); !ok {
-		return fmt.Errorf("could not parse path from filename: %s", b.FileName)
-	}
-	// Validate that our names match on the base. If they don't, the disk we are
-	// looking for has either disappeared completely, or the name has changed in
-	// a way that we can't track it anymore. Treat this like an orphaned disk and
-	// ensure that keep_on_remove is set.
-	if origName != nil && origName.(string) != "" {
-		ob := path.Base(origName.(string))
-		cb := path.Base(dp.Path)
-		if ob != cb {
-			log.Printf(
-				"[DEBUG] %q on virtual machine %q: Disk name mismatch (key: %d, device_address: %q, expected: %q actual: %q) - treating disk as orphaned",
-				r,
-				r.rdd.Get("name").(string),
-				r.Get("key").(int),
-				r.Get("device_address").(string),
-				ob,
-				cb,
-			)
-			r.Set("keep_on_remove", true)
-		}
-	}
-	r.Set("name", dp.Path)
-
 	// Disk settings
 	if !attach {
+		dp := &object.DatastorePath{}
+		if ok := dp.FromString(b.FileName); !ok {
+			return fmt.Errorf("could not parse path from filename: %s", b.FileName)
+		}
+		r.Set("path", dp.Path)
 		r.Set("size", structure.ByteToGiB(disk.CapacityInBytes))
 	}
 
@@ -1159,13 +1201,9 @@ func (r *DiskSubresource) Read(l object.VirtualDeviceList) error {
 // Update updates a vsphere_virtual_machine disk sub-resource.
 func (r *DiskSubresource) Update(l object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
 	log.Printf("[DEBUG] %s: Beginning update", r)
-	device, err := r.FindVirtualDevice(l)
+	disk, err := r.findVirtualDisk(l, false)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find disk device: %s", err)
-	}
-	disk, ok := device.(*types.VirtualDisk)
-	if !ok {
-		return nil, fmt.Errorf("device at %q is not a virtual disk", l.Name(device))
 	}
 
 	// Has the unit number changed?
@@ -1208,13 +1246,9 @@ func (r *DiskSubresource) Update(l object.VirtualDeviceList) ([]types.BaseVirtua
 // Delete deletes a vsphere_virtual_machine disk sub-resource.
 func (r *DiskSubresource) Delete(l object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
 	log.Printf("[DEBUG] %s: Beginning delete", r)
-	device, err := r.FindVirtualDevice(l)
+	disk, err := r.findVirtualDisk(l, false)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find disk device: %s", err)
-	}
-	disk, ok := device.(*types.VirtualDisk)
-	if !ok {
-		return nil, fmt.Errorf("device at %q is not a virtual disk", l.Name(device))
 	}
 	deleteSpec, err := object.VirtualDeviceList{disk}.ConfigSpec(types.VirtualDeviceConfigSpecOperationRemove)
 	if err != nil {
@@ -1232,20 +1266,30 @@ func (r *DiskSubresource) Delete(l object.VirtualDeviceList) ([]types.BaseVirtua
 	return deleteSpec, nil
 }
 
-// ValidateDiff performs any complex validation of an individual disk
-// sub-resource that can't be done in schema alone.
-//
-// Do not use resourceData in this function as it's not populated and calls to
-// it will cause a panic.
-func (r *DiskSubresource) ValidateDiff() error {
-	log.Printf("[DEBUG] %s: Beginning diff validation (device information may be incomplete)", r)
-	name := r.Get("name").(string)
-
-	// name is a required field. If it's blank here, that means it's computed,
-	// which we don't allow either - so kick back an error.
-	if name == "" {
-		return fmt.Errorf("value of disk name cannot be computed")
+// Diff performs normalization and validation tasks for a specific disk
+// sub-resource's diff.
+func (r *DiskSubresource) Diff() error {
+	log.Printf("[DEBUG] %s: Beginning diff validation and normalization (device information may be incomplete)", r)
+	name, err := diskLabelOrName(r.data)
+	if err != nil {
+		return err
 	}
+
+	// Prevent a backward migration of label -> name. TODO: Remove this after
+	// 2.0.
+	olabel, nlabel := r.GetChange("label")
+	if olabel != "" && nlabel == "" {
+		return errors.New("cannot migrate from label to name")
+	}
+
+	// set some computed fields: key, device_address, and uuid will always be
+	// non-populated, so copy those.
+	okey, _ := r.GetChange("key")
+	odaddr, _ := r.GetChange("device_address")
+	ouuid, _ := r.GetChange("uuid")
+	r.Set("key", okey)
+	r.Set("device_address", odaddr)
+	r.Set("uuid", ouuid)
 
 	// Enforce the maximum unit number, which is the current value of
 	// scsi_controller_count * 15 - 1.
@@ -1256,8 +1300,7 @@ func (r *DiskSubresource) ValidateDiff() error {
 		return fmt.Errorf("unit_number on disk %q too high (%d) - maximum value is %d with %d SCSI controller(s)", name, currentUnit, maxUnit, ctlrCount)
 	}
 
-	switch r.Get("attach").(bool) {
-	case true:
+	if r.Get("attach").(bool) {
 		switch {
 		case r.Get("datastore_id").(string) == "":
 			return fmt.Errorf("datastore_id for disk %q is required when attach is set", name)
@@ -1268,31 +1311,13 @@ func (r *DiskSubresource) ValidateDiff() error {
 		case r.Get("keep_on_remove").(bool):
 			return fmt.Errorf("keep_on_remove for disk %q is implicit when attach is set, please remove this setting", name)
 		}
-	default:
+	} else {
+		// Enforce size as a required field when attach is not set
 		if r.Get("size").(int) < 1 {
 			return fmt.Errorf("size for disk %q: required option not set", name)
 		}
 	}
-	log.Printf("[DEBUG] %s: Diff validation complete", r)
-	return nil
-}
 
-// NormalizeDiff checks the diff for a vsphere_virtual_machine disk
-// sub-resource. It should be called after setting data and olddata to values
-// that seems similar enough to be possibly the same resource, after which this
-// function should then compare them and fill in any values that may be missing
-// from the new set due to computed values, such as inferred datastore or path
-// names.
-//
-// Do not use resourceData in this function as it's not populated and calls to
-// it will cause a panic.
-func (r *DiskSubresource) NormalizeDiff() error {
-	log.Printf("[DEBUG] %s: Beginning diff normalization (device information may be incomplete)", r)
-	// key and device_address will always be non-populated, so copy those.
-	okey, _ := r.GetChange("key")
-	odaddr, _ := r.GetChange("device_address")
-	r.Set("key", okey)
-	r.Set("device_address", odaddr)
 	// Set the datastore if it's missing as we infer this from the default
 	// datastore in that case
 	if r.Get("datastore_id") == "" {
@@ -1316,16 +1341,9 @@ func (r *DiskSubresource) NormalizeDiff() error {
 		r.Set("io_share_count", osc)
 	}
 
-	// Normalize the path. This should have already have been vetted as being
-	// ultimately the same path by the caller.
-	oname, _ := r.GetChange("name")
-	r.Set("name", oname)
-
 	// Ensure that the user is not attempting to shrink the disk. If we do more
 	// we might want to change the name of this method, but we want to check this
 	// here as CustomizeDiff is meant for vetoing.
-	name := r.Get("name").(string)
-
 	osize, nsize := r.GetChange("size")
 	if osize.(int) > nsize.(int) {
 		return fmt.Errorf("virtual disk %q: virtual disks cannot be shrunk (old: %d new: %d)", name, osize.(int), nsize.(int))
@@ -1360,7 +1378,7 @@ func (r *DiskSubresource) NormalizeDiff() error {
 		}
 	}
 
-	log.Printf("[DEBUG] %s: Diff normalization complete", r)
+	log.Printf("[DEBUG] %s: Diff validation and normalization complete", r)
 	return nil
 }
 
@@ -1387,39 +1405,7 @@ func (r *DiskSubresource) validateStorageRelocateDiff() error {
 	if err := r.blockRelocateAttachedDisks(); err != nil {
 		return err
 	}
-	if err := r.blockRelocateInvalidName(); err != nil {
-		return err
-	}
-	if err := r.blockRelocateLinkedClone(); err != nil {
-		return err
-	}
 	log.Printf("[DEBUG] %s: Storage vMotion validation successful", r)
-	return nil
-}
-
-func (r *DiskSubresource) blockRelocateInvalidName() error {
-	vmName := r.rdd.Get("name").(string)
-	diskPath := r.Get("name").(string)
-	expected := standardDiskName(vmName, r.Index)
-	actual := path.Base(diskPath)
-	if expected != actual {
-		return fmt.Errorf(
-			"virtual disk %q has an ineligible file name for migration (expected: %q)",
-			actual,
-			expected,
-		)
-	}
-	return nil
-}
-
-func (r *DiskSubresource) blockRelocateLinkedClone() error {
-	lc := r.rdd.Get("clone.0.linked_clone")
-	if lc == nil {
-		return nil
-	}
-	if lc.(bool) {
-		return fmt.Errorf("virtual disks of linked clones cannot be migrated")
-	}
 	return nil
 }
 
@@ -1438,14 +1424,10 @@ func (r *DiskSubresource) blockRelocateAttachedDisks() error {
 // and is used for both cloning and storage vMotion.
 func (r *DiskSubresource) Relocate(l object.VirtualDeviceList) (types.VirtualMachineRelocateSpecDiskLocator, error) {
 	log.Printf("[DEBUG] %s: Starting relocate generation", r)
-	device, err := r.FindVirtualDevice(l)
+	disk, err := r.findVirtualDisk(l, false)
 	var relocate types.VirtualMachineRelocateSpecDiskLocator
 	if err != nil {
 		return relocate, fmt.Errorf("cannot find disk device: %s", err)
-	}
-	disk, ok := device.(*types.VirtualDisk)
-	if !ok {
-		return relocate, fmt.Errorf("device at %q is not a virtual disk", l.Name(device))
 	}
 
 	// Expand all of the necessary disk settings first. This ensures all backing
@@ -1473,17 +1455,10 @@ func (r *DiskSubresource) Relocate(l object.VirtualDeviceList) (types.VirtualMac
 	if r.rdd.Id() == "" {
 		log.Printf("[DEBUG] %s: Adding additional options to relocator for cloning", r)
 
-		// Set the new name. This is basically the same logic as create.
-		diskName := r.Get("name").(string)
-		vmxPath := r.rdd.Get("vmx_path").(string)
-		if path.Base(diskName) == diskName && vmxPath != "" {
-			diskName = path.Join(path.Dir(vmxPath), diskName)
-		}
-
 		backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
-		backing.FileName = ds.Path(diskName)
+		backing.FileName = ds.Path("")
 		backing.Datastore = &dsref
-		relocate.DiskBackingInfo = disk.Backing
+		relocate.DiskBackingInfo = backing
 	}
 
 	// Done!
@@ -1493,13 +1468,13 @@ func (r *DiskSubresource) Relocate(l object.VirtualDeviceList) (types.VirtualMac
 }
 
 // String prints out the disk sub-resource's information including the ID at
-// time of instantiation, the short name of the disk, and the current device
+// time of instantiation, the label of the disk, and the current device
 // key and address.
 func (r *DiskSubresource) String() string {
-	n := r.Get("name")
+	n, err := diskLabelOrName(r.data)
 	var name string
-	if n != nil {
-		name = path.Base(n.(string))
+	if err != nil {
+		name = n
 	} else {
 		name = "<unknown>"
 	}
@@ -1570,15 +1545,12 @@ func (r *DiskSubresource) createDisk(l object.VirtualDeviceList) (*types.Virtual
 	}
 	dsref := ds.Reference()
 
-	// Determine the full path to the disk if no directory is specified. The path
-	// is the same path as the VMX file's current location. If we don't have a
-	// VMX file path right now, don't worry about it - this means that the VM is
-	// just being created and the file will be created in a directory of the same
-	// name as the VMX file that is being created.
-	diskName := r.Get("name").(string)
-	vmxPath := r.rdd.Get("vmx_path").(string)
-	if path.Base(diskName) == diskName && vmxPath != "" {
-		diskName = path.Join(path.Dir(vmxPath), diskName)
+	var diskName string
+	if r.Get("attach").(bool) {
+		// No path interpolation is performed any more for attached disks - the
+		// provided path must be the full path to the virtual disk you want to
+		// attach.
+		diskName = diskPathOrName(r.data)
 	}
 
 	disk := &types.VirtualDisk{
@@ -1751,19 +1723,6 @@ func (s virtualDiskSubresourceSorter) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-// walkDiskBacking walks up a disk backing's parent disk chain looking for the
-// supplied file name. It returns the full filename/datastore combination when
-// it finds it, otherwise returns nothing.
-func walkDiskBacking(b *types.VirtualDiskFlatVer2BackingInfo, name string) string {
-	if datastorePathHasBase(b.FileName, name) {
-		return b.FileName
-	}
-	if b.Parent != nil {
-		return walkDiskBacking(b.Parent, name)
-	}
-	return ""
-}
-
 // datastorePathHasBase is a helper to check if a datastore path's file matches
 // a supplied file name.
 func datastorePathHasBase(p, b string) bool {
@@ -1797,16 +1756,101 @@ func selectDisks(l object.VirtualDeviceList, count int) object.VirtualDeviceList
 	return devices
 }
 
-// standardDiskName returns a disk name that matches the vSphere naming
-// convention for virtual disks:
+// diskLabelOrName is a helper method that returns the unique label for a disk
+// - either its label or name. An error is returned if both are defined.
 //
-// * The first disk is named VMNAME.vmdk (index = 0)
-// * The second disk is named VMNAME_1.vmdk (index = 1)
-// * All subsequent disks are named VMNAME_INDEX.vmdk (as per index = 1)
-func standardDiskName(name string, index int) string {
-	var extra string
-	if index > 0 {
-		extra = fmt.Sprintf("_%d", index)
+// TODO: This method will be removed in future releases.
+func diskLabelOrName(data map[string]interface{}) (string, error) {
+	var label, name string
+	if v, ok := data["label"]; ok && v != nil {
+		label = v.(string)
 	}
-	return fmt.Sprintf("%s%s.vmdk", name, extra)
+	if v, ok := data["name"]; ok && v != nil {
+		name = v.(string)
+	}
+	switch {
+	case label == "" && name == "":
+		return "", errors.New("disk label or name must be defined and cannot be computed")
+	case label != "" && name != "":
+		return "", errors.New("disk label and name cannot be defined at the same time")
+	case label != "":
+		log.Printf("[DEBUG] diskLabelOrName: Using defined label value: %s", label)
+		return label, nil
+	}
+	log.Printf("[DEBUG] diskLabelOrName: Using defined name value as fallback: %s", name)
+	return name, nil
+}
+
+// diskPathOrName is a helper method that returns the path for a disk - either
+// its path attribute or name as a fallback.
+//
+// TODO: This method will be removed in future releases.
+func diskPathOrName(data map[string]interface{}) string {
+	var path, name string
+	if v, ok := data["path"]; ok && v != nil {
+		path = v.(string)
+	}
+	if v, ok := data["name"]; ok && v != nil {
+		name = v.(string)
+	}
+	if path != "" {
+		log.Printf("[DEBUG] diskPathOrName: Using defined path value: %s", path)
+		return path
+	}
+	log.Printf("[DEBUG] diskPathOrName: Using defined name value as fallback: %s", name)
+	return name
+}
+
+// findVirtualDisk locates a virtual disk by it UUID, or by its device address
+// if UUID is missing.
+//
+// The device address search is only used if fallback is true - this is so that
+// we can distinguish situations where it should be used, such as a read,
+// versus situations where it should never be used, such as an update or
+// delete.
+func (r *DiskSubresource) findVirtualDisk(l object.VirtualDeviceList, fallback bool) (*types.VirtualDisk, error) {
+	device, err := r.findVirtualDiskByUUIDOrAddress(l, fallback)
+	if err != nil {
+		return nil, err
+	}
+	return device.(*types.VirtualDisk), nil
+}
+
+func (r *DiskSubresource) findVirtualDiskByUUIDOrAddress(l object.VirtualDeviceList, fallback bool) (types.BaseVirtualDevice, error) {
+	var uuid string
+	if v := r.Get("uuid"); v != nil {
+		uuid = v.(string)
+	}
+	switch {
+	case uuid == "" && fallback:
+		return r.FindVirtualDevice(l)
+	case uuid == "" && !fallback:
+		return nil, errors.New("disk UUID is missing")
+	}
+	devices := l.Select(func(device types.BaseVirtualDevice) bool {
+		return diskUUIDMatch(device, uuid)
+	})
+	switch {
+	case len(devices) < 1:
+		return nil, fmt.Errorf("virtual disk with UUID %s not found", uuid)
+	case len(devices) > 1:
+		// This is an edge/should never happen case
+		return nil, fmt.Errorf("multiple virtual disks with UUID %s found", uuid)
+	}
+	return devices[0], nil
+}
+
+func diskUUIDMatch(device types.BaseVirtualDevice, uuid string) bool {
+	disk, ok := device.(*types.VirtualDisk)
+	if !ok {
+		return false
+	}
+	backing, ok := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+	if !ok {
+		return false
+	}
+	if backing.Uuid != uuid {
+		return false
+	}
+	return true
 }

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -927,11 +927,13 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 			return nil, nil, fmt.Errorf("error copying current device state for disk at unit_number %d: %s", src["unit_number"].(int), err)
 		}
 		for k, v := range src {
-			// Skip label, name, datastore_id, and uuid. Also skip share_count if we
-			// the share level isn't custom.
-			// TODO: Remove "name" after 2.0
+			// Skip label, path (path will always be computed here as cloned disks
+			// are not being attached externally), name, datastore_id, and uuid. Also
+			// skip share_count if we the share level isn't custom.
+			//
+			// TODO: Remove "name" after 2.0.
 			switch k {
-			case "label", "name", "datastore_id", "uuid":
+			case "label", "path", "name", "datastore_id", "uuid":
 				continue
 			case "io_share_count":
 				if src["io_share_level"] != string(types.SharesLevelCustom) {

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -188,7 +188,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceVSphereVirtualMachineImport,
 		},
-		SchemaVersion: 2,
+		SchemaVersion: 3,
 		MigrateState:  resourceVSphereVirtualMachineMigrateState,
 		Schema:        s,
 	}

--- a/vsphere/resource_vsphere_virtual_machine_migrate.go
+++ b/vsphere/resource_vsphere_virtual_machine_migrate.go
@@ -126,11 +126,14 @@ func migrateVSphereVirtualMachineStateV2(is *terraform.InstanceState, meta inter
 	// machine. We leverage some of the special parts of the import functionality
 	// - namely validating disks, and flagging the VM as imported in the state to
 	// guard against someone adding customization to the configuration and
-	// accidentally forcing a new resource.
+	// accidentally forcing a new resource. To assist with the migration of state
+	// from V1 to V3 as well, we now pull in disk attribute data that is
+	// populated during the import process.
 	//
 	// Read will handle most of the population post-migration as it does for
 	// import, and there will be an unavoidable diff for TF-only options on the
-	// next plan.
+	// next plan. This diff should not require a reconfigure of the virtual
+	// machine.
 	client := meta.(*VSphereClient).vimClient
 	name := is.ID
 	id := is.Attributes["uuid"]

--- a/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
@@ -201,8 +201,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    label = "disk0"
+    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
   }
 
   clone {

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -1472,9 +1472,13 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 					{
 						Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone(os.Getenv("VSPHERE_DATASTORE2")),
 						Check: resource.ComposeTestCheckFunc(
+							copyStatePtr(&state),
 							testAccResourceVSphereVirtualMachineCheckExists(true),
 							testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("VSPHERE_DATASTORE2")),
-							testAccResourceVSphereVirtualMachineCheckVmdkDatastore("terraform-test.vmdk", os.Getenv("VSPHERE_DATASTORE2")),
+							func(s *terraform.State) error {
+								filename := path.Base(state.RootModule().Resources["vsphere_virtual_machine.vm"].Primary.Attributes["disk.0.path"])
+								return testAccResourceVSphereVirtualMachineCheckVmdkDatastore(filename, os.Getenv("VSPHERE_DATASTORE2"))(s)
+							},
 						),
 					},
 				},

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -769,6 +769,27 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 			},
 		},
 		{
+			"block disk label starting with orphaned prefix",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config:      testAccResourceVSphereVirtualMachineConfigBadOrphanedLabel(),
+						ExpectError: regexp.MustCompile(regexp.QuoteMeta(`disk label "orphaned_disk_0" cannot start with "orphaned_disk_"`)),
+						PlanOnly:    true,
+					},
+					{
+						Config: testAccResourceVSphereEmpty,
+						Check:  resource.ComposeTestCheckFunc(),
+					},
+				},
+			},
+		},
+		{
 			"clone from template",
 			resource.TestCase{
 				PreCheck: func() {
@@ -4018,6 +4039,69 @@ resource "vsphere_virtual_machine" "vm" {
     properties {
       "foo" = "bar"
     }
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
+		os.Getenv("VSPHERE_DATASTORE"),
+	)
+}
+
+func testAccResourceVSphereVirtualMachineConfigBadOrphanedLabel() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinux64Guest"
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    label = "orphaned_disk_0"
+    size  = 20
   }
 }
 `,

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -2227,12 +2227,12 @@ func testAccResourceVSphereVirtualMachineCheckMultiDevice(expectedD, expectedN [
 
 		for n, actual := range actualD {
 			if actual != expectedD[n] {
-				return fmt.Errorf("could not locate disk at index %d", n)
+				return fmt.Errorf("expected disk at index %d to be %t, got %t", n, expectedD[n], actual)
 			}
 		}
 		for n, actual := range actualN {
 			if actual != expectedN[n] {
-				return fmt.Errorf("could not locate network interface at index %d", n)
+				return fmt.Errorf("expected network interface at index %d to be %t, got %t", n, expectedN[n], actual)
 			}
 		}
 

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -25,15 +25,10 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-const diskDeleteRenameErrorExpectedHeader = `
-Terraform discovered disks that were being deleted or detached that contained
-the old virtual machine name during a virtual machine rename operation:
-`
-
 const (
-	testAccResourceVSphereVirtualMachineDiskNameEager     = "terraform-test-extra-eager.vmdk"
-	testAccResourceVSphereVirtualMachineDiskNameLazy      = "terraform-test-extra-lazy.vmdk"
-	testAccResourceVSphereVirtualMachineDiskNameThin      = "terraform-test-extra-thin.vmdk"
+	testAccResourceVSphereVirtualMachineDiskNameEager     = "terraform-test_1.vmdk"
+	testAccResourceVSphereVirtualMachineDiskNameLazy      = "terraform-test_2.vmdk"
+	testAccResourceVSphereVirtualMachineDiskNameThin      = "terraform-test_3.vmdk"
 	testAccResourceVSphereVirtualMachineDiskNameExtraVmdk = "terraform-test-vm-extra-disk.vmdk"
 	testAccResourceVSphereVirtualMachineStaticMacAddr     = "06:5c:89:2b:a0:64"
 	testAccResourceVSphereVirtualMachineAnnotation        = "Managed by Terraform"
@@ -714,7 +709,7 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 				Steps: []resource.TestStep{
 					{
 						Config:      testAccResourceVSphereVirtualMachineConfigComputedDisk(),
-						ExpectError: regexp.MustCompile("value of disk name cannot be computed"),
+						ExpectError: regexp.MustCompile("disk label or name must be defined and cannot be computed"),
 						PlanOnly:    true,
 					},
 					{
@@ -933,29 +928,6 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 					{
 						Config: testAccResourceVSphereEmpty,
 						Check:  resource.ComposeTestCheckFunc(),
-					},
-				},
-			},
-		},
-		{
-			"clone - prevent accidental disk deletion from shared name variable",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereVirtualMachinePreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereVirtualMachineConfigCloneParameterized("terraform-test"),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereVirtualMachineCheckExists(true),
-						),
-					},
-					{
-						Config:      testAccResourceVSphereVirtualMachineConfigCloneParameterized("foo-test"),
-						ExpectError: regexp.MustCompile(diskDeleteRenameErrorExpectedHeader),
-						PlanOnly:    true,
 					},
 				},
 			},
@@ -1422,7 +1394,7 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 			},
 		},
 		{
-			"storage vmotion - block disk and name mismatch",
+			"storage vmotion - renamed virtual machine",
 			resource.TestCase{
 				PreCheck: func() {
 					testAccPreCheck(tp)
@@ -1449,15 +1421,17 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 					},
 					{
 						Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionRename("foobar-test", os.Getenv("VSPHERE_DATASTORE2")),
-						ExpectError: regexp.MustCompile(regexp.QuoteMeta(
-							`virtual disk "terraform-test.vmdk" has an ineligible file name for migration (expected: "foobar-test.vmdk")`,
-						)),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("VSPHERE_DATASTORE2")),
+							testAccResourceVSphereVirtualMachineCheckVmdkDatastore("foobar-test.vmdk", os.Getenv("VSPHERE_DATASTORE2")),
+						),
 					},
 				},
 			},
 		},
 		{
-			"storage vmotion - block linked clones",
+			"storage vmotion - linked clones",
 			resource.TestCase{
 				PreCheck: func() {
 					testAccPreCheck(tp)
@@ -1475,8 +1449,12 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 						),
 					},
 					{
-						Config:      testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone(os.Getenv("VSPHERE_DATASTORE2")),
-						ExpectError: regexp.MustCompile(regexp.QuoteMeta(`virtual disks of linked clones cannot be migrated`)),
+						Config: testAccResourceVSphereVirtualMachineConfigStorageVMotionLinkedClone(os.Getenv("VSPHERE_DATASTORE2")),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("VSPHERE_DATASTORE2")),
+							testAccResourceVSphereVirtualMachineCheckVmdkDatastore("terraform-test.vmdk", os.Getenv("VSPHERE_DATASTORE2")),
+						),
 					},
 				},
 			},
@@ -1504,6 +1482,173 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 						ExpectError: regexp.MustCompile(regexp.QuoteMeta(
 							fmt.Sprintf("externally attached disk %q cannot be migrated", testAccResourceVSphereVirtualMachineDiskNameExtraVmdk),
 						)),
+					},
+				},
+			},
+		},
+		{
+			"single custom attribute",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigWithCustomAttribute(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							testAccResourceVSphereVirtualMachineCheckCustomAttributes(),
+						),
+					},
+				},
+			},
+		},
+		{
+			"multi custom attribute",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigWithMultiCustomAttribute(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							testAccResourceVSphereVirtualMachineCheckCustomAttributes(),
+						),
+					},
+				},
+			},
+		},
+		{
+			"switch custom attribute",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigWithCustomAttribute(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							testAccResourceVSphereVirtualMachineCheckCustomAttributes(),
+						),
+					},
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigWithMultiCustomAttribute(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							testAccResourceVSphereVirtualMachineCheckCustomAttributes(),
+						),
+					},
+				},
+			},
+		},
+		// TODO: Remove this test in 2.0
+		{
+			"transition to label",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigBasicDiskNameOrLabel("name"),
+						Check: resource.ComposeTestCheckFunc(
+							copyState(&state),
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+						),
+					},
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigBasicDiskNameOrLabel("label"),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							func(s *terraform.State) error {
+								uuid := state.RootModule().Resources["vsphere_virtual_machine.vm"].Primary.Attributes["disk.0.uuid"]
+								return resource.TestCheckResourceAttr("vsphere_virtual_machine.vm", "disk.0.uuid", uuid)(s)
+							},
+						),
+					},
+				},
+			},
+		},
+		// TODO: Remove this test in 2.0
+		{
+			"prevent revert to name",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigBasicDiskNameOrLabel("name"),
+						Check: resource.ComposeTestCheckFunc(
+							copyState(&state),
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+						),
+					},
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigBasicDiskNameOrLabel("label"),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							func(s *terraform.State) error {
+								uuid := state.RootModule().Resources["vsphere_virtual_machine.vm"].Primary.Attributes["disk.0.uuid"]
+								return resource.TestCheckResourceAttr("vsphere_virtual_machine.vm", "disk.0.uuid", uuid)(s)
+							},
+						),
+					},
+					{
+						Config:      testAccResourceVSphereVirtualMachineConfigBasicDiskNameOrLabel("name"),
+						ExpectError: regexp.MustCompile("cannot migrate from label to name"),
+					},
+				},
+			},
+		},
+		// TODO: Remove this test in 2.0
+		{
+			"transition to label - attached disk",
+			resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(tp)
+					testAccResourceVSphereVirtualMachinePreCheck(tp)
+				},
+				Providers:    testAccProviders,
+				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigExistingVmdkWithName(),
+						Check: resource.ComposeTestCheckFunc(
+							copyState(&state),
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+						),
+					},
+					{
+						Config: testAccResourceVSphereVirtualMachineConfigExistingVmdkWithLabel(),
+						Check: resource.ComposeTestCheckFunc(
+							testAccResourceVSphereVirtualMachineCheckExists(true),
+							func(s *terraform.State) error {
+								uuid := state.RootModule().Resources["vsphere_virtual_machine.vm"].Primary.Attributes["disk.1.uuid"]
+								if err := resource.TestCheckResourceAttr("vsphere_virtual_machine.vm", "disk.1.uuid", uuid)(s); err != nil {
+									return err
+								}
+								return resource.TestCheckResourceAttr("vsphere_virtual_machine.vm", "disk.1.attach", "true")(s)
+							},
+						),
 					},
 				},
 			},
@@ -1581,73 +1726,6 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 						Config: testAccResourceVSphereVirtualMachineConfigMultiHighBus(),
 						Check: resource.ComposeTestCheckFunc(
 							testAccResourceVSphereVirtualMachineCheckExists(true),
-						),
-					},
-				},
-			},
-		},
-		{
-			"single custom attribute",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereVirtualMachinePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereVirtualMachineConfigWithCustomAttribute(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereVirtualMachineCheckExists(true),
-							testAccResourceVSphereVirtualMachineCheckCustomAttributes(),
-						),
-					},
-				},
-			},
-		},
-		{
-			"multi custom attribute",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereVirtualMachinePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereVirtualMachineConfigWithMultiCustomAttribute(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereVirtualMachineCheckExists(true),
-							testAccResourceVSphereVirtualMachineCheckCustomAttributes(),
-						),
-					},
-				},
-			},
-		},
-		{
-			"switch custom attribute",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereVirtualMachinePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereVirtualMachineConfigWithCustomAttribute(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereVirtualMachineCheckExists(true),
-							testAccResourceVSphereVirtualMachineCheckCustomAttributes(),
-						),
-					},
-					{
-						Config: testAccResourceVSphereVirtualMachineConfigWithMultiCustomAttribute(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereVirtualMachineCheckExists(true),
-							testAccResourceVSphereVirtualMachineCheckCustomAttributes(),
 						),
 					},
 				},
@@ -2524,8 +2602,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 `,
@@ -2574,8 +2652,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 `,
@@ -2646,18 +2724,18 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 
   disk {
-    name        = "terraform-test_1.vmdk"
+    label       = "disk1"
     unit_number = 1
     size        = 10
   }
 
   disk {
-    name        = "terraform-test_2.vmdk"
+    label       = "disk2"
     unit_number = 2
     size        = 5
   }
@@ -2734,18 +2812,18 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 
   disk {
-    name        = "terraform-test_1.vmdk"
+    label       = "disk1"
     unit_number = 15
     size        = 10
   }
 
   disk {
-    name        = "terraform-test_2.vmdk"
+    label       = "disk2"
     unit_number = 31
     size        = 5
   }
@@ -2815,12 +2893,12 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 
   disk {
-    name        = "terraform-test_2.vmdk"
+    label       = "disk2"
     unit_number = 2
     size        = 5
   }
@@ -2890,12 +2968,12 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 
   disk {
-    name        = "terraform-test_2.vmdk"
+    label       = "disk2"
     unit_number = 1
     size        = 5
   }
@@ -2974,8 +3052,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 
   cdrom {
@@ -3044,8 +3122,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 `,
@@ -3143,8 +3221,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 `,
@@ -3211,8 +3289,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 `,
@@ -3275,8 +3353,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = %d
+    label = "disk0"
+    size  = %d
   }
 }
 `,
@@ -3341,8 +3419,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 `,
@@ -3408,8 +3486,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 `,
@@ -3485,13 +3563,14 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 
   disk {
+    label        = "disk1"
     datastore_id = "${data.vsphere_datastore.datastore.id}"
-    name         = "${vsphere_virtual_disk.disk.vmdk_path}"
+    path         = "${vsphere_virtual_disk.disk.vmdk_path}"
     disk_mode    = "independent_persistent"
     attach       = true
     unit_number  = 1
@@ -3564,8 +3643,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 `,
@@ -3629,8 +3708,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 `,
@@ -3707,8 +3786,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 
   tags = [
@@ -3801,8 +3880,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 
   tags = ["${vsphere_tag.terraform-test-tags-alt.*.id}"]
@@ -3868,8 +3947,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test-${random_pet.pet.id}.vmdk"
-    size = 20
+    label = "terraform-test-${random_pet.pet.id}.vmdk"
+    size  = 20
   }
 }
 `,
@@ -3931,8 +4010,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 
   vapp {
@@ -4030,7 +4109,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -4071,132 +4150,6 @@ resource "vsphere_virtual_machine" "vm" {
 	)
 }
 
-func testAccResourceVSphereVirtualMachineConfigCloneParameterized(name string) string {
-	return fmt.Sprintf(`
-variable "datacenter" {
-  default = "%s"
-}
-
-variable "resource_pool" {
-  default = "%s"
-}
-
-variable "network_label" {
-  default = "%s"
-}
-
-variable "ipv4_address" {
-  default = "%s"
-}
-
-variable "ipv4_netmask" {
-  default = "%s"
-}
-
-variable "ipv4_gateway" {
-  default = "%s"
-}
-
-variable "dns_server" {
-  default = "%s"
-}
-
-variable "datastore" {
-  default = "%s"
-}
-
-variable "template" {
-  default = "%s"
-}
-
-variable "linked_clone" {
-  default = "%s"
-}
-
-variable "virtual_machine_name" {
-	default = "%s"
-}
-
-data "vsphere_datacenter" "dc" {
-  name = "${var.datacenter}"
-}
-
-data "vsphere_datastore" "datastore" {
-  name          = "${var.datastore}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
-}
-
-data "vsphere_resource_pool" "pool" {
-  name          = "${var.resource_pool}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
-}
-
-data "vsphere_network" "network" {
-  name          = "${var.network_label}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
-}
-
-data "vsphere_virtual_machine" "template" {
-  name          = "${var.template}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
-}
-
-resource "vsphere_virtual_machine" "vm" {
-  name             = "${var.virtual_machine_name}"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
-
-  num_cpus = 2
-  memory   = 2048
-  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
-
-  network_interface {
-    network_id   = "${data.vsphere_network.network.id}"
-    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
-  }
-
-  disk {
-    name             = "${var.virtual_machine_name}.vmdk"
-    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
-    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
-    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
-  }
-
-  clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
-    linked_clone  = "${var.linked_clone != "" ? "true" : "false" }"
-
-    customize {
-      linux_options {
-        host_name = "terraform-test"
-        domain    = "test.internal"
-      }
-
-      network_interface {
-        ipv4_address = "${var.ipv4_address}"
-        ipv4_netmask = "${var.ipv4_netmask}"
-      }
-
-      ipv4_gateway    = "${var.ipv4_gateway}"
-      dns_server_list = ["${var.dns_server}"]
-      dns_suffix_list = ["test.internal"]
-    }
-  }
-}
-`,
-		os.Getenv("VSPHERE_DATACENTER"),
-		os.Getenv("VSPHERE_RESOURCE_POOL"),
-		os.Getenv("VSPHERE_NETWORK_LABEL"),
-		os.Getenv("VSPHERE_IPV4_ADDRESS"),
-		os.Getenv("VSPHERE_IPV4_PREFIX"),
-		os.Getenv("VSPHERE_IPV4_GATEWAY"),
-		os.Getenv("VSPHERE_DNS"),
-		os.Getenv("VSPHERE_DATASTORE"),
-		os.Getenv("VSPHERE_TEMPLATE"),
-		os.Getenv("VSPHERE_USE_LINKED_CLONE"),
-		name,
-	)
-}
 func testAccResourceVSphereVirtualMachineConfigBadEager() string {
 	return fmt.Sprintf(`
 variable "datacenter" {
@@ -4278,7 +4231,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub == "true" ? "false" : "true"}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -4400,7 +4353,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned == "true" ? "false" : "true"}"
@@ -4522,7 +4475,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = 999
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -4644,7 +4597,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = 1
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -4768,7 +4721,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -4896,7 +4849,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -5020,7 +4973,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -5155,7 +5108,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -5287,7 +5240,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -5414,7 +5367,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -5525,7 +5478,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -5651,7 +5604,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -5774,7 +5727,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -5896,7 +5849,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -6026,15 +5979,15 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
   }
 
   disk {
+    label        = "disk1"
     datastore_id = "${data.vsphere_datastore.disk_datastore.id}"
-    name         = "terraform-test_1.vmdk"
     size         = 1
     unit_number  = 1
   }
@@ -6164,15 +6117,15 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
   }
 
   disk {
+    label        = "disk1"
     datastore_id = "${data.vsphere_datastore.disk_datastore.id}"
-    name         = "terraform-test_1.vmdk"
     size         = 1
     unit_number  = 1
   }
@@ -6282,18 +6235,6 @@ data "vsphere_virtual_machine" "template" {
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
-resource "null_resource" "disk_prefix" {
-  triggers = {
-    prefix = "${var.vm_name}"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      "triggers",
-    ]
-  }
-}
-
 resource "vsphere_virtual_machine" "vm" {
   name             = "${var.vm_name}"
   resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
@@ -6309,7 +6250,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "${null_resource.disk_prefix.triggers.prefix}.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -6431,7 +6372,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -6566,15 +6507,16 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
   }
 
   disk {
+    label        = "disk1"
     datastore_id = "${data.vsphere_datastore.datastore.id}"
-    name         = "${vsphere_virtual_disk.disk.vmdk_path}"
+    path         = "${vsphere_virtual_disk.disk.vmdk_path}"
     disk_mode    = "independent_persistent"
     attach       = true
     unit_number  = 1
@@ -6673,18 +6615,6 @@ variable "host" {
   default = "%s"
 }
 
-variable "disk_name_eager" {
-  default = "%s"
-}
-
-variable "disk_name_lazy" {
-  default = "%s"
-}
-
-variable "disk_name_thin" {
-  default = "%s"
-}
-
 data "vsphere_datacenter" "dc" {
   name = "${var.datacenter}"
 }
@@ -6735,14 +6665,14 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
   }
 
   disk {
-    name             = "${var.disk_name_eager}"
+    label            = "disk1"
     size             = 1
     unit_number      = 1
     thin_provisioned = false
@@ -6750,7 +6680,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "${var.disk_name_lazy}"
+    label            = "disk2"
     size             = 1
     unit_number      = 2
     thin_provisioned = false
@@ -6758,11 +6688,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name        = "${var.disk_name_thin}"
+    label       = "disk3"
     size        = 1
-    unit_number = 3
-  }
-
   clone {
     template_uuid = "${data.vsphere_virtual_machine.template.id}"
     linked_clone  = false
@@ -6798,9 +6725,6 @@ resource "vsphere_virtual_machine" "vm" {
 		os.Getenv("VSPHERE_DS_VMFS_DISK1"),
 		os.Getenv("VSPHERE_DS_VMFS_DISK2"),
 		os.Getenv("VSPHERE_ESXI_HOST"),
-		testAccResourceVSphereVirtualMachineDiskNameEager,
-		testAccResourceVSphereVirtualMachineDiskNameLazy,
-		testAccResourceVSphereVirtualMachineDiskNameThin,
 	)
 }
 
@@ -6887,7 +6811,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -7021,8 +6945,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    label = "disk0"
+    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
   }
 
   clone {
@@ -7168,8 +7092,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    label = "disk0"
+    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
   }
 
   clone {
@@ -7289,8 +7213,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    label = "disk0"
+    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
   }
 
   vapp {
@@ -7404,8 +7328,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    label = "disk0"
+    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
   }
 
   vapp {
@@ -7520,8 +7444,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    label = "disk0"
+    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
   }
 
   vapp {
@@ -7637,7 +7561,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name             = "terraform-test.vmdk"
+    label            = "disk0"
     size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
     eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
     thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
@@ -7681,5 +7605,243 @@ resource "vsphere_virtual_machine" "vm" {
 		os.Getenv("VSPHERE_DATASTORE"),
 		os.Getenv("VSPHERE_TEMPLATE"),
 		os.Getenv("VSPHERE_USE_LINKED_CLONE"),
+	)
+}
+
+// TODO: Remove this fixture in 2.0
+func testAccResourceVSphereVirtualMachineConfigBasicDiskNameOrLabel(nameKey string) string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinux64Guest"
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    %s    = "terraform-test.vmdk"
+    size  = 20
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
+		os.Getenv("VSPHERE_DATASTORE"),
+		nameKey,
+	)
+}
+
+// TODO: Remove this fixture in 2.0
+func testAccResourceVSphereVirtualMachineConfigExistingVmdkWithName() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+variable "extra_vmdk_name" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_virtual_disk" "disk" {
+  size         = 1
+  vmdk_path    = "${var.extra_vmdk_name}"
+  datacenter   = "${var.datacenter}"
+  datastore    = "${var.datastore}"
+  type         = "thin"
+  adapter_type = "lsiLogic"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinux64Guest"
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    name  = "terraform-test.vmdk"
+    size  = 20
+  }
+
+  disk {
+    name         = "${vsphere_virtual_disk.disk.vmdk_path}"
+    datastore_id = "${data.vsphere_datastore.datastore.id}"
+    disk_mode    = "independent_persistent"
+    attach       = true
+    unit_number  = 1
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
+		os.Getenv("VSPHERE_DATASTORE"),
+		testAccResourceVSphereVirtualMachineDiskNameExtraVmdk,
+	)
+}
+
+// TODO: Remove this fixture in 2.0
+func testAccResourceVSphereVirtualMachineConfigExistingVmdkWithLabel() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+variable "extra_vmdk_name" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_virtual_disk" "disk" {
+  size         = 1
+  vmdk_path    = "${var.extra_vmdk_name}"
+  datacenter   = "${var.datacenter}"
+  datastore    = "${var.datastore}"
+  type         = "thin"
+  adapter_type = "lsiLogic"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinux64Guest"
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    label = "terraform-test.vmdk"
+    size  = 20
+  }
+
+  disk {
+    label        = "${vsphere_virtual_disk.disk.vmdk_path}"
+    path         = "${vsphere_virtual_disk.disk.vmdk_path}"
+    datastore_id = "${data.vsphere_datastore.datastore.id}"
+    disk_mode    = "independent_persistent"
+    attach       = true
+    unit_number  = 1
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
+		os.Getenv("VSPHERE_DATASTORE"),
+		testAccResourceVSphereVirtualMachineDiskNameExtraVmdk,
 	)
 }

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -6690,6 +6690,9 @@ resource "vsphere_virtual_machine" "vm" {
   disk {
     label       = "disk3"
     size        = 1
+    unit_number = 3
+  }
+
   clone {
     template_uuid = "${data.vsphere_virtual_machine.template.id}"
     linked_clone  = false

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -85,8 +85,8 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    name = "terraform-test.vmdk"
-    size = 20
+    label = "disk0"
+    size  = 20
   }
 }
 ```


### PR DESCRIPTION
This resource implements the work discussed in #295, which significantly changes the way that we work with virtual disks in the `vsphere_virtual_machine` resource.

The changes are:

* Virtual disks are now addressed via the `label` attribute in configuration, rather than the `name` attribute, which previously dictated both the name of the virtual disk in configuration, and the actual VMDK filename on the virtual machine. This was problematic for several reasons that are discussed in #295.
* The `path` attribute has been implemented as a dual-purpose attribute that, depending on the setting of `attach`, either controls the path of the externally attached disk, or is a read-only computed attribute that gives the current path to the specific virtual disk (in the event of non-attached virtual disks).
* `uuid` has been added to track the lifecycle of a disk via the UUID of its VMDK backing. This now makes locating a virtual disk that has had its position on the SCSI bus modified much more stable, and should survive such destructive operations like swapping two disks that Terraform tracks around so that disk A is at disk B's position according to the state, and vice versa. Terraform should correctly change this during the next apply operating, versus the old behaviour of detaching the disks (a safeguard against the previous behaviour of complete deletion).

`name` has been kept, with a deprecation notice noting its planned removal (which will probably be in version 2.0 of the provider, which should be happening sometime in the early-mid spring). It currently acts as an fallback alias of sorts to `label` and `path`, with its old behaviour of controlling the name of the VMDK file on disk removed.

This means that we have been able to lift the following restrictions:

* Cloning no longer requires you to choose a disk label (name) that matches the name of the VM.
* Storage vMotion can now be performed on renamed virtual machines.
* Storage vMotion no longer cares what your disks are labeled (named).
* Storage vMotion now works on linked clones.

There is still the stipulation that if you import, you must choose a format on labels that matches the convention `diskN`, where N is the disk number, ordered by the disk's position on the SCSI bus. This however is a lot more stable and generic than the previous behaviour which required knowledge of the disk's VMDK filename.

Waiting on tests and will post the results when they are complete.

