### PR TITLE
Convert all acceptance tests to individual tests

### DIFF
--- a/vsphere/data_source_vsphere_custom_attribute_test.go
+++ b/vsphere/data_source_vsphere_custom_attribute_test.go
@@ -7,50 +7,34 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereCustomAttribute(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereCustomAttributeCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereCustomAttributeConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr(
-								"data.vsphere_custom_attribute.terraform-test-attribute-data",
-								"name",
-								testAccDataSourceVSphereCustomAttributeConfigName,
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_custom_attribute.terraform-test-attribute-data",
-								"managed_object_type",
-								testAccDataSourceVSphereCustomAttributeConfigType,
-							),
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_custom_attribute.terraform-test-attribute-data", "id",
-								"vsphere_custom_attribute.terraform-test-attribute", "id",
-							),
-						),
-					},
-				},
+func TestAccDataSourceVSphereCustomAttribute_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereCustomAttributeConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.vsphere_custom_attribute.terraform-test-attribute-data",
+						"name",
+						testAccDataSourceVSphereCustomAttributeConfigName,
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_custom_attribute.terraform-test-attribute-data",
+						"managed_object_type",
+						testAccDataSourceVSphereCustomAttributeConfigType,
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_custom_attribute.terraform-test-attribute-data", "id",
+						"vsphere_custom_attribute.terraform-test-attribute", "id",
+					),
+				),
 			},
 		},
-	}
-
-	for _, tc := range testAccDataSourceVSphereCustomAttributeCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+	})
 }
 
 const testAccDataSourceVSphereCustomAttributeConfigName = "terraform-test-attribute"

--- a/vsphere/data_source_vsphere_datacenter_test.go
+++ b/vsphere/data_source_vsphere_datacenter_test.go
@@ -11,64 +11,48 @@ import (
 
 var testAccDataSourceVSphereDatacenterExpectedRegexp = regexp.MustCompile("^datacenter-")
 
-func TestAccDataSourceVSphereDatacenter(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereDatacenterCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereDatacenterPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereDatacenterConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestMatchResourceAttr(
-								"data.vsphere_datacenter.dc",
-								"id",
-								testAccDataSourceVSphereDatacenterExpectedRegexp,
-							),
-						),
-					},
-				},
+func TestAccDataSourceVSphereDatacenter_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereDatacenterPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDatacenterConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.vsphere_datacenter.dc",
+						"id",
+						testAccDataSourceVSphereDatacenterExpectedRegexp,
+					),
+				),
 			},
 		},
-		{
-			"default",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereDatacenterPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereDatacenterConfigDefault,
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestMatchResourceAttr(
-								"data.vsphere_datacenter.dc",
-								"id",
-								testAccDataSourceVSphereDatacenterExpectedRegexp,
-							),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccDataSourceVSphereDatacenterCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccDataSourceVSphereDatacenter_defaultDatacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereDatacenterPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDatacenterConfigDefault,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.vsphere_datacenter.dc",
+						"id",
+						testAccDataSourceVSphereDatacenterExpectedRegexp,
+					),
+				),
+			},
+		},
+	})
 }
 
 func testAccDataSourceVSphereDatacenterPreCheck(t *testing.T) {

--- a/vsphere/data_source_vsphere_datastore_test.go
+++ b/vsphere/data_source_vsphere_datastore_test.go
@@ -8,62 +8,46 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereDatastore(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereDatastoreCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereDatastorePreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereDatastoreConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_datastore.datastore_data", "id",
-								"vsphere_nas_datastore.datastore", "id",
-							),
-						),
-					},
-				},
+func TestAccDataSourceVSphereDatastore_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereDatastorePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDatastoreConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_datastore.datastore_data", "id",
+						"vsphere_nas_datastore.datastore", "id",
+					),
+				),
 			},
 		},
-		{
-			"no datacenter and absolute path",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereDatastorePreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereDatastoreConfigAbsolutePath(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_datastore.datastore_data", "id",
-								"vsphere_nas_datastore.datastore", "id",
-							),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccDataSourceVSphereDatastoreCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccDataSourceVSphereDatastore_noDatacenterAndAbsolutePath(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereDatastorePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDatastoreConfigAbsolutePath(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_datastore.datastore_data", "id",
+						"vsphere_nas_datastore.datastore", "id",
+					),
+				),
+			},
+		},
+	})
 }
 
 func testAccDataSourceVSphereDatastorePreCheck(t *testing.T) {

--- a/vsphere/data_source_vsphere_distributed_virtual_switch_test.go
+++ b/vsphere/data_source_vsphere_distributed_virtual_switch_test.go
@@ -8,126 +8,110 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereDistributedVirtualSwitch(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereDistributedVirtualSwitchCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereDistributedVirtualSwitchConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr(
-								"data.vsphere_distributed_virtual_switch.dvs-data",
-								"uplinks.#",
-								"2",
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_distributed_virtual_switch.dvs-data",
-								"uplinks.0",
-								"tfup1",
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_distributed_virtual_switch.dvs-data",
-								"uplinks.1",
-								"tfup2",
-							),
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_distributed_virtual_switch.dvs-data", "id",
-								"vsphere_distributed_virtual_switch.dvs", "id",
-							),
-						),
-					},
-				},
+func TestAccDataSourceVSphereDistributedVirtualSwitch_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDistributedVirtualSwitchConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.vsphere_distributed_virtual_switch.dvs-data",
+						"uplinks.#",
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_distributed_virtual_switch.dvs-data",
+						"uplinks.0",
+						"tfup1",
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_distributed_virtual_switch.dvs-data",
+						"uplinks.1",
+						"tfup2",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_distributed_virtual_switch.dvs-data", "id",
+						"vsphere_distributed_virtual_switch.dvs", "id",
+					),
+				),
 			},
 		},
-		{
-			"absolute path - no datacenter specified",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereDistributedVirtualSwitchConfigAbsolute(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr(
-								"data.vsphere_distributed_virtual_switch.dvs-data",
-								"uplinks.#",
-								"2",
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_distributed_virtual_switch.dvs-data",
-								"uplinks.0",
-								"tfup1",
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_distributed_virtual_switch.dvs-data",
-								"uplinks.1",
-								"tfup2",
-							),
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_distributed_virtual_switch.dvs-data", "id",
-								"vsphere_distributed_virtual_switch.dvs", "id",
-							),
-						),
-					},
-				},
-			},
-		},
-		{
-			"create portgroup",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereDistributedVirtualSwitchConfigWithPortgroup(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr(
-								"vsphere_distributed_port_group.pg",
-								"active_uplinks.#",
-								"1",
-							),
-							resource.TestCheckResourceAttr(
-								"vsphere_distributed_port_group.pg",
-								"standby_uplinks.#",
-								"1",
-							),
-							resource.TestCheckResourceAttr(
-								"vsphere_distributed_port_group.pg",
-								"active_uplinks.0",
-								"tfup1",
-							),
-							resource.TestCheckResourceAttr(
-								"vsphere_distributed_port_group.pg",
-								"standby_uplinks.0",
-								"tfup2",
-							),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccDataSourceVSphereDistributedVirtualSwitchCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccDataSourceVSphereDistributedVirtualSwitch_absolutePathNoDatacenterSpecified(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDistributedVirtualSwitchConfigAbsolute(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.vsphere_distributed_virtual_switch.dvs-data",
+						"uplinks.#",
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_distributed_virtual_switch.dvs-data",
+						"uplinks.0",
+						"tfup1",
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_distributed_virtual_switch.dvs-data",
+						"uplinks.1",
+						"tfup2",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_distributed_virtual_switch.dvs-data", "id",
+						"vsphere_distributed_virtual_switch.dvs", "id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVSphereDistributedVirtualSwitch_CreatePortgroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDistributedVirtualSwitchConfigWithPortgroup(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"vsphere_distributed_port_group.pg",
+						"active_uplinks.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						"vsphere_distributed_port_group.pg",
+						"standby_uplinks.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						"vsphere_distributed_port_group.pg",
+						"active_uplinks.0",
+						"tfup1",
+					),
+					resource.TestCheckResourceAttr(
+						"vsphere_distributed_port_group.pg",
+						"standby_uplinks.0",
+						"tfup2",
+					),
+				),
+			},
+		},
+	})
 }
 
 func testAccDataSourceVSphereDistributedVirtualSwitchConfig() string {

--- a/vsphere/data_source_vsphere_host_test.go
+++ b/vsphere/data_source_vsphere_host_test.go
@@ -9,65 +9,49 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereHost(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereHostCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereHostPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereHostConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestMatchResourceAttr(
-								"data.vsphere_host.host",
-								"id",
-								testAccDataSourceVSphereHostExpectedRegexp(),
-							),
-						),
-					},
-				},
+func TestAccDataSourceVSphereHost_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereHostPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereHostConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.vsphere_host.host",
+						"id",
+						testAccDataSourceVSphereHostExpectedRegexp(),
+					),
+				),
 			},
 		},
-		{
-			"default",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereHostPreCheck(tp)
-					testAccSkipIfNotEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereHostConfigDefault,
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestMatchResourceAttr(
-								"data.vsphere_host.host",
-								"id",
-								testAccDataSourceVSphereHostExpectedRegexp(),
-							),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccDataSourceVSphereHostCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccDataSourceVSphereHost_defaultHost(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereHostPreCheck(t)
+			testAccSkipIfNotEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereHostConfigDefault,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.vsphere_host.host",
+						"id",
+						testAccDataSourceVSphereHostExpectedRegexp(),
+					),
+				),
+			},
+		},
+	})
 }
 
 func testAccDataSourceVSphereHostPreCheck(t *testing.T) {

--- a/vsphere/data_source_vsphere_network_test.go
+++ b/vsphere/data_source_vsphere_network_test.go
@@ -8,106 +8,90 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereNetwork(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereNetworkCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"DVS portgroup",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereNetworkPreCheck(tp)
-					testAccSkipIfEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereNetworkConfigDVSPortgroup(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr("data.vsphere_network.net", "type", "DistributedVirtualPortgroup"),
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_network.net", "id",
-								"vsphere_distributed_port_group.pg", "id",
-							),
-						),
-					},
-				},
+func TestAccDataSourceVSphereNetwork_dvsPortgroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereNetworkPreCheck(t)
+			testAccSkipIfEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereNetworkConfigDVSPortgroup(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vsphere_network.net", "type", "DistributedVirtualPortgroup"),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_network.net", "id",
+						"vsphere_distributed_port_group.pg", "id",
+					),
+				),
 			},
 		},
-		{
-			"absolute path - no datacenter",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereNetworkPreCheck(tp)
-					testAccSkipIfEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereNetworkConfigDVSPortgroupAbsolute(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr("data.vsphere_network.net", "type", "DistributedVirtualPortgroup"),
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_network.net", "id",
-								"vsphere_distributed_port_group.pg", "id",
-							),
-						),
-					},
-				},
-			},
-		},
-		{
-			"host portgroups",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereNetworkPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereNetworkConfigHostPortgroup(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr("data.vsphere_network.net", "type", "Network"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"absolute path ending in the same name - govmomi #875",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereNetworkPreCheck(tp)
-					testAccSkipIfEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereNetworkConfigSimilarNet(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_network.net", "id",
-								"vsphere_distributed_port_group.pg1", "id",
-							),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccDataSourceVSphereNetworkCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccDataSourceVSphereNetwork_absolutePathNoDatacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereNetworkPreCheck(t)
+			testAccSkipIfEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereNetworkConfigDVSPortgroupAbsolute(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vsphere_network.net", "type", "DistributedVirtualPortgroup"),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_network.net", "id",
+						"vsphere_distributed_port_group.pg", "id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVSphereNetwork_hostPortgroups(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereNetworkPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereNetworkConfigHostPortgroup(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vsphere_network.net", "type", "Network"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVSphereNetwork_absolutePathEndingInSameName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereNetworkPreCheck(t)
+			testAccSkipIfEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereNetworkConfigSimilarNet(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_network.net", "id",
+						"vsphere_distributed_port_group.pg1", "id",
+					),
+				),
+			},
+		},
+	})
 }
 
 func testAccDataSourceVSphereNetworkPreCheck(t *testing.T) {

--- a/vsphere/data_source_vsphere_resource_pool_test.go
+++ b/vsphere/data_source_vsphere_resource_pool_test.go
@@ -9,99 +9,83 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereResourcePool(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereResourcePoolCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereResourcePoolPreCheck(tp)
-					testAccSkipIfEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereResourcePoolConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestMatchResourceAttr("data.vsphere_resource_pool.pool", "id", regexp.MustCompile("^resgroup-")),
-						),
-					},
-				},
+func TestAccDataSourceVSphereResourcePool_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereResourcePoolPreCheck(t)
+			testAccSkipIfEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereResourcePoolConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.vsphere_resource_pool.pool", "id", regexp.MustCompile("^resgroup-")),
+				),
 			},
 		},
-		{
-			"no datacenter and absolute path",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereResourcePoolPreCheck(tp)
-					testAccSkipIfEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereResourcePoolConfigAbsolutePath(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestMatchResourceAttr("data.vsphere_resource_pool.pool", "id", regexp.MustCompile("^resgroup-")),
-						),
-					},
-				},
-			},
-		},
-		{
-			"default resource pool for ESXi",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereResourcePoolPreCheck(tp)
-					testAccSkipIfNotEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereResourcePoolConfigDefault,
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestMatchResourceAttr("data.vsphere_resource_pool.pool", "id", regexp.MustCompile("^ha-root-pool$")),
-						),
-					},
-				},
-			},
-		},
-		{
-			"empty name on vCenter, should error",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereResourcePoolPreCheck(tp)
-					testAccSkipIfEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config:      testAccDataSourceVSphereResourcePoolConfigDefault,
-						ExpectError: regexp.MustCompile("name cannot be empty when using vCenter"),
-						PlanOnly:    true,
-					},
-					{
-						Config: testAccResourceVSphereEmpty,
-						Check:  resource.ComposeTestCheckFunc(),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccDataSourceVSphereResourcePoolCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccDataSourceVSphereResourcePool_noDatacenterAndAbsolutePath(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereResourcePoolPreCheck(t)
+			testAccSkipIfEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereResourcePoolConfigAbsolutePath(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.vsphere_resource_pool.pool", "id", regexp.MustCompile("^resgroup-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVSphereResourcePool_defaultResourcePoolForESXi(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereResourcePoolPreCheck(t)
+			testAccSkipIfNotEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereResourcePoolConfigDefault,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.vsphere_resource_pool.pool", "id", regexp.MustCompile("^ha-root-pool$")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVSphereResourcePool_emptyNameOnVCenterShouldError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereResourcePoolPreCheck(t)
+			testAccSkipIfEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceVSphereResourcePoolConfigDefault,
+				ExpectError: regexp.MustCompile("name cannot be empty when using vCenter"),
+				PlanOnly:    true,
+			},
+			{
+				Config: testAccResourceVSphereEmpty,
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
 }
 
 func testAccDataSourceVSphereResourcePoolPreCheck(t *testing.T) {

--- a/vsphere/data_source_vsphere_tag_category_test.go
+++ b/vsphere/data_source_vsphere_tag_category_test.go
@@ -7,65 +7,49 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereTagCategory(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereTagCategoryCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereTagCategoryConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr(
-								"data.vsphere_tag_category.terraform-test-category-data",
-								"name",
-								testAccDataSourceVSphereTagCategoryConfigName,
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_tag_category.terraform-test-category-data",
-								"description",
-								testAccDataSourceVSphereTagCategoryConfigDescription,
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_tag_category.terraform-test-category-data",
-								"cardinality",
-								testAccDataSourceVSphereTagCategoryConfigCardinality,
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_tag_category.terraform-test-category-data",
-								"associable_types.#",
-								"1",
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_tag_category.terraform-test-category-data",
-								"associable_types.3125094965",
-								testAccDataSourceVSphereTagCategoryConfigAssociableType,
-							),
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_tag_category.terraform-test-category-data", "id",
-								"vsphere_tag_category.terraform-test-category", "id",
-							),
-						),
-					},
-				},
+func TestAccDataSourceVSphereTagCategory_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereTagCategoryConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.vsphere_tag_category.terraform-test-category-data",
+						"name",
+						testAccDataSourceVSphereTagCategoryConfigName,
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_tag_category.terraform-test-category-data",
+						"description",
+						testAccDataSourceVSphereTagCategoryConfigDescription,
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_tag_category.terraform-test-category-data",
+						"cardinality",
+						testAccDataSourceVSphereTagCategoryConfigCardinality,
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_tag_category.terraform-test-category-data",
+						"associable_types.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_tag_category.terraform-test-category-data",
+						"associable_types.3125094965",
+						testAccDataSourceVSphereTagCategoryConfigAssociableType,
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_tag_category.terraform-test-category-data", "id",
+						"vsphere_tag_category.terraform-test-category", "id",
+					),
+				),
 			},
 		},
-	}
-
-	for _, tc := range testAccDataSourceVSphereTagCategoryCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+	})
 }
 
 const testAccDataSourceVSphereTagCategoryConfigName = "terraform-test-category"

--- a/vsphere/data_source_vsphere_tag_test.go
+++ b/vsphere/data_source_vsphere_tag_test.go
@@ -7,54 +7,38 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereTag(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereTagCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereTagConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr(
-								"data.vsphere_tag.terraform-test-tag-data",
-								"name",
-								testAccDataSourceVSphereTagConfigName,
-							),
-							resource.TestCheckResourceAttr(
-								"data.vsphere_tag.terraform-test-tag-data",
-								"description",
-								testAccDataSourceVSphereTagConfigDescription,
-							),
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_tag.terraform-test-tag-data", "id",
-								"vsphere_tag.terraform-test-tag", "id",
-							),
-							resource.TestCheckResourceAttrPair(
-								"data.vsphere_tag.terraform-test-tag-data", "category_id",
-								"vsphere_tag_category.terraform-test-category", "id",
-							),
-						),
-					},
-				},
+func TestAccDataSourceVSphereTag_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereTagConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.vsphere_tag.terraform-test-tag-data",
+						"name",
+						testAccDataSourceVSphereTagConfigName,
+					),
+					resource.TestCheckResourceAttr(
+						"data.vsphere_tag.terraform-test-tag-data",
+						"description",
+						testAccDataSourceVSphereTagConfigDescription,
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_tag.terraform-test-tag-data", "id",
+						"vsphere_tag.terraform-test-tag", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_tag.terraform-test-tag-data", "category_id",
+						"vsphere_tag_category.terraform-test-category", "id",
+					),
+				),
 			},
 		},
-	}
-
-	for _, tc := range testAccDataSourceVSphereTagCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+	})
 }
 
 const testAccDataSourceVSphereTagConfigName = "terraform-test-tag"

--- a/vsphere/data_source_vsphere_virtual_machine_test.go
+++ b/vsphere/data_source_vsphere_virtual_machine_test.go
@@ -9,76 +9,60 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereVirtualMachine(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereVirtualMachineCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereVirtualMachinePreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereVirtualMachineConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestMatchResourceAttr(
-								"data.vsphere_virtual_machine.template",
-								"id",
-								regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "guest_id"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "scsi_type"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.#"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.size"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.eagerly_scrub"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.thin_provisioned"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interface_types.#"),
-						),
-					},
-				},
+func TestAccDataSourceVSphereVirtualMachine_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereVirtualMachineConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.vsphere_virtual_machine.template",
+						"id",
+						regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "guest_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "scsi_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.size"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.eagerly_scrub"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.thin_provisioned"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interface_types.#"),
+				),
 			},
 		},
-		{
-			"no datacenter and absolute path",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereVirtualMachinePreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereVirtualMachineConfigAbsolutePath(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestMatchResourceAttr(
-								"data.vsphere_virtual_machine.template",
-								"id",
-								regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "guest_id"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "scsi_type"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.#"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.size"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.eagerly_scrub"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.thin_provisioned"),
-							resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interface_types.#"),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccDataSourceVSphereVirtualMachineCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccDataSourceVSphereVirtualMachine_noDatacenterAndAbsolutePath(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereVirtualMachineConfigAbsolutePath(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.vsphere_virtual_machine.template",
+						"id",
+						regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "guest_id"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "scsi_type"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.#"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.size"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.eagerly_scrub"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "disks.0.thin_provisioned"),
+					resource.TestCheckResourceAttrSet("data.vsphere_virtual_machine.template", "network_interface_types.#"),
+				),
+			},
+		},
+	})
 }
 
 func testAccDataSourceVSphereVirtualMachinePreCheck(t *testing.T) {

--- a/vsphere/data_source_vsphere_vmfs_disks_test.go
+++ b/vsphere/data_source_vsphere_vmfs_disks_test.go
@@ -117,7 +117,7 @@ data "vsphere_vmfs_disks" "available" {
 }
 
 output "expected_length" {
-  value = "${length(data.vsphere_vmfs_disks.available.disks) == 2 ? "true" : "false" }"
+  value = "${length(data.vsphere_vmfs_disks.available.disks) == 3 ? "true" : "false" }"
 }
 `, os.Getenv("VSPHERE_VMFS_REGEXP"), os.Getenv("VSPHERE_DATACENTER"), os.Getenv("VSPHERE_ESXI_HOST"))
 }

--- a/vsphere/data_source_vsphere_vmfs_disks_test.go
+++ b/vsphere/data_source_vsphere_vmfs_disks_test.go
@@ -8,56 +8,40 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceVSphereVmfsDisks(t *testing.T) {
-	var tp *testing.T
-	testAccDataSourceVSphereVmfsDisksCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereVmfsDisksPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereVmfsDisksConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckOutput("found", "true"),
-						),
-					},
-				},
+func TestAccDataSourceVSphereVmfsDisks_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereVmfsDisksPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereVmfsDisksConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("found", "true"),
+				),
 			},
 		},
-		{
-			"with regular expression",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccDataSourceVSphereVmfsDisksPreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccDataSourceVSphereVmfsDisksConfigRegexp(),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckOutput("expected_length", "true"),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccDataSourceVSphereVmfsDisksCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccDataSourceVSphereVmfsDisks_withRegularExpression(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereVmfsDisksPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereVmfsDisksConfigRegexp(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("expected_length", "true"),
+				),
+			},
+		},
+	})
 }
 
 func testAccDataSourceVSphereVmfsDisksPreCheck(t *testing.T) {

--- a/vsphere/resource_vsphere_custom_attribute_test.go
+++ b/vsphere/resource_vsphere_custom_attribute_test.go
@@ -9,148 +9,130 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccResourceVSphereCustomAttribute(t *testing.T) {
-	var tp *testing.T
-	testAccResourceVSphereCustomAttributeCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereCustomAttributeConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereCustomAttributeExists(true),
-							testAccResourceVSphereCustomAttributeHasName("terraform-test-attribute"),
-							testAccResourceVSphereCustomAttributeHasType(""),
-						),
-					},
-				},
+func TestAccResourceVSphereCustomAttribute_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereCustomAttributeConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereCustomAttributeExists(true),
+					testAccResourceVSphereCustomAttributeHasName("terraform-test-attribute"),
+					testAccResourceVSphereCustomAttributeHasType(""),
+				),
 			},
 		},
-		{
-			"with type",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereCustomAttributeConfigType,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereCustomAttributeExists(true),
-							testAccResourceVSphereCustomAttributeHasName("terraform-test-attribute"),
-							testAccResourceVSphereCustomAttributeHasType("VirtualMachine"),
-						),
-					},
-				},
+	})
+}
+func TestAccResourceVSphereCustomAttribute_withType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereCustomAttributeConfigType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereCustomAttributeExists(true),
+					testAccResourceVSphereCustomAttributeHasName("terraform-test-attribute"),
+					testAccResourceVSphereCustomAttributeHasType("VirtualMachine"),
+				),
 			},
 		},
-		{
-			"rename",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereCustomAttributeConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereCustomAttributeExists(true),
-						),
-					},
-					{
-						Config: testAccResourceVSphereCustomAttributeConfigAltName,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereCustomAttributeExists(true),
-							testAccResourceVSphereCustomAttributeHasName("terraform-test-attribute-renamed"),
-						),
-					},
-				},
+	})
+}
+func TestAccResourceVSphereCustomAttribute_rename(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereCustomAttributeConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereCustomAttributeExists(true),
+				),
+			},
+			{
+				Config: testAccResourceVSphereCustomAttributeConfigAltName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereCustomAttributeExists(true),
+					testAccResourceVSphereCustomAttributeHasName("terraform-test-attribute-renamed"),
+				),
 			},
 		},
-		{
-			"change type",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereCustomAttributeConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereCustomAttributeExists(true),
-							testAccResourceVSphereCustomAttributeHasType(""),
-						),
-					},
-					{
-						Config: testAccResourceVSphereCustomAttributeConfigType,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereCustomAttributeExists(true),
-							testAccResourceVSphereCustomAttributeHasType("VirtualMachine"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"import",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereCustomAttributeConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereCustomAttributeExists(true),
-						),
-					},
-					{
-						ResourceName:      "vsphere_custom_attribute.terraform-test-attribute",
-						ImportState:       true,
-						ImportStateVerify: true,
-						ImportStateIdFunc: func(s *terraform.State) (string, error) {
-							attr, err := testGetCustomAttribute(s, "terraform-test-attribute")
-							if err != nil {
-								return "", err
-							}
-							if attr == nil {
-								return "", errors.New("custom attribute does not exist")
-							}
-							return attr.Name, nil
-						},
-						Config: testAccResourceVSphereCustomAttributeConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereCustomAttributeExists(true),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccResourceVSphereCustomAttributeCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccResourceVSphereCustomAttribute_changeType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereCustomAttributeConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereCustomAttributeExists(true),
+					testAccResourceVSphereCustomAttributeHasType(""),
+				),
+			},
+			{
+				Config: testAccResourceVSphereCustomAttributeConfigType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereCustomAttributeExists(true),
+					testAccResourceVSphereCustomAttributeHasType("VirtualMachine"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereCustomAttribute_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereCustomAttributeExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereCustomAttributeConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereCustomAttributeExists(true),
+				),
+			},
+			{
+				ResourceName:      "vsphere_custom_attribute.terraform-test-attribute",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					attr, err := testGetCustomAttribute(s, "terraform-test-attribute")
+					if err != nil {
+						return "", err
+					}
+					if attr == nil {
+						return "", errors.New("custom attribute does not exist")
+					}
+					return attr.Name, nil
+				},
+				Config: testAccResourceVSphereCustomAttributeConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereCustomAttributeExists(true),
+				),
+			},
+		},
+	})
 }
 
 func testAccResourceVSphereCustomAttributeExists(expected bool) resource.TestCheckFunc {

--- a/vsphere/resource_vsphere_datacenter_test.go
+++ b/vsphere/resource_vsphere_datacenter_test.go
@@ -285,7 +285,6 @@ func testAccCheckVSphereDatacenterDestroy(s *terraform.State) error {
 		if err != nil {
 			switch err.(type) {
 			case *find.NotFoundError:
-				fmt.Printf("Expected error received: %s\n", err)
 				return nil
 			default:
 				return err
@@ -323,7 +322,6 @@ func testAccCheckVSphereDatacenterExists(n string, exists bool) resource.TestChe
 				if exists {
 					return fmt.Errorf("datacenter does not exist: %s", e.Error())
 				}
-				fmt.Printf("Expected error received: %s\n", e.Error())
 				return nil
 			default:
 				return err

--- a/vsphere/resource_vsphere_datacenter_test.go
+++ b/vsphere/resource_vsphere_datacenter_test.go
@@ -123,7 +123,7 @@ resource "vsphere_datacenter" "testDC" {
 `
 
 // Create a datacenter on the root folder
-func TestAccVSphereDatacenter_createOnRootFolder(t *testing.T) {
+func TestAccResourceVSphereDatacenter_createOnRootFolder(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -139,7 +139,7 @@ func TestAccVSphereDatacenter_createOnRootFolder(t *testing.T) {
 }
 
 // Create a datacenter on a subfolder
-func TestAccVSphereDatacenter_createOnSubfolder(t *testing.T) {
+func TestAccResourceVSphereDatacenter_createOnSubfolder(t *testing.T) {
 	dcFolder := os.Getenv("VSPHERE_DC_FOLDER")
 
 	resource.Test(t, resource.TestCase{
@@ -160,144 +160,112 @@ func TestAccVSphereDatacenter_createOnSubfolder(t *testing.T) {
 	})
 }
 
-func TestAccVSphereDatacenterTags(t *testing.T) {
-	var tp *testing.T
-	testAccResourceVSphereNasDatastoreCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"single tag",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckVSphereDatacenterDestroy,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccCheckVSphereDatacenterConfigTags,
-						Check: resource.ComposeTestCheckFunc(
-							testAccCheckVSphereDatacenterExists(
-								testAccCheckVSphereDatacenterResourceName,
-								true,
-							),
-							testAccResourceVSphereDatacenterCheckTags("terraform-test-tag"),
-						),
-					},
-				},
+func TestAccResourceVSphereDatacenter_singleTag(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVSphereDatacenterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVSphereDatacenterConfigTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVSphereDatacenterExists(
+						testAccCheckVSphereDatacenterResourceName,
+						true,
+					),
+					testAccResourceVSphereDatacenterCheckTags("terraform-test-tag"),
+				),
 			},
 		},
-		{
-			"modify tags",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckVSphereDatacenterDestroy,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccCheckVSphereDatacenterConfigTags,
-						Check: resource.ComposeTestCheckFunc(
-							testAccCheckVSphereDatacenterExists(
-								testAccCheckVSphereDatacenterResourceName,
-								true,
-							),
-							testAccResourceVSphereDatacenterCheckTags("terraform-test-tag"),
-						),
-					},
-					{
-						Config: testAccCheckVSphereDatacenterConfigMultiTags,
-						Check: resource.ComposeTestCheckFunc(
-							testAccCheckVSphereDatacenterExists(
-								testAccCheckVSphereDatacenterResourceName,
-								true,
-							),
-							testAccResourceVSphereDatacenterCheckTags("terraform-test-tags-alt"),
-						),
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testAccResourceVSphereNasDatastoreCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+	})
 }
 
-func TestAccVSphereDatacenterCustomAttributes(t *testing.T) {
-	var tp *testing.T
-	testAccResourceCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"single custom attribute",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckVSphereDatacenterDestroy,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccCheckVSphereDatacenterConfigCustomAttributes,
-						Check: resource.ComposeTestCheckFunc(
-							testAccCheckVSphereDatacenterExists(
-								testAccCheckVSphereDatacenterResourceName,
-								true,
-							),
-							testAccResourceVSphereDatacenterHasCustomAttributes(),
-						),
-					},
-				},
+func TestAccResourceVSphereDatacenter_modifyTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVSphereDatacenterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVSphereDatacenterConfigTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVSphereDatacenterExists(
+						testAccCheckVSphereDatacenterResourceName,
+						true,
+					),
+					testAccResourceVSphereDatacenterCheckTags("terraform-test-tag"),
+				),
+			},
+			{
+				Config: testAccCheckVSphereDatacenterConfigMultiTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVSphereDatacenterExists(
+						testAccCheckVSphereDatacenterResourceName,
+						true,
+					),
+					testAccResourceVSphereDatacenterCheckTags("terraform-test-tags-alt"),
+				),
 			},
 		},
-		{
-			"modify custom attribute",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccCheckVSphereDatacenterDestroy,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccCheckVSphereDatacenterConfigCustomAttributes,
-						Check: resource.ComposeTestCheckFunc(
-							testAccCheckVSphereDatacenterExists(
-								testAccCheckVSphereDatacenterResourceName,
-								true,
-							),
-							testAccResourceVSphereDatacenterHasCustomAttributes(),
-						),
-					},
-					{
-						Config: testAccCheckVSphereDatacenterConfigMultiCustomAttributes,
-						Check: resource.ComposeTestCheckFunc(
-							testAccCheckVSphereDatacenterExists(
-								testAccCheckVSphereDatacenterResourceName,
-								true,
-							),
-							testAccResourceVSphereDatacenterHasCustomAttributes(),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccResourceCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccResourceVSphereDatacenter_singleCustomAttribute(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVSphereDatacenterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVSphereDatacenterConfigCustomAttributes,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVSphereDatacenterExists(
+						testAccCheckVSphereDatacenterResourceName,
+						true,
+					),
+					testAccResourceVSphereDatacenterHasCustomAttributes(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatacenter_modifyCustomAttribute(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVSphereDatacenterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVSphereDatacenterConfigCustomAttributes,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVSphereDatacenterExists(
+						testAccCheckVSphereDatacenterResourceName,
+						true,
+					),
+					testAccResourceVSphereDatacenterHasCustomAttributes(),
+				),
+			},
+			{
+				Config: testAccCheckVSphereDatacenterConfigMultiCustomAttributes,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVSphereDatacenterExists(
+						testAccCheckVSphereDatacenterResourceName,
+						true,
+					),
+					testAccResourceVSphereDatacenterHasCustomAttributes(),
+				),
+			},
+		},
+	})
 }
 
 func testAccCheckVSphereDatacenterDestroy(s *terraform.State) error {

--- a/vsphere/resource_vsphere_distributed_virtual_switch_test.go
+++ b/vsphere/resource_vsphere_distributed_virtual_switch_test.go
@@ -607,7 +607,7 @@ func testAccResourceVSphereDistributedVirtualSwitchMatchInventoryPath(expected s
 			return err
 		}
 
-		expected, err := folder.RootPathParticleNetwork.PathFromNewRoot(dvs.InventoryPath, folder.RootPathParticleNetwork, expected)
+		expected, err = folder.RootPathParticleNetwork.PathFromNewRoot(dvs.InventoryPath, folder.RootPathParticleNetwork, expected)
 		actual := path.Dir(dvs.InventoryPath)
 		if err != nil {
 			return fmt.Errorf("bad: %s", err)

--- a/vsphere/resource_vsphere_distributed_virtual_switch_test.go
+++ b/vsphere/resource_vsphere_distributed_virtual_switch_test.go
@@ -361,9 +361,10 @@ func TestAccResourceVSphereDistributedVirtualSwitch_import(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "vsphere_distributed_virtual_switch.dvs",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "vsphere_distributed_virtual_switch.dvs",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"vlan_range"},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					dvs, err := testGetDVS(s, "dvs")
 					if err != nil {

--- a/vsphere/resource_vsphere_file_test.go
+++ b/vsphere/resource_vsphere_file_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Basic file creation (upload to vSphere)
-func TestAccVSphereFile_basic(t *testing.T) {
+func TestAccResourceVSphereFile_basic(t *testing.T) {
 	testVmdkFileData := []byte("# Disk DescriptorFile\n")
 	testVmdkFile := "/tmp/tf_test.vmdk"
 	err := ioutil.WriteFile(testVmdkFile, testVmdkFileData, 0644)
@@ -55,7 +55,7 @@ func TestAccVSphereFile_basic(t *testing.T) {
 }
 
 // Basic file copy within vSphere
-func TestAccVSphereFile_basicUploadAndCopy(t *testing.T) {
+func TestAccResourceVSphereFile_basicUploadAndCopy(t *testing.T) {
 	testVmdkFileData := []byte("# Disk DescriptorFile\n")
 	sourceFile := "/tmp/tf_test.vmdk"
 	uploadResourceName := "myfileupload"
@@ -108,7 +108,7 @@ func TestAccVSphereFile_basicUploadAndCopy(t *testing.T) {
 }
 
 // file creation followed by a rename of file (update)
-func TestAccVSphereFile_renamePostCreation(t *testing.T) {
+func TestAccResourceVSphereFile_renamePostCreation(t *testing.T) {
 	testVmdkFileData := []byte("# Disk DescriptorFile\n")
 	testVmdkFile := "/tmp/tf_test.vmdk"
 	err := ioutil.WriteFile(testVmdkFile, testVmdkFileData, 0644)
@@ -166,7 +166,7 @@ func TestAccVSphereFile_renamePostCreation(t *testing.T) {
 }
 
 // file upload, then copy, finally the copy is renamed (moved) (update)
-func TestAccVSphereFile_uploadAndCopyAndUpdate(t *testing.T) {
+func TestAccResourceVSphereFile_uploadAndCopyAndUpdate(t *testing.T) {
 	testVmdkFileData := []byte("# Disk DescriptorFile\n")
 	sourceFile := "/tmp/tf_test.vmdk"
 	uploadResourceName := "myfileupload"
@@ -266,9 +266,8 @@ func testAccCheckVSphereFileDestroy(s *terraform.State) error {
 
 		_, err = ds.Stat(context.TODO(), rs.Primary.Attributes["destination_file"])
 		if err != nil {
-			switch e := err.(type) {
+			switch err.(type) {
 			case object.DatastoreNoSuchFileError:
-				fmt.Printf("Expected error received: %s\n", e.Error())
 				return nil
 			default:
 				return err
@@ -313,7 +312,6 @@ func testAccCheckVSphereFileExists(n string, df string, exists bool) resource.Te
 				if exists {
 					return fmt.Errorf("File does not exist: %s", e.Error())
 				}
-				fmt.Printf("Expected error received: %s\n", e.Error())
 				return nil
 			default:
 				return err

--- a/vsphere/resource_vsphere_folder_migrate_test.go
+++ b/vsphere/resource_vsphere_folder_migrate_test.go
@@ -18,7 +18,7 @@ func testAccResourceVSphereFolderMigrateStatePreCheck(t *testing.T) {
 	}
 }
 
-func TestAccResourceVSphereFolderMigrateState(t *testing.T) {
+func TestAccResourceVSphereFolderMigrateState_basic(t *testing.T) {
 	testAccResourceVSphereFolderMigrateStatePreCheck(t)
 	testAccPreCheck(t)
 

--- a/vsphere/resource_vsphere_folder_test.go
+++ b/vsphere/resource_vsphere_folder_test.go
@@ -19,452 +19,437 @@ const testAccResourceVSphereFolderConfigExpectedAltName = "terraform-renamed-fol
 const testAccResourceVSphereFolderConfigExpectedParentName = "terraform-test-parent"
 const testAccResourceVSphereFolderConfigOOBName = "terraform-test-oob"
 
-func TestAccResourceVSphereFolder(t *testing.T) {
-	var tp *testing.T
-	var s *terraform.State
-	testAccResourceVSphereFolderCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic (VM folder)",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-						),
-					},
-				},
+func TestAccResourceVSphereFolder_vmFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+				),
 			},
 		},
-		{
-			"datastore folder",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeDatastore,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeDatastore),
-						),
-					},
-				},
-			},
-		},
-		{
-			"network folder",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeNetwork,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeNetwork),
-						),
-					},
-				},
-			},
-		},
-		{
-			"host folder",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeHost,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeHost),
-						),
-					},
-				},
-			},
-		},
-		{
-			"datacenter folder",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeDatacenter,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeDatacenter),
-						),
-					},
-				},
-			},
-		},
-		{
-			"rename",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-						),
-					},
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedAltName,
-							folder.VSphereFolderTypeVM,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedAltName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-						),
-					},
-				},
-			},
-		},
-		{
-			"subfolder",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigSubFolder(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderHasParent(false, testAccResourceVSphereFolderConfigExpectedParentName),
-						),
-					},
-				},
-			},
-		},
-		{
-			"move to subfolder",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderHasParent(true, "vm"),
-						),
-					},
-					{
-						Config: testAccResourceVSphereFolderConfigSubFolder(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderHasParent(false, testAccResourceVSphereFolderConfigExpectedParentName),
-						),
-					},
-				},
-			},
-		},
-		{
-			"tags",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigTag(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderCheckTags("terraform-test-tag"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"modify tags",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigTag(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderCheckTags("terraform-test-tag"),
-						),
-					},
-					{
-						Config: testAccResourceVSphereFolderConfigMultiTag(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderCheckTags("terraform-test-tags-alt"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"custom attributes",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderCustomAttribute(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderHasCustomAttributes(),
-						),
-					},
-				},
-			},
-		},
-		{
-			"modify custom attributes",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderCustomAttribute(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderHasCustomAttributes(),
-						),
-					},
-					{
-						Config: testAccResourceVSphereFolderMultiCustomAttributes(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderHasCustomAttributes(),
-						),
-					},
-				},
-			},
-		},
-		{
-			"remove all custom attributes",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderMultiCustomAttributes(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderHasCustomAttributes(),
-						),
-					},
-					{
-						Config: testAccResourceVSphereFolderRemovedCustomAttributes(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							testAccResourceVSphereFolderHasCustomAttributes(),
-						),
-					},
-				},
-			},
-		},
-		{
-			"prevent delete if not empty",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-							copyStatePtr(&s),
-						),
-					},
-					{
-						PreConfig: func() {
-							if err := testAccResourceVSphereFolderCreateOOB(s); err != nil {
-								panic(err)
-							}
-						},
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-						Destroy:     true,
-						ExpectError: regexp.MustCompile("folder is not empty, please remove all items before deleting"),
-					},
-					{
-						PreConfig: func() {
-							if err := testAccResourceVSphereFolderDeleteOOB(s); err != nil {
-								panic(err)
-							}
-						},
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-					},
-				},
-			},
-		},
-		{
-			"import",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereFolderExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-						),
-					},
-					{
-						ResourceName:      "vsphere_folder.folder",
-						ImportState:       true,
-						ImportStateVerify: true,
-						ImportStateIdFunc: func(s *terraform.State) (string, error) {
-							folder, err := testGetFolder(s, "folder")
-							if err != nil {
-								return "", err
-							}
-							return folder.InventoryPath, nil
-						},
-						Config: testAccResourceVSphereFolderConfigBasic(
-							testAccResourceVSphereFolderConfigExpectedName,
-							folder.VSphereFolderTypeVM,
-						),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereFolderExists(true),
-							testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
-							testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccResourceVSphereFolderCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccResourceVSphereFolder_datastoreFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeDatastore,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeDatastore),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_networkFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeNetwork,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeNetwork),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_hostFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeHost,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeHost),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_datacenterFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeDatacenter,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeDatacenter),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_rename(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+				),
+			},
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedAltName,
+					folder.VSphereFolderTypeVM,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedAltName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_subfolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigSubFolder(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderHasParent(false, testAccResourceVSphereFolderConfigExpectedParentName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_moveToSubfolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderHasParent(true, "vm"),
+				),
+			},
+			{
+				Config: testAccResourceVSphereFolderConfigSubFolder(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderHasParent(false, testAccResourceVSphereFolderConfigExpectedParentName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_tags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigTag(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderCheckTags("terraform-test-tag"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_modifyTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigTag(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderCheckTags("terraform-test-tag"),
+				),
+			},
+			{
+				Config: testAccResourceVSphereFolderConfigMultiTag(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderCheckTags("terraform-test-tags-alt"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_customAttributes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderCustomAttribute(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderHasCustomAttributes(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_modifyCustomAttributes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderCustomAttribute(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderHasCustomAttributes(),
+				),
+			},
+			{
+				Config: testAccResourceVSphereFolderMultiCustomAttributes(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderHasCustomAttributes(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_removeAllCustomAttributes(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderMultiCustomAttributes(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderHasCustomAttributes(),
+				),
+			},
+			{
+				Config: testAccResourceVSphereFolderRemovedCustomAttributes(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					testAccResourceVSphereFolderHasCustomAttributes(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_preventDeleteIfNotEmpty(t *testing.T) {
+	var s *terraform.State
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+					copyStatePtr(&s),
+				),
+			},
+			{
+				PreConfig: func() {
+					if err := testAccResourceVSphereFolderCreateOOB(s); err != nil {
+						panic(err)
+					}
+				},
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("folder is not empty, please remove all items before deleting"),
+			},
+			{
+				PreConfig: func() {
+					if err := testAccResourceVSphereFolderDeleteOOB(s); err != nil {
+						panic(err)
+					}
+				},
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereFolder_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereFolderExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+				),
+			},
+			{
+				ResourceName:      "vsphere_folder.folder",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					folder, err := testGetFolder(s, "folder")
+					if err != nil {
+						return "", err
+					}
+					return folder.InventoryPath, nil
+				},
+				Config: testAccResourceVSphereFolderConfigBasic(
+					testAccResourceVSphereFolderConfigExpectedName,
+					folder.VSphereFolderTypeVM,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereFolderExists(true),
+					testAccResourceVSphereFolderHasName(testAccResourceVSphereFolderConfigExpectedName),
+					testAccResourceVSphereFolderHasType(folder.VSphereFolderTypeVM),
+				),
+			},
+		},
+	})
 }
 
 func testAccResourceVSphereFolderExists(expected bool) resource.TestCheckFunc {

--- a/vsphere/resource_vsphere_host_port_group_test.go
+++ b/vsphere/resource_vsphere_host_port_group_test.go
@@ -10,91 +10,75 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccResourceVSphereHostPortGroup(t *testing.T) {
-	var tp *testing.T
-	testAccResourceVSphereHostPortGroupCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic, inherited policy",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereHostPortGroupPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereHostPortGroupExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereHostPortGroupConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereHostPortGroupExists(true),
-						),
-					},
-				},
+func TestAccResourceVSphereHostPortGroup_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereHostPortGroupPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereHostPortGroupExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereHostPortGroupConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereHostPortGroupExists(true),
+				),
 			},
 		},
-		{
-			"more complex configuration and overridden attributes",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereHostPortGroupPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereHostPortGroupExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereHostPortGroupConfigWithOverrides(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereHostPortGroupExists(true),
-							testAccResourceVSphereHostPortGroupCheckVlan(1000),
-							testAccResourceVSphereHostPortGroupCheckEffectiveActive([]string{os.Getenv("VSPHERE_HOST_NIC0")}),
-							testAccResourceVSphereHostPortGroupCheckEffectiveStandby([]string{os.Getenv("VSPHERE_HOST_NIC1")}),
-							testAccResourceVSphereHostPortGroupCheckEffectivePromisc(true),
-						),
-					},
-				},
-			},
-		},
-		{
-			"basic, then complex config",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereHostPortGroupPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereHostPortGroupExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereHostPortGroupConfig(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereHostPortGroupExists(true),
-						),
-					},
-					{
-						Config: testAccResourceVSphereHostPortGroupConfigWithOverrides(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereHostPortGroupExists(true),
-							testAccResourceVSphereHostPortGroupCheckVlan(1000),
-							testAccResourceVSphereHostPortGroupCheckEffectiveActive([]string{os.Getenv("VSPHERE_HOST_NIC0")}),
-							testAccResourceVSphereHostPortGroupCheckEffectiveStandby([]string{os.Getenv("VSPHERE_HOST_NIC1")}),
-							testAccResourceVSphereHostPortGroupCheckEffectivePromisc(true),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccResourceVSphereHostPortGroupCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccResourceVSphereHostPortGroup_complexWithOverrides(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereHostPortGroupPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereHostPortGroupExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereHostPortGroupConfigWithOverrides(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereHostPortGroupExists(true),
+					testAccResourceVSphereHostPortGroupCheckVlan(1000),
+					testAccResourceVSphereHostPortGroupCheckEffectiveActive([]string{os.Getenv("VSPHERE_HOST_NIC0")}),
+					testAccResourceVSphereHostPortGroupCheckEffectiveStandby([]string{os.Getenv("VSPHERE_HOST_NIC1")}),
+					testAccResourceVSphereHostPortGroupCheckEffectivePromisc(true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereHostPortGroup_basicToComplex(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereHostPortGroupPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereHostPortGroupExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereHostPortGroupConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereHostPortGroupExists(true),
+				),
+			},
+			{
+				Config: testAccResourceVSphereHostPortGroupConfigWithOverrides(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereHostPortGroupExists(true),
+					testAccResourceVSphereHostPortGroupCheckVlan(1000),
+					testAccResourceVSphereHostPortGroupCheckEffectiveActive([]string{os.Getenv("VSPHERE_HOST_NIC0")}),
+					testAccResourceVSphereHostPortGroupCheckEffectiveStandby([]string{os.Getenv("VSPHERE_HOST_NIC1")}),
+					testAccResourceVSphereHostPortGroupCheckEffectivePromisc(true),
+				),
+			},
+		},
+	})
 }
 
 func testAccResourceVSphereHostPortGroupPreCheck(t *testing.T) {

--- a/vsphere/resource_vsphere_license_test.go
+++ b/vsphere/resource_vsphere_license_test.go
@@ -20,7 +20,7 @@ resource "vsphere_license" "foo" {
 }
 `
 
-func TestAccVSphereLicenseBasic(t *testing.T) {
+func TestAccResourceVSphereLicense_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -41,7 +41,7 @@ func TestAccVSphereLicenseBasic(t *testing.T) {
 
 }
 
-func TestAccVSphereLicenseInvalid(t *testing.T) {
+func TestAccResourceVSphereLicense_invalid(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -61,7 +61,7 @@ func TestAccVSphereLicenseInvalid(t *testing.T) {
 
 }
 
-func TestAccVSphereLicenseWithLabelsOnVCenter(t *testing.T) {
+func TestAccResourceVSphereLicense_withLabelsOnVCenter(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -82,7 +82,7 @@ func TestAccVSphereLicenseWithLabelsOnVCenter(t *testing.T) {
 
 }
 
-func TestAccVSphereLicenseWithLabelsOnESXiServer(t *testing.T) {
+func TestAccResourceVSphereLicense_withLabelsOnESXiServer(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/vsphere/resource_vsphere_nas_datastore_test.go
+++ b/vsphere/resource_vsphere_nas_datastore_test.go
@@ -364,7 +364,7 @@ func testAccResourceVSphereNasDatastoreMatchInventoryPath(expected string) resou
 			return err
 		}
 
-		expected, err := folder.RootPathParticleDatastore.PathFromNewRoot(ds.InventoryPath, folder.RootPathParticleDatastore, expected)
+		expected, err = folder.RootPathParticleDatastore.PathFromNewRoot(ds.InventoryPath, folder.RootPathParticleDatastore, expected)
 		actual := path.Dir(ds.InventoryPath)
 		if err != nil {
 			return fmt.Errorf("bad: %s", err)

--- a/vsphere/resource_vsphere_nas_datastore_test.go
+++ b/vsphere/resource_vsphere_nas_datastore_test.go
@@ -13,306 +13,290 @@ import (
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
 )
 
-func TestAccResourceVSphereNasDatastore(t *testing.T) {
-	var tp *testing.T
-	testAccResourceVSphereNasDatastoreCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasic(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-						),
-					},
-				},
+func TestAccResourceVSphereNasDatastore_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+				),
 			},
 		},
-		{
-			"multi-host",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-					testAccSkipIfEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigMultiHost(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-						),
-					},
-				},
-			},
-		},
-		{
-			"basic, then multi-host",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasic(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-						),
-					},
-					{
-						Config:      testAccResourceVSphereNasDatastoreConfigMultiHost(),
-						ExpectError: expectErrorIfNotVirtualCenter(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-						),
-					},
-				},
-			},
-		},
-		{
-			"multi-host, then basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-					testAccSkipIfEsxi(tp)
-				},
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigMultiHost(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-						),
-					},
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasic(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-						),
-					},
-				},
-			},
-		},
-		{
-			"rename datastore",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasic(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-						),
-					},
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasicAltName(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-							testAccResourceVSphereNasDatastoreHasName("terraform-test-nas-renamed"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"with folder",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-					// NOTE: This test can't run on ESXi without giving a "dangling
-					// resource" error during testing - "move to folder after" hits the
-					// error on the same path of the call stack that triggers an error in
-					// both create and update and should provide adequate coverage
-					// barring manual testing.
-					testAccSkipIfEsxi(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasicFolder(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-							testAccResourceVSphereNasDatastoreMatchInventoryPath(os.Getenv("VSPHERE_DS_FOLDER")),
-						),
-					},
-				},
-			},
-		},
-		{
-			"move to folder after",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasic(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-						),
-					},
-					{
-						Config:      testAccResourceVSphereNasDatastoreConfigBasicFolder(),
-						ExpectError: expectErrorIfNotVirtualCenter(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-							testAccResourceVSphereNasDatastoreMatchInventoryPath(os.Getenv("VSPHERE_DS_FOLDER")),
-						),
-					},
-				},
-			},
-		},
-		{
-			"single tag",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasicTags(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-							testAccResourceVSphereDatastoreCheckTags("vsphere_nas_datastore.datastore", "terraform-test-tag"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"modify tags",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasicTags(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-							testAccResourceVSphereDatastoreCheckTags("vsphere_nas_datastore.datastore", "terraform-test-tag"),
-						),
-					},
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigMultiTags(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-							testAccResourceVSphereDatastoreCheckTags("vsphere_nas_datastore.datastore", "terraform-test-tags-alt"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"import",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigBasic(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-						),
-					},
-					{
-						Config:            testAccResourceVSphereNasDatastoreConfigBasic(),
-						ImportState:       true,
-						ResourceName:      "vsphere_nas_datastore.datastore",
-						ImportStateVerify: true,
-					},
-				},
-			},
-		},
-		{
-			"single custom attribute",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigSingleCustomAttribute(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-							testAccResourceVSphereNasDatastoreHasCustomAttributes(),
-						),
-					},
-				},
-			},
-		},
-		{
-			"multi custom attribute",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-					testAccResourceVSphereNasDatastorePreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigSingleCustomAttribute(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-							testAccResourceVSphereNasDatastoreHasCustomAttributes(),
-						),
-					},
-					{
-						Config: testAccResourceVSphereNasDatastoreConfigMultiCustomAttributes(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereNasDatastoreExists(true),
-							testAccResourceVSphereNasDatastoreHasCustomAttributes(),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccResourceVSphereNasDatastoreCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccResourceVSphereNasDatastore_multiHost(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+			testAccSkipIfEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigMultiHost(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_basicToMultiHost(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+				),
+			},
+			{
+				Config:      testAccResourceVSphereNasDatastoreConfigMultiHost(),
+				ExpectError: expectErrorIfNotVirtualCenter(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_multiHostToBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+			testAccSkipIfEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigMultiHost(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+				),
+			},
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_renameDatastore(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+				),
+			},
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasicAltName(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+					testAccResourceVSphereNasDatastoreHasName("terraform-test-nas-renamed"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_inFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+			// NOTE: This test can't run on ESXi without giving a "dangling
+			// resource" error during testing - "move to folder after" hits the
+			// error on the same path of the call stack that triggers an error in
+			// both create and update and should provide adequate coverage
+			// barring manual testing.
+			testAccSkipIfEsxi(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasicFolder(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+					testAccResourceVSphereNasDatastoreMatchInventoryPath(os.Getenv("VSPHERE_DS_FOLDER")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_moveToFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+				),
+			},
+			{
+				Config:      testAccResourceVSphereNasDatastoreConfigBasicFolder(),
+				ExpectError: expectErrorIfNotVirtualCenter(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+					testAccResourceVSphereNasDatastoreMatchInventoryPath(os.Getenv("VSPHERE_DS_FOLDER")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_singleTag(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasicTags(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+					testAccResourceVSphereDatastoreCheckTags("vsphere_nas_datastore.datastore", "terraform-test-tag"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_modifyTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasicTags(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+					testAccResourceVSphereDatastoreCheckTags("vsphere_nas_datastore.datastore", "terraform-test-tag"),
+				),
+			},
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigMultiTags(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+					testAccResourceVSphereDatastoreCheckTags("vsphere_nas_datastore.datastore", "terraform-test-tags-alt"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+				),
+			},
+			{
+				Config:            testAccResourceVSphereNasDatastoreConfigBasic(),
+				ImportState:       true,
+				ResourceName:      "vsphere_nas_datastore.datastore",
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_singleCustomAttribute(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigSingleCustomAttribute(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+					testAccResourceVSphereNasDatastoreHasCustomAttributes(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereNasDatastore_multiCustomAttribute(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereNasDatastorePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereNasDatastoreExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigSingleCustomAttribute(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+					testAccResourceVSphereNasDatastoreHasCustomAttributes(),
+				),
+			},
+			{
+				Config: testAccResourceVSphereNasDatastoreConfigMultiCustomAttributes(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereNasDatastoreExists(true),
+					testAccResourceVSphereNasDatastoreHasCustomAttributes(),
+				),
+			},
+		},
+	})
 }
 
 func testAccResourceVSphereNasDatastorePreCheck(t *testing.T) {

--- a/vsphere/resource_vsphere_tag_category_test.go
+++ b/vsphere/resource_vsphere_tag_category_test.go
@@ -13,174 +13,177 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccResourceVSphereTagCategory(t *testing.T) {
-	var tp *testing.T
-	testAccResourceVSphereTagCategoryCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagCategoryConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagCategoryExists(true),
-							testAccResourceVSphereTagCategoryHasName("terraform-test-category"),
-							testAccResourceVSphereTagCategoryHasCardinality(vSphereTagCategoryCardinalitySingle),
-							testAccResourceVSphereTagCategoryHasTypes([]string{
-								vSphereTagTypeVirtualMachine,
-							}),
-						),
-					},
-				},
+func TestAccResourceVSphereTagCategory_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagCategoryConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+					testAccResourceVSphereTagCategoryHasName("terraform-test-category"),
+					testAccResourceVSphereTagCategoryHasCardinality(vSphereTagCategoryCardinalitySingle),
+					testAccResourceVSphereTagCategoryHasTypes([]string{
+						vSphereTagTypeVirtualMachine,
+					}),
+				),
 			},
 		},
-		{
-			"add type",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagCategoryConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagCategoryExists(true),
-							testAccResourceVSphereTagCategoryHasTypes([]string{
-								vSphereTagTypeVirtualMachine,
-							}),
-						),
-					},
-					{
-						Config: testAccResourceVSphereTagCategoryConfigMultiType,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagCategoryExists(true),
-							testAccResourceVSphereTagCategoryHasTypes([]string{
-								vSphereTagTypeVirtualMachine,
-								vSphereTagTypeDatastore,
-							}),
-						),
-					},
-				},
-			},
-		},
-		{
-			"remove type, should error",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagCategoryConfigMultiType,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagCategoryExists(true),
-						),
-					},
-					{
-						Config:      testAccResourceVSphereTagCategoryConfigBasic,
-						ExpectError: regexp.MustCompile("removal of associable types is not supported"),
-					},
-				},
-			},
-		},
-		{
-			"rename",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagCategoryConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagCategoryExists(true),
-						),
-					},
-					{
-						Config: testAccResourceVSphereTagCategoryConfigAltName,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagCategoryExists(true),
-							testAccResourceVSphereTagCategoryHasName("terraform-test-category-renamed"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"single cardinality",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagCategoryConfigSingleCardinality,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagCategoryExists(true),
-							testAccResourceVSphereTagCategoryHasCardinality(vSphereTagCategoryCardinalitySingle),
-						),
-					},
-				},
-			},
-		},
-		{
-			"import",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagCategoryConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagCategoryExists(true),
-						),
-					},
-					{
-						ResourceName:      "vsphere_tag_category.terraform-test-category",
-						ImportState:       true,
-						ImportStateVerify: true,
-						ImportStateIdFunc: func(s *terraform.State) (string, error) {
-							cat, err := testGetTagCategory(s, "terraform-test-category")
-							if err != nil {
-								return "", err
-							}
-							return cat.Name, nil
-						},
-						Config: testAccResourceVSphereTagCategoryConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagCategoryExists(true),
-						),
-					},
-				},
-			},
-		},
-	}
+	})
+}
 
-	for _, tc := range testAccResourceVSphereTagCategoryCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccResourceVSphereTagCategory_addType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagCategoryConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+					testAccResourceVSphereTagCategoryHasTypes([]string{
+						vSphereTagTypeVirtualMachine,
+					}),
+				),
+			},
+			{
+				Config: testAccResourceVSphereTagCategoryConfigMultiType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+					testAccResourceVSphereTagCategoryHasTypes([]string{
+						vSphereTagTypeVirtualMachine,
+						vSphereTagTypeDatastore,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereTagCategory_removeTypeShouldError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagCategoryConfigMultiType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+				),
+			},
+			{
+				Config:      testAccResourceVSphereTagCategoryConfigBasic,
+				ExpectError: regexp.MustCompile("removal of associable types is not supported"),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereTagCategory_rename(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagCategoryConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+				),
+			},
+			{
+				Config: testAccResourceVSphereTagCategoryConfigAltName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+					testAccResourceVSphereTagCategoryHasName("terraform-test-category-renamed"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereTagCategory_singleCardinality(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagCategoryConfigSingleCardinality,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+					testAccResourceVSphereTagCategoryHasCardinality(vSphereTagCategoryCardinalitySingle),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereTagCategory_multiCardinality(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagCategoryConfigMultiCardinality,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+					testAccResourceVSphereTagCategoryHasCardinality(vSphereTagCategoryCardinalityMultiple),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereTagCategory_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagCategoryExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagCategoryConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+				),
+			},
+			{
+				ResourceName:      "vsphere_tag_category.terraform-test-category",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					cat, err := testGetTagCategory(s, "terraform-test-category")
+					if err != nil {
+						return "", err
+					}
+					return cat.Name, nil
+				},
+				Config: testAccResourceVSphereTagCategoryConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagCategoryExists(true),
+				),
+			},
+		},
+	})
 }
 
 func testAccResourceVSphereTagCategoryExists(expected bool) resource.TestCheckFunc {

--- a/vsphere/resource_vsphere_tag_test.go
+++ b/vsphere/resource_vsphere_tag_test.go
@@ -12,162 +12,146 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccResourceVSphereTag(t *testing.T) {
-	var tp *testing.T
-	testAccResourceVSphereTagCases := []struct {
-		name     string
-		testCase resource.TestCase
-	}{
-		{
-			"basic",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagExists(true),
-							testAccResourceVSphereTagHasName("terraform-test-tag"),
-							testAccResourceVSphereTagHasDescription("Managed by Terraform"),
-							testAccResourceVSphereTagHasCategory(),
-						),
-					},
-				},
+func TestAccResourceVSphereTag_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagExists(true),
+					testAccResourceVSphereTagHasName("terraform-test-tag"),
+					testAccResourceVSphereTagHasDescription("Managed by Terraform"),
+					testAccResourceVSphereTagHasCategory(),
+				),
 			},
 		},
-		{
-			"change name",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagExists(true),
-						),
-					},
-					{
-						Config: testAccResourceVSphereTagConfigAltName,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagExists(true),
-							testAccResourceVSphereTagHasName("terraform-test-tag-renamed"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"change description",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagExists(true),
-						),
-					},
-					{
-						Config: testAccResourceVSphereTagConfigAltDescription,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagExists(true),
-							testAccResourceVSphereTagHasDescription("Still managed by Terraform"),
-						),
-					},
-				},
-			},
-		},
-		{
-			"detach all tags",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagConfigOnFolderAttached(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagExists(true),
-						),
-					},
-					{
-						Config: testAccResourceVSphereTagConfigOnFolderNotAttached(),
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagExists(true),
-							testAccResourceVSphereFolderCheckNoTags(),
-						),
-					},
-				},
-			},
-		},
-		{
-			"import",
-			resource.TestCase{
-				PreCheck: func() {
-					testAccPreCheck(tp)
-				},
-				Providers:    testAccProviders,
-				CheckDestroy: testAccResourceVSphereTagExists(false),
-				Steps: []resource.TestStep{
-					{
-						Config: testAccResourceVSphereTagConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagExists(true),
-						),
-					},
-					{
-						ResourceName:      "vsphere_tag.terraform-test-tag",
-						ImportState:       true,
-						ImportStateVerify: true,
-						ImportStateIdFunc: func(s *terraform.State) (string, error) {
-							cat, err := testGetTagCategory(s, "terraform-test-category")
-							if err != nil {
-								return "", err
-							}
-							tag, err := testGetTag(s, "terraform-test-tag")
-							if err != nil {
-								return "", err
-							}
-							m := make(map[string]string)
-							m["category_name"] = cat.Name
-							m["tag_name"] = tag.Name
-							b, err := json.Marshal(m)
-							if err != nil {
-								return "", err
-							}
+	})
+}
 
-							return string(b), nil
-						},
-						Config: testAccResourceVSphereTagConfigBasic,
-						Check: resource.ComposeTestCheckFunc(
-							testAccResourceVSphereTagExists(true),
-						),
-					},
-				},
+func TestAccResourceVSphereTag_changeName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagExists(true),
+				),
+			},
+			{
+				Config: testAccResourceVSphereTagConfigAltName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagExists(true),
+					testAccResourceVSphereTagHasName("terraform-test-tag-renamed"),
+				),
 			},
 		},
-	}
+	})
+}
 
-	for _, tc := range testAccResourceVSphereTagCases {
-		t.Run(tc.name, func(t *testing.T) {
-			tp = t
-			resource.Test(t, tc.testCase)
-		})
-	}
+func TestAccResourceVSphereTag_changeDescription(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagExists(true),
+				),
+			},
+			{
+				Config: testAccResourceVSphereTagConfigAltDescription,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagExists(true),
+					testAccResourceVSphereTagHasDescription("Still managed by Terraform"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereTag_detachAllTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagConfigOnFolderAttached(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagExists(true),
+				),
+			},
+			{
+				Config: testAccResourceVSphereTagConfigOnFolderNotAttached(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagExists(true),
+					testAccResourceVSphereFolderCheckNoTags(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereTag_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereTagExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereTagConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagExists(true),
+				),
+			},
+			{
+				ResourceName:      "vsphere_tag.terraform-test-tag",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					cat, err := testGetTagCategory(s, "terraform-test-category")
+					if err != nil {
+						return "", err
+					}
+					tag, err := testGetTag(s, "terraform-test-tag")
+					if err != nil {
+						return "", err
+					}
+					m := make(map[string]string)
+					m["category_name"] = cat.Name
+					m["tag_name"] = tag.Name
+					b, err := json.Marshal(m)
+					if err != nil {
+						return "", err
+					}
+
+					return string(b), nil
+				},
+				Config: testAccResourceVSphereTagConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereTagExists(true),
+				),
+			},
+		},
+	})
 }
 
 func testAccResourceVSphereTagExists(expected bool) resource.TestCheckFunc {

--- a/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_snapshot_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine"
 )
 
-func TestAccResourceVSphereVirtualMachineSnapshot_Basic(t *testing.T) {
+func TestAccResourceVSphereVirtualMachineSnapshot_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)


### PR DESCRIPTION
This PR is large but hopefully straightforward, and is a refactor to convert acceptance tests from the provider-local subtest pattern to the more widely used single-function-per-test pattern (ie: `TestAccResourceVSphereSomeResource_basic` et al).

The reason this is needed is that our currently acceptance test runner in CI relies heavily on the common convention, for doing things like collating the output of individual tests into their own streams, formatted into a format that TeamCity is aware of. `go test -list` is also made use of, which currently does not support subtests, so this would be a full stop blocker to getting nightly acceptance tests working here.

A couple of minor fixes have been made to tests that were missing `ImportStateVerify` keys, and also a couple of linter fixes were made as well. These have been noted as individual commits in most cases, or as commit message details in others.