### PR TITLE
r/virtual_machine: Switch ContainerView search to use manual filter

### DIFF
--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -128,7 +128,7 @@ func virtualMachineFromContainerView(ctx context.Context, client *govmomi.Client
 	}()
 
 	var vms, results []mo.VirtualMachine
-	err = v.Retrieve(ctx, []string{"VirtualMachine"}, nil, &results)
+	err = v.Retrieve(ctx, []string{"VirtualMachine"}, []string{"config.uuid"}, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -127,10 +127,19 @@ func virtualMachineFromContainerView(ctx context.Context, client *govmomi.Client
 		}
 	}()
 
-	var vms []mo.VirtualMachine
-	err = v.RetrieveWithFilter(ctx, []string{"VirtualMachine"}, []string{"summary"}, &vms, property.Filter{"config.uuid": uuid})
+	var vms, results []mo.VirtualMachine
+	err = v.Retrieve(ctx, []string{"VirtualMachine"}, nil, &results)
 	if err != nil {
 		return nil, err
+	}
+
+	for _, result := range results {
+		if result.Config == nil {
+			continue
+		}
+		if result.Config.Uuid == uuid {
+			vms = append(vms, result)
+		}
 	}
 
 	switch {


### PR DESCRIPTION
There seems like there is possibly a bug in `RetrieveWithFilter` when it
comes to MO's with missing keys and the function returning a false
positive for the object in question. This has caused issues with the VM
search functionality where duplicate UUID errors will be returned for
VMs with UUIDs that are otherwise unique within vSphere inventory if
there are orphaned VMs in inventory that lack a configuration (as in the
whole config data object is missing).

This bug applies to the provider when being used with vSphere 6.0 and
earlier.