### PR TITLE
r/virtual_machine: Handle missing environment browser

### DIFF
--- a/tf-vsphere-devrc.mk.example
+++ b/tf-vsphere-devrc.mk.example
@@ -33,6 +33,7 @@ export VSPHERE_IPV4_GATEWAY        ?= 10.0.0.1   # Customization gateway
 export VSPHERE_DNS                 ?= 10.0.0.10  # Customization DNS
 export VSPHERE_DATACENTER          ?= vm-dc      # VM placement DC
 export VSPHERE_CLUSTER             ?= vm-clus1   # VM placement cluster
+export VSPHERE_EMPTY_CLUSTER       ?= vm-clus2   # Empty cluster for testing
 export VSPHERE_RESOURCE_POOL       ?= vm-respool # VM resource resource pool
 export VSPHERE_DATASTORE           ?= datastore1 # VM placement datastore
 export VSPHERE_DATASTORE2          ?= datastore2 # 2nd datastore for vMotion

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -803,10 +803,6 @@ func TestAccResourceVSphereVirtualMachine(t *testing.T) {
 						Config:      testAccResourceVSphereVirtualMachineConfigBasicEmptyCluster(),
 						ExpectError: regexp.MustCompile("compute resource .* is missing an Environment Browser\\. Check host, cluster, and vSphere license health of all associated resources and try again"),
 					},
-					{
-						Config: testAccResourceVSphereEmpty,
-						Check:  resource.ComposeTestCheckFunc(),
-					},
 				},
 			},
 		},


### PR DESCRIPTION
The virtual machine resource relies on the cluster or standalone host
it's deployed on for information regarding a default hardware set or
guest OS family information. This is obtained via the `EnvironmentBrowser`
MO referenced by the respective cluster or host's `ComputeResource` MO.

There are certain situations where this attribute will be missing, two
of which have been identified so far via bug reports:

* A cluster without hosts will not contain an environment browser.
* vSphere licensing issues may cause a missing environment browser (#409
reported an expired vCenter).

This update wraps our fetching of the environment browser by the two
current compute resource helpers that utilize it in a helper that
validates that we actually have an environment browser before proceeding
to load it up, issuing an error alluding to the above if it is missing.

Fixes #411.
May also correct #409.