### PR TITLE
r/virtual_machine: Fix template UUID lookup for older vSphere versions

### DIFF
--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -123,7 +123,7 @@ func virtualMachineFromContainerView(ctx context.Context, client *govmomi.Client
 
 	defer func() {
 		if err = v.Destroy(ctx); err != nil {
-			panic(err)
+			log.Printf("[DEBUG] virtualMachineFromContainerView: Unexpected error destroying container view: %s", err)
 		}
 	}()
 


### PR DESCRIPTION
Historically, the `FindByUuid` method under `SearchIndex` did not support
looking up VMs marked as template. However, at some point in time, this
was changed (possibly vSphere 6.5, based on bug reports), and any
mention of the UUID search not supporting templates was removed from the
API documentation, without a mention of when support for templates was
introduced. Since this is the method that we use to look up both VMs and
templates, this means that templates have not been functional for
vSphere <= 6.0 users since the resource was re-written in 1.0.

There has been a workaround in that the source template is just
converted back to virtual machine, but this update fixes it so that on
versions of vSphere older than 6.5, we fall back to using `ContainerView`
with a filter on the UUID. This works for all versions of vSphere. We
keep `FindByUuid` for 6.5 as it may possibly be more direct path.

-----

Fixes #271