### PR TITLE
r/virtual_machine: Fix broken acceptance tests and CD drives

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -471,7 +471,16 @@ func (r *CdromSubresource) Read(l object.VirtualDeviceList) error {
 		r.Set("datastore_id", backing.Datastore.Value)
 		r.Set("path", dp.Path)
 	default:
-		return fmt.Errorf("%s: Unknown CDROM type %s", r, backing)
+		// This is an unsupported entry, so we clear all attributes in the
+		// subresource (except for the device address and key, of course).  In
+		// addition to making sure correct diffs get created for these kinds of
+		// devices, this ensures we don't fail on CDROM device types we don't
+		// support right now, such as passthrough devices. We might support these
+		// later.
+		log.Printf("%s: [DEBUG] Unknown CDROM type %T, clearing all attributes", r, backing)
+		r.Set("datastore_id", "")
+		r.Set("path", "")
+		r.Set("client_device", false)
 	}
 	// Save the device key and address data
 	ctlr, err := findControllerForDevice(l, d)

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -189,6 +189,7 @@ func TestAccResourceVSphereVirtualMachine_addDevices(t *testing.T) {
 }
 
 func TestAccResourceVSphereVirtualMachine_removeMiddleDevices(t *testing.T) {
+	var state *terraform.State
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -200,11 +201,22 @@ func TestAccResourceVSphereVirtualMachine_removeMiddleDevices(t *testing.T) {
 			{
 				Config: testAccResourceVSphereVirtualMachineConfigMultiDevice(),
 				Check: resource.ComposeTestCheckFunc(
+					copyStatePtr(&state),
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 					testAccResourceVSphereVirtualMachineCheckMultiDevice([]bool{true, true, true}, []bool{true, true, true}),
 				),
 			},
 			{
+				PreConfig: func() {
+					// As sometimes the OS image that we are using to test "bare metal"
+					// changes in how well it integrates VMware tools, we power down the
+					// VM for this operation. This is not necessarily checking that a
+					// hot-remove operation happened so it's not essential it's powered
+					// on.
+					if err := testPowerOffVM(state, "vm"); err != nil {
+						panic(err)
+					}
+				},
 				Config: testAccResourceVSphereVirtualMachineConfigRemoveMiddle(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
@@ -7860,8 +7872,10 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    label = "disk0"
-    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
   }
 
   vapp {
@@ -7975,8 +7989,10 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    label = "disk0"
-    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
   }
 
   vapp {
@@ -8091,8 +8107,10 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    label = "disk0"
-    size  = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
   }
 
   vapp {

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -773,14 +773,19 @@ resource "vsphere_virtual_machine" "vm" {
 The options are:
 
 * `client_device` - (Optional) Indicates whether the device should be backed by
-  remote client device. Conflicts with datastore_id and path.
+  remote client device. Conflicts with `datastore_id` and `path`.
 * `datastore_id` - (Optional) The datastore ID that the ISO is located in.
-  Requried for using a datastore ISO. Conflicts with client_device.
+  Requried for using a datastore ISO. Conflicts with `client_device`.
 * `path` - (Optional) The path to the ISO file. Requried for using a datastore
-  ISO. Conflicts with client_device.
+  ISO. Conflicts with `client_device`.
 
--> **NOTE:** Either client_device (for a remote backed CDROM) or datastore_id
+~> **NOTE:** Either `client_device` (for a remote backed CDROM) or `datastore_id`
 and path (for a datastore ISO backed CDROM) are required.
+
+~> **NOTE:** Some CDROM drive types are currently unsupported by this resource,
+such as pass-through devices. If these drives are present in a cloned template,
+or added outside of Terraform, they will have their configurations corrected to
+that of the defined device, or removed if no `cdrom` sub-resource is present.
 
 ### Virtual device computed options
 


### PR DESCRIPTION
This does a few things:

* Looks like some acceptance test were broken - first one was due to
something changing in RancherOS that does not allow for the proper
hot-remove of virtual NICs anymore. I've adjusted this test so it
powers off the VM first, which is not so much an issue as we aren't
testing for a hot-remove anyway, but more to make sure that things are
consistent in state.
* The vApp property tests were missing settings for `thin_provisioned` and
`eagerly_scrub`, which should be coming from the template data sources.
These were failing as a result as the CoreOS OVA does not use thin
provisioned disks.
* Finally, #421 introduced a change where we were actually failing if we
didn't recognize the CD drive type. There are a few we still don't
support, namely passthrough CD drives. I've changed this to a debug log
message, and a unsetting of all parameters. This should ensure that
devices that aren't recognized but need to be changed to a recognized
device are properly accounted for in the diff, in addition to removing
unrecognized devices in the event no CDROM drive is necessary.