### PR TITLE
Added a check for invalid ISO file on CD/DVD Drives

### DIFF
--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -663,3 +663,25 @@ func testResourceHasCustomAttributeValues(s *terraform.State, resourceType strin
 	}
 	return nil
 }
+
+func testSetOvfEnvironmentTransportIso(s *terraform.State, resourceName string) error {
+	vm, err := testGetVirtualMachine(s, resourceName)
+	if err != nil {
+		return err
+	}
+	if err := testPowerOffVM(s, resourceName); err != nil {
+		return err
+	}
+
+	spec := types.VirtualMachineConfigSpec{
+		VAppConfig: &types.VmConfigSpec{
+			OvfEnvironmentTransport: []string{"iso"},
+		},
+	}
+	virtualmachine.Reconfigure(vm, spec)
+	virtualmachine.PowerOn(vm)
+	if err := testPowerOffVM(s, resourceName); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -686,23 +686,23 @@ func testGetDatastoreClusterProperties(s *terraform.State, resourceName string) 
 }
 
 func testSetOvfEnvironmentTransportIso(s *terraform.State, resourceName string) error {
-    vm, err := testGetVirtualMachine(s, resourceName)
-    if err != nil {
-        return err
-    }
-    if err := testPowerOffVM(s, resourceName); err != nil {
-        return err
-    }
+	vm, err := testGetVirtualMachine(s, resourceName)
+	if err != nil {
+		return err
+	}
+	if err := testPowerOffVM(s, resourceName); err != nil {
+		return err
+	}
 
-    spec := types.VirtualMachineConfigSpec{
-        VAppConfig: &types.VmConfigSpec{
-            OvfEnvironmentTransport: []string{"iso"},
-        },
-    }
-    virtualmachine.Reconfigure(vm, spec)
-    virtualmachine.PowerOn(vm)
-    if err := testPowerOffVM(s, resourceName); err != nil {
-        return err
-    }
-    return nil
+	spec := types.VirtualMachineConfigSpec{
+		VAppConfig: &types.VmConfigSpec{
+			OvfEnvironmentTransport: []string{"iso"},
+		},
+	}
+	virtualmachine.Reconfigure(vm, spec)
+	virtualmachine.PowerOn(vm)
+	if err := testPowerOffVM(s, resourceName); err != nil {
+		return err
+	}
+	return nil
 }

--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -463,6 +463,8 @@ func (r *CdromSubresource) Read(l object.VirtualDeviceList) error {
 	switch backing := device.Backing.(type) {
 	case *types.VirtualCdromRemoteAtapiBackingInfo:
 		r.Set("client_device", true)
+	case *types.VirtualCdromRemotePassthroughBackingInfo:
+		r.Set("client_device", true)
 	case *types.VirtualCdromIsoBackingInfo:
 		dp := &object.DatastorePath{}
 		if ok := dp.FromString(backing.FileName); !ok {

--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -445,7 +445,10 @@ func (r *CdromSubresource) Read(l object.VirtualDeviceList) error {
 		if ok := dp.FromString(backing.FileName); !ok {
 			return fmt.Errorf("could not read datastore path in backing %q", backing.FileName)
 		}
-		r.Set("datastore_id", backing.Datastore.Value)
+		// It's possible to have an invalid ISO file due to OVF environment loading
+		if backing.Datastore != nil {
+			r.Set("datastore_id", backing.Datastore.Value)
+		}
 		r.Set("path", dp.Path)
 	}
 	// Save the device key and address data


### PR DESCRIPTION
This is a fix for #413.  

When a VM is created from a template or VM that has an OVF environment,  vSphere will create an ISO and mount it as CD/DVD Drive.  If subsequent VM are created in Terraform after the VM had the ISO loaded,  vSphere will report to Terraform that the CD/Drive is loaded with an ISO of path "[]".  The vSphere provider then tries to access an invalid Datastore field and causes a crash.  

This fix checks to make sure the Datastore is not nil before accessing it, otherwise it skips over it.