### PR TITLE
r/virtual_machine: Address vCenter upgrade issues

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1094,7 +1094,7 @@ func ReadDiskAttrsForDataSource(l object.VirtualDeviceList, count int) ([]map[st
 		if backing.ThinProvisioned != nil {
 			thin = *backing.ThinProvisioned
 		}
-		m["size"] = int(structure.ByteToGiB(disk.CapacityInBytes).(int64))
+		m["size"] = diskCapacityInGiB(disk)
 		m["eagerly_scrub"] = eager
 		m["thin_provisioned"] = thin
 		out = append(out, m)
@@ -1194,7 +1194,7 @@ func (r *DiskSubresource) Read(l object.VirtualDeviceList) error {
 			return fmt.Errorf("could not parse path from filename: %s", b.FileName)
 		}
 		r.Set("path", dp.Path)
-		r.Set("size", structure.ByteToGiB(disk.CapacityInBytes))
+		r.Set("size", diskCapacityInGiB(disk))
 	}
 
 	if allocation := disk.StorageIOAllocation; allocation != nil {
@@ -1875,4 +1875,19 @@ func diskUUIDMatch(device types.BaseVirtualDevice, uuid string) bool {
 		return false
 	}
 	return true
+}
+
+// diskCapacityInGiB reports the supplied disk's capacity, by first checking
+// CapacityInBytes, and then falling back to CapacityInKB if that value is
+// unavailable. This helps correct some situations where the former value's
+// data gets cleared, which seems to happen on upgrades.
+func diskCapacityInGiB(disk *types.VirtualDisk) int {
+	if disk.CapacityInBytes > 0 {
+		return int(structure.ByteToGiB(disk.CapacityInBytes).(int64))
+	}
+	log.Printf(
+		"[DEBUG] diskCapacityInGiB: capacityInBytes missing for for %s, falling back to capacityInKB",
+		object.VirtualDeviceList{}.Name(disk),
+	)
+	return int(structure.ByteToGiB(disk.CapacityInKB * 1024).(int64))
 }

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1175,9 +1175,13 @@ func (r *DiskSubresource) Read(l object.VirtualDeviceList) error {
 	r.Set("disk_mode", b.DiskMode)
 	r.Set("write_through", b.WriteThrough)
 
-	// Only use disk_sharing if we are on vSphere 6.0 and higher
+	// Only use disk_sharing if we are on vSphere 6.0 and higher. In addition,
+	// skip if the value is unset - this prevents spurious diffs during upgrade
+	// situations where the VM hardware version does not actually allow disk
+	// sharing. In this situation, the value will be blank, and setting it will
+	// actually result in an error.
 	version := viapi.ParseVersionFromClient(r.client)
-	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
+	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) && b.Sharing != "" {
 		r.Set("disk_sharing", b.Sharing)
 	}
 

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource_test.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource_test.go
@@ -1,0 +1,39 @@
+package virtualdevice
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestDiskCapacityInGiB(t *testing.T) {
+	cases := []struct {
+		name     string
+		subject  *types.VirtualDisk
+		expected int
+	}{
+		{
+			name: "capacityInBytes",
+			subject: &types.VirtualDisk{
+				CapacityInBytes: 4294967296,
+				CapacityInKB:    4194304,
+			},
+			expected: 4,
+		},
+		{
+			name: "capacityInKB",
+			subject: &types.VirtualDisk{
+				CapacityInKB: 4194304,
+			},
+			expected: 4,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := diskCapacityInGiB(tc.subject)
+			if tc.expected != actual {
+				t.Fatalf("expected %d, got %d", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A couple of issues come up when vCenter is upgraded:

* First off, disk `capacityInBytes` values for virtual machine disk devices are cleared. This is a value we rely on to set the capacity of a disk, so a fallback to capacityInKB is necessary. This is specifically important for templates, as while VMs will be powered on and this value will be populated again, more than likely templates will remain off after the upgrade.
* Also post-upgrade, the VM hardware version of an existing virtual machine will not have been updated (this would need to be changed manually), hence `disk_sharing` will be unset and unusable. However, this value will now be read in by Terraform due to the upgraded vCenter, albeit with a blank value, and will trigger a diff that will ultimately result in an error. Hence, we skip setting the sharing value if it is blank.

Note that the second issue presents another problem that is not fixed by this PR, namely that if only vCenter is upgraded, and the hypervisors are not, more than likely deploying VMs using Terraform will fail until VMs can be deployed using a hardware version that supports disk sharing. This won't be fixed until we have some awareness around VM hardware versions, which is currently not the case.

Fixes #403. Possibly helps with #402 as well but would remain to be seen.