### PR TITLE
New resource: vsphere_datastore_cluster

### DIFF
--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/resourcepool"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/storagepod"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/virtualdisk"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/virtualmachine"
@@ -662,4 +663,24 @@ func testResourceHasCustomAttributeValues(s *terraform.State, resourceType strin
 		return fmt.Errorf("expected custom attributes to be %q, got %q", expectedAttrs, actualAttrs)
 	}
 	return nil
+}
+
+// testGetDatastoreCluster is a convenience method to fetch a datastore cluster by
+// resource name.
+func testGetDatastoreCluster(s *terraform.State, resourceName string) (*object.StoragePod, error) {
+	vars, err := testClientVariablesForResource(s, fmt.Sprintf("%s.%s", resourceVSphereDatastoreClusterName, resourceName))
+	if err != nil {
+		return nil, err
+	}
+	return storagepod.FromID(vars.client, vars.resourceID)
+}
+
+// testGetDatastoreClusterProperties is a convenience method that adds an extra
+// step to testGetDatastoreCluster to get the properties of a StoragePod.
+func testGetDatastoreClusterProperties(s *terraform.State, resourceName string) (*mo.StoragePod, error) {
+	pod, err := testGetDatastoreCluster(s, resourceName)
+	if err != nil {
+		return nil, err
+	}
+	return storagepod.Properties(pod)
 }

--- a/vsphere/internal/helper/customattribute/custom_attributes_helper.go
+++ b/vsphere/internal/helper/customattribute/custom_attributes_helper.go
@@ -52,6 +52,10 @@ func IsSupported(client *govmomi.Client) bool {
 	return VerifySupport(client) == nil
 }
 
+// ReadFromResource reads the custom attributes from an object and saves the
+// data into the supplied ResourceData.
+//
+// TODO: Add error handling and reporting to this method.
 func ReadFromResource(client *govmomi.Client, entity *mo.ManagedEntity, d *schema.ResourceData) {
 	customAttrs := make(map[string]interface{})
 	if len(entity.CustomValue) > 0 {

--- a/vsphere/internal/helper/folder/folder_helper.go
+++ b/vsphere/internal/helper/folder/folder_helper.go
@@ -191,6 +191,8 @@ func folderFromObject(client *govmomi.Client, obj interface{}, folderType RootPa
 		p, err = RootPathParticleNetwork.PathFromNewRoot(o.InventoryPath, folderType, relative)
 	case *object.Datastore:
 		p, err = RootPathParticleDatastore.PathFromNewRoot(o.InventoryPath, folderType, relative)
+	case *object.StoragePod:
+		p, err = RootPathParticleDatastore.PathFromNewRoot(o.InventoryPath, folderType, relative)
 	case *object.HostSystem:
 		p, err = RootPathParticleHost.PathFromNewRoot(o.InventoryPath, folderType, relative)
 	case *object.ResourcePool:

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -1,0 +1,90 @@
+package storagepod
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/provider"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// FromID locates a StoragePod by its managed object reference ID.
+func FromID(client *govmomi.Client, id string) (*object.StoragePod, error) {
+	log.Printf("[DEBUG] Locating datastore cluster with ID %q", id)
+	finder := find.NewFinder(client.Client, false)
+
+	ref := types.ManagedObjectReference{
+		Type:  "StoragePod",
+		Value: id,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	r, err := finder.ObjectReference(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	pod := r.(*object.StoragePod)
+	log.Printf("[DEBUG] Datastore cluster with ID %q found (%s)", pod.Reference().Value, pod.InventoryPath)
+	return pod, nil
+}
+
+// FromPath loads a StoragePod from its path. The datacenter is optional if the
+// path is specific enough to not require it.
+func FromPath(client *govmomi.Client, name string, dc *object.Datacenter) (*object.StoragePod, error) {
+	finder := find.NewFinder(client.Client, false)
+	if dc != nil {
+		log.Printf("[DEBUG] Attempting to locate datastore cluster %q in datacenter %q", name, dc.InventoryPath)
+		finder.SetDatacenter(dc)
+	} else {
+		log.Printf("[DEBUG] Attempting to locate datastore cluster at absolute path %q", name)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	return finder.DatastoreCluster(ctx, name)
+}
+
+// Properties is a convenience method that wraps fetching the
+// StoragePod MO from its higher-level object.
+func Properties(pod *object.StoragePod) (*mo.StoragePod, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	var props mo.StoragePod
+	if err := pod.Properties(ctx, pod.Reference(), nil, &props); err != nil {
+		return nil, err
+	}
+	return &props, nil
+}
+
+// Create creates a StoragePod from a supplied folder. The resulting StoragePod
+// is returned.
+func Create(f *object.Folder, name string) (*object.StoragePod, error) {
+	log.Printf("[DEBUG] Creating datastore cluster %q", fmt.Sprintf("%s/%s", f.InventoryPath, name))
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	pod, err := f.CreateStoragePod(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return pod, nil
+}
+
+// ApplyDRSConfiguration takes a types.StorageDrsConfigSpec and applies it
+// against the specified StoragePod.
+func ApplyDRSConfiguration(client *govmomi.Client, pod *object.StoragePod, spec types.StorageDrsConfigSpec) error {
+	log.Printf("[DEBUG] Applying storage DRS configuration against datastore clsuter %q", pod.InventoryPath)
+	mgr := object.NewStorageResourceManager(client.Client)
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	task, err := mgr.ConfigureStorageDrsForPod(ctx, pod, spec, true)
+	if err != nil {
+		return err
+	}
+	return task.Wait(ctx)
+}

--- a/vsphere/internal/helper/storagepod/storage_pod_helper.go
+++ b/vsphere/internal/helper/storagepod/storage_pod_helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/provider"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
@@ -83,6 +84,51 @@ func ApplyDRSConfiguration(client *govmomi.Client, pod *object.StoragePod, spec 
 	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
 	defer cancel()
 	task, err := mgr.ConfigureStorageDrsForPod(ctx, pod, spec, true)
+	if err != nil {
+		return err
+	}
+	return task.Wait(ctx)
+}
+
+// Rename renames a StoragePod.
+func Rename(pod *object.StoragePod, name string) error {
+	log.Printf("[DEBUG] Renaming storage pod %q to %s", pod.InventoryPath, name)
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	task, err := pod.Rename(ctx, name)
+	if err != nil {
+		return err
+	}
+	return task.Wait(ctx)
+}
+
+// MoveToFolder is a complex method that moves a StoragePod to a given relative
+// datastore folder path. "Relative" here means relative to a datacenter, which
+// is discovered from the current StoragePod path.
+func MoveToFolder(client *govmomi.Client, pod *object.StoragePod, relative string) error {
+	f, err := folder.DatastoreFolderFromObject(client, pod, relative)
+	if err != nil {
+		return err
+	}
+	return folder.MoveObjectTo(pod.Reference(), f)
+}
+
+// HasChildren checks to see if a datastore cluster has any child items
+// (datastores) and returns true if that is the case. This is useful when
+// checking to see if a datastore cluster is safe to delete - destroying a
+// datastore cluster in vSphere destroys *all* children if at all possible
+// (including removing datastores), so extra verification is necessary to
+// prevent accidental removal.
+func HasChildren(pod *object.StoragePod) (bool, error) {
+	return folder.HasChildren(pod.Folder)
+}
+
+// Delete destroys a StoragePod.
+func Delete(pod *object.StoragePod) error {
+	log.Printf("[DEBUG] Deleting datastore cluster %q", pod.InventoryPath)
+	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
+	defer cancel()
+	task, err := pod.Destroy(ctx)
 	if err != nil {
 		return err
 	}

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -90,6 +90,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"vsphere_custom_attribute":           resourceVSphereCustomAttribute(),
 			"vsphere_datacenter":                 resourceVSphereDatacenter(),
+			"vsphere_datastore_cluster":          resourceVSphereDatastoreCluster(),
 			"vsphere_distributed_port_group":     resourceVSphereDistributedPortGroup(),
 			"vsphere_distributed_virtual_switch": resourceVSphereDistributedVirtualSwitch(),
 			"vsphere_file":                       resourceVSphereFile(),

--- a/vsphere/resource_vsphere_datastore_cluster.go
+++ b/vsphere/resource_vsphere_datastore_cluster.go
@@ -1,0 +1,526 @@
+package vsphere
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/customattribute"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/folder"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/storagepod"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/structure"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var storageDrsPodConfigInfoBehaviorAllowedValues = []string{
+	string(types.StorageDrsPodConfigInfoBehaviorManual),
+	string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+}
+
+var storageDrsSpaceLoadBalanceConfigSpaceThresholdModeAllowedValues = []string{
+	string(types.StorageDrsSpaceLoadBalanceConfigSpaceThresholdModeUtilization),
+	string(types.StorageDrsSpaceLoadBalanceConfigSpaceThresholdModeFreeSpace),
+}
+
+func resourceVSphereDatastoreCluster() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVSphereDatastoreClusterCreate,
+		Read:   resourceVSphereDatastoreClusterRead,
+		Update: resourceVSphereDatastoreClusterUpdate,
+		Delete: resourceVSphereDatastoreClusterDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name for the new storage pod.",
+				StateFunc:   folder.NormalizePath,
+			},
+			"datacenter_id": {
+				Type:        schema.TypeString,
+				Description: "The managed object ID of the datacenter to put the datastore cluster in.",
+				Required:    true,
+			},
+			"folder": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the folder to locate the datastore cluster in.",
+				StateFunc:   folder.NormalizePath,
+			},
+			"sdrs_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable storage DRS for this datastore cluster.",
+			},
+			"sdrs_automation_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+				Description:  "The default automation level for all virtual machines in this storage cluster.",
+				ValidateFunc: validation.StringInSlice(storageDrsPodConfigInfoBehaviorAllowedValues, false),
+			},
+			"sdrs_space_balance_automation_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Overrides the default automation settings when correcting disk space imbalances.",
+				ValidateFunc: validation.StringInSlice(storageDrsPodConfigInfoBehaviorAllowedValues, false),
+			},
+			"sdrs_io_balance_automation_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Overrides the default automation settings when correcting I/O load imbalances.",
+				ValidateFunc: validation.StringInSlice(storageDrsPodConfigInfoBehaviorAllowedValues, false),
+			},
+			"sdrs_rule_enforcement_automation_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Overrides the default automation settings when correcting affinity rule violations.",
+				ValidateFunc: validation.StringInSlice(storageDrsPodConfigInfoBehaviorAllowedValues, false),
+			},
+			"sdrs_policy_enforcement_automation_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Overrides the default automation settings when correcting storage and VM policy violations.",
+				ValidateFunc: validation.StringInSlice(storageDrsPodConfigInfoBehaviorAllowedValues, false),
+			},
+			"sdrs_vm_evacuation_automation_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Overrides the default automation settings when generating recommendations for datastore evacuation.",
+				ValidateFunc: validation.StringInSlice(storageDrsPodConfigInfoBehaviorAllowedValues, false),
+			},
+			"sdrs_io_load_balance_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Enable I/O load balancing for this datastore cluster.",
+			},
+			"sdrs_default_intra_vm_affinity": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "When true, storage DRS keeps VMDKs for individual VMs on the same datastore by default.",
+			},
+			"sdrs_io_latency_threshold": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      15,
+				Description:  "The I/O latency threshold, in milliseconds, that storage DRS uses to make recommendations to move disks from this datastore.",
+				ValidateFunc: validation.IntBetween(5, 100),
+			},
+			"sdrs_io_load_imbalance_threshold": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      5,
+				Description:  "The difference between load in datastores in the cluster before storage DRS makes recommendations to balance the load.",
+				ValidateFunc: validation.IntBetween(1, 100),
+			},
+			"sdrs_io_reservable_iops_threshold": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The threshold of reservable IOPS of all virtual machines on the datastore before storage DRS makes recommendations to move VMs off of a datastore.",
+			},
+			"sdrs_io_reservable_percent_threshold": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      60,
+				Description:  "The threshold, in percent, of actual estimated performance of the datastore (in IOPS) that storage DRS uses to make recommendations to move VMs off of a datastore when the total reservable IOPS exceeds the threshold.",
+				ValidateFunc: validation.IntBetween(30, 100),
+			},
+			"sdrs_io_reservable_threshold_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+				Description:  "The reservable IOPS threshold to use, percent in the event of automatic, or manual threshold in the event of manual.",
+				ValidateFunc: validation.StringInSlice(storageDrsPodConfigInfoBehaviorAllowedValues, false),
+			},
+			"sdrs_load_balance_interval": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      480,
+				Description:  "The storage DRS poll interval, in minutes.",
+				ValidateFunc: validation.IntBetween(60, 2505600),
+			},
+			"sdrs_free_space_threshold": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      50,
+				Description:  "The threshold, in GB, that storage DRS uses to make decisions to migrate VMs out of a datastore.",
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"sdrs_free_space_utilization_difference": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      5,
+				Description:  "The threshold, in percent, of difference between space utilization in datastores before storage DRS makes decisions to balance the space.",
+				ValidateFunc: validation.IntBetween(1, 50),
+			},
+			"sdrs_space_utilization_threshold": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      80,
+				Description:  "The threshold, in percent of used space, that storage DRS uses to make decisions to migrate VMs out of a datastore.",
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"sdrs_free_space_threshold_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      string(types.StorageDrsSpaceLoadBalanceConfigSpaceThresholdModeUtilization),
+				Description:  "The free space threshold to use. When set to utilization, drs_space_utilization_threshold is used, and when set to freeSpace, drs_free_space_threshold is used.",
+				ValidateFunc: validation.StringInSlice(storageDrsSpaceLoadBalanceConfigSpaceThresholdModeAllowedValues, false),
+			},
+			"sdrs_advanced_options": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Advanced configuration options for storage DRS.",
+			},
+			vSphereTagAttributeKey:    tagsSchema(),
+			customattribute.ConfigKey: customattribute.ConfigSchema(),
+		},
+	}
+}
+
+func resourceVSphereDatastoreClusterCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] %s: Beginning create", resourceVSphereDatastoreClusterIDString(d))
+
+	pod, err := resourceVSphereDatastoreClusterApplyCreate(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if err := resourceVSphereDatastoreClusterApplyTags(d, meta, pod); err != nil {
+		return err
+	}
+
+	if err := resourceVSphereDatastoreClusterApplyCustomAttributes(d, meta, pod); err != nil {
+		return err
+	}
+
+	if err := resourceVSphereDatastoreClusterApplySDRSConfig(d, meta, pod); err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] %s: Create finished successfully", resourceVSphereDatastoreClusterIDString(d))
+	return resourceVSphereDatastoreClusterRead(d, meta)
+}
+
+func resourceVSphereDatastoreClusterRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] %s: Beginning read", resourceVSphereDatastoreClusterIDString(d))
+	pod, err := resourceVSphereDatastoreClusterGetPod(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if err := resourceVSphereDatastoreClusterFlattenSDRSData(d, meta, pod); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceVSphereDatastoreClusterUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceVSphereDatastoreClusterRead(d, meta)
+}
+
+func resourceVSphereDatastoreClusterDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+// resourceVSphereDatastoreClusterApplyCreate processes the creation part of
+// resourceVSphereDatastoreClusterCreate.
+func resourceVSphereDatastoreClusterApplyCreate(d *schema.ResourceData, meta interface{}) (*object.StoragePod, error) {
+	log.Printf("[DEBUG] %s: Processing datastore cluster creation", resourceVSphereDatastoreClusterIDString(d))
+	client := meta.(*VSphereClient).vimClient
+	if err := viapi.ValidateVirtualCenter(client); err != nil {
+		return nil, err
+	}
+
+	dc, err := datacenterFromID(client, d.Get("datacenter_id").(string))
+	if err != nil {
+		return nil, fmt.Errorf("cannot locate datacenter: %s", err)
+	}
+
+	// Find the folder based off the path to the datacenter. This is where we
+	// create the datastore cluster.
+	f, err := folder.DatastoreFolderFromObject(client, dc, d.Get("folder").(string))
+	if err != nil {
+		return nil, fmt.Errorf("cannot locate folder: %s", err)
+	}
+
+	// Create the storage pod (datastore cluster).
+	pod, err := storagepod.Create(f, d.Get("name").(string))
+	if err != nil {
+		return nil, fmt.Errorf("error creating datastore cluster: %s", err)
+	}
+
+	// Set the ID now before proceeding with tags, custom attributes, and DRS.
+	// This ensures that we can recover from a problem with any of these
+	// operations.
+	d.SetId(pod.Reference().Value)
+
+	return pod, nil
+}
+
+// resourceVSphereDatastoreClusterApplyTags processes the tags step for both
+// create and update for vsphere_datastore_cluster.
+func resourceVSphereDatastoreClusterApplyTags(d *schema.ResourceData, meta interface{}, pod *object.StoragePod) error {
+	tagsClient, err := tagsClientIfDefined(d, meta)
+	if err != nil {
+		return err
+	}
+
+	// Apply any pending tags now
+	if tagsClient == nil {
+		log.Printf("[DEBUG] %s: Tags unsupported on this connection, skipping", resourceVSphereDatastoreClusterIDString(d))
+		return nil
+	}
+
+	log.Printf("[DEBUG] %s: Applying any pending tags", resourceVSphereDatastoreClusterIDString(d))
+	return processTagDiff(tagsClient, d, pod)
+}
+
+// resourceVSphereDatastoreClusterReadTags reads the tags for
+// vsphere_datastore_cluster.
+func resourceVSphereDatastoreClusterReadTags(d *schema.ResourceData, meta interface{}, pod *object.StoragePod) error {
+	if tagsClient, _ := meta.(*VSphereClient).TagsClient(); tagsClient != nil {
+		log.Printf("[DEBUG] %s: Reading tags", resourceVSphereDatastoreClusterIDString(d))
+		if err := readTagsForResource(tagsClient, pod, d); err != nil {
+			return err
+		}
+	} else {
+		log.Printf("[DEBUG] %s: Tags unsupported on this connection, skipping tag read", resourceVSphereDatastoreClusterIDString(d))
+	}
+	return nil
+}
+
+// resourceVSphereDatastoreClusterApplyCustomAttributes processes the custom
+// attributes step for both create and update for vsphere_datastore_cluster.
+func resourceVSphereDatastoreClusterApplyCustomAttributes(d *schema.ResourceData, meta interface{}, pod *object.StoragePod) error {
+	client := meta.(*VSphereClient).vimClient
+	// Verify a proper vCenter before proceeding if custom attributes are defined
+	attrsProcessor, err := customattribute.GetDiffProcessorIfAttributesDefined(client, d)
+	if err != nil {
+		return err
+	}
+
+	if attrsProcessor == nil {
+		log.Printf("[DEBUG] %s: Custom attributes unsupported on this connection, skipping", resourceVSphereDatastoreClusterIDString(d))
+		return nil
+	}
+
+	log.Printf("[DEBUG] %s: Applying any pending custom attributes", resourceVSphereDatastoreClusterIDString(d))
+	return attrsProcessor.ProcessDiff(pod)
+}
+
+// resourceVSphereDatastoreClusterReadCustomAttributes reads the custom
+// attributes for vsphere_datastore_cluster.
+func resourceVSphereDatastoreClusterReadCustomAttributes(d *schema.ResourceData, meta interface{}, pod *object.StoragePod) error {
+	client := meta.(*VSphereClient).vimClient
+	// Read custom attributes
+	if customattribute.IsSupported(client) {
+		log.Printf("[DEBUG] %s: Reading custom attributes", resourceVSphereDatastoreClusterIDString(d))
+		props, err := storagepod.Properties(pod)
+		if err != nil {
+			return err
+		}
+		customattribute.ReadFromResource(client, props.Entity(), d)
+	} else {
+		log.Printf("[DEBUG] %s: Custom attributes unsupported on this connection, skipping", resourceVSphereDatastoreClusterIDString(d))
+	}
+
+	return nil
+}
+
+// resourceVSphereDatastoreClusterApplySDRSConfig applies the SDRS configuration to a datastore cluster.
+func resourceVSphereDatastoreClusterApplySDRSConfig(d *schema.ResourceData, meta interface{}, pod *object.StoragePod) error {
+	log.Printf("[DEBUG] %s: Applying SDRS configuration", resourceVSphereDatastoreClusterIDString(d))
+	client := meta.(*VSphereClient).vimClient
+	if err := viapi.ValidateVirtualCenter(client); err != nil {
+		return err
+	}
+
+	// Get the version of the vSphere connection to help determine what
+	// attributes we need to set
+	version := viapi.ParseVersionFromClient(client)
+
+	// Expand the SDRS configuration.
+	spec := types.StorageDrsConfigSpec{
+		PodConfigSpec: expandStorageDrsPodConfigSpec(d, version),
+	}
+
+	return storagepod.ApplyDRSConfiguration(client, pod, spec)
+}
+
+// resourceVSphereDatastoreClusterGetPod gets the StoragePod from the ID in the
+// supplied ResourceData.
+func resourceVSphereDatastoreClusterGetPod(d structure.ResourceIDStringer, meta interface{}) (*object.StoragePod, error) {
+	log.Printf("[DEBUG] %s: Fetching StoragePod object from resource ID", resourceVSphereDatastoreClusterIDString(d))
+	client := meta.(*VSphereClient).vimClient
+	if err := viapi.ValidateVirtualCenter(client); err != nil {
+		return nil, err
+	}
+
+	return storagepod.FromID(client, d.Id())
+}
+
+// resourceVSphereDatastoreClusterSaveNameAndPath saves the name and path of a
+// StoragePod into the supplied ResourceData.
+func resourceVSphereDatastoreClusterSaveNameAndPath(d *schema.ResourceData, pod *object.StoragePod) error {
+	log.Printf(
+		"[DEBUG] %s: Saving name and path data for datastore cluster %q",
+		resourceVSphereDatastoreClusterIDString(d),
+		pod.InventoryPath,
+	)
+
+	if err := d.Set("name", pod.Name()); err != nil {
+		return fmt.Errorf("error saving name: %s", err)
+	}
+
+	f, err := folder.RootPathParticleDatastore.SplitRelativeFolder(pod.InventoryPath)
+	if err != nil {
+		return fmt.Errorf("error parsing datastore cluster path %q: %s", pod.InventoryPath, err)
+	}
+	if err := d.Set("folder", folder.NormalizePath(f)); err != nil {
+		return fmt.Errorf("error saving folder: %s", err)
+	}
+	return nil
+}
+
+// resourceVSphereDatastoreClusterFlattenSDRSData saves the DRS attributes from
+// a StoragePod into the supplied ResourceData.
+//
+// Note that other functions handle non-SDRS related items, such as path, name,
+// tags, and custom attributes.
+func resourceVSphereDatastoreClusterFlattenSDRSData(d *schema.ResourceData, meta interface{}, pod *object.StoragePod) error {
+	log.Printf("[DEBUG] %s: Saving datastore cluster attributes", resourceVSphereDatastoreClusterIDString(d))
+	client := meta.(*VSphereClient).vimClient
+	if err := viapi.ValidateVirtualCenter(client); err != nil {
+		return err
+	}
+
+	// Get the version of the vSphere connection to help determine what
+	// attributes we need to set
+	version := viapi.ParseVersionFromClient(client)
+
+	props, err := storagepod.Properties(pod)
+	if err != nil {
+		return err
+	}
+
+	return flattenStorageDrsPodConfigInfo(d, props.PodStorageDrsEntry.StorageDrsConfig.PodConfig, version)
+}
+
+// expandStorageDrsPodConfigSpec reads certain ResourceData keys and returns a
+// StorageDrsPodConfigSpec.
+func expandStorageDrsPodConfigSpec(d *schema.ResourceData, version viapi.VSphereVersion) *types.StorageDrsPodConfigSpec {
+	obj := &types.StorageDrsPodConfigSpec{
+		DefaultIntraVmAffinity: structure.GetBool(d, "sdrs_default_intra_vm_affinity"),
+		DefaultVmBehavior:      d.Get("sdrs_automation_level").(string),
+		Enabled:                structure.GetBool(d, "sdrs_enabled"),
+		IoLoadBalanceConfig:    expandStorageDrsIoLoadBalanceConfig(d, version),
+		IoLoadBalanceEnabled:   structure.GetBool(d, "sdrs_io_load_balance_enabled"),
+		LoadBalanceInterval:    int32(d.Get("sdrs_load_balance_interval").(int)),
+		SpaceLoadBalanceConfig: expandStorageDrsSpaceLoadBalanceConfig(d, version),
+		Option:                 expandStorageDrsOptionSpec(d),
+	}
+
+	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
+		obj.AutomationOverrides = expandStorageDrsAutomationConfig(d)
+	}
+
+	return obj
+}
+
+// flattenStorageDrsPodConfigInfo saves a StorageDrsPodConfigInfo into the supplied ResourceData.
+func flattenStorageDrsPodConfigInfo(d *schema.ResourceData, obj types.StorageDrsPodConfigInfo, version viapi.VSphereVersion) error {
+	attrs := map[string]interface{}{
+		"sdrs_default_intra_vm_affinity": obj.DefaultIntraVmAffinity,
+		"sdrs_automation_level":          obj.DefaultVmBehavior,
+		"sdrs_enabled":                   obj.Enabled,
+		"sdrs_io_load_balance_enabled":   obj.IoLoadBalanceEnabled,
+		"sdrs_load_balance_interval":     obj.LoadBalanceInterval,
+	}
+	for k, v := range attrs {
+		if err := d.Set(k, v); err != nil {
+			return fmt.Errorf("error setting attribute %q: %s", k, err)
+		}
+	}
+
+	return nil
+}
+
+// expandStorageDrsAutomationConfig reads certain ResourceData keys and returns
+// a StorageDrsAutomationConfig.
+func expandStorageDrsAutomationConfig(d *schema.ResourceData) *types.StorageDrsAutomationConfig {
+	obj := &types.StorageDrsAutomationConfig{
+		IoLoadBalanceAutomationMode:     d.Get("sdrs_io_balance_automation_level").(string),
+		PolicyEnforcementAutomationMode: d.Get("sdrs_policy_enforcement_automation_level").(string),
+		RuleEnforcementAutomationMode:   d.Get("sdrs_rule_enforcement_automation_level").(string),
+		SpaceLoadBalanceAutomationMode:  d.Get("sdrs_space_balance_automation_level").(string),
+		VmEvacuationAutomationMode:      d.Get("sdrs_vm_evacuation_automation_level").(string),
+	}
+	return obj
+}
+
+// expandStorageDrsIoLoadBalanceConfig reads certain ResourceData keys and returns
+// a StorageDrsIoLoadBalanceConfig.
+func expandStorageDrsIoLoadBalanceConfig(d *schema.ResourceData, version viapi.VSphereVersion) *types.StorageDrsIoLoadBalanceConfig {
+	obj := &types.StorageDrsIoLoadBalanceConfig{
+		IoLatencyThreshold:       int32(d.Get("sdrs_io_latency_threshold").(int)),
+		IoLoadImbalanceThreshold: int32(d.Get("sdrs_io_load_imbalance_threshold").(int)),
+	}
+
+	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
+		obj.ReservableIopsThreshold = int32(d.Get("sdrs_io_reservable_iops_threshold").(int))
+		obj.ReservablePercentThreshold = int32(d.Get("sdrs_io_reservable_percent_threshold").(int))
+		obj.ReservableThresholdMode = d.Get("sdrs_io_reservable_threshold_mode").(string)
+	}
+
+	return obj
+}
+
+// expandStorageDrsSpaceLoadBalanceConfig reads certain ResourceData keys and returns
+// a StorageDrsSpaceLoadBalanceConfig.
+func expandStorageDrsSpaceLoadBalanceConfig(
+	d *schema.ResourceData,
+	version viapi.VSphereVersion,
+) *types.StorageDrsSpaceLoadBalanceConfig {
+	obj := &types.StorageDrsSpaceLoadBalanceConfig{
+		MinSpaceUtilizationDifference: int32(d.Get("sdrs_free_space_utilization_difference").(int)),
+		SpaceUtilizationThreshold:     int32(d.Get("sdrs_space_utilization_threshold").(int)),
+	}
+
+	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6}) {
+		obj.FreeSpaceThresholdGB = int32(d.Get("sdrs_free_space_threshold").(int))
+		obj.SpaceThresholdMode = d.Get("sdrs_free_space_threshold_mode").(string)
+	}
+
+	return obj
+}
+
+// expandStorageDrsOptionSpec reads certain ResourceData keys and returns
+// a StorageDrsOptionSpec.
+func expandStorageDrsOptionSpec(d *schema.ResourceData) []types.StorageDrsOptionSpec {
+	var opts []types.StorageDrsOptionSpec
+
+	m := d.Get("sdrs_advanced_options").(map[string]interface{})
+	for k, v := range m {
+		opts = append(opts, types.StorageDrsOptionSpec{
+			Option: &types.OptionValue{
+				Key:   k,
+				Value: types.AnyType(v),
+			},
+		})
+	}
+	return opts
+}
+
+// resourceVSphereDatastoreClusterIDString prints a friendly string for the
+// vsphere_datastore_cluster resource.
+func resourceVSphereDatastoreClusterIDString(d structure.ResourceIDStringer) string {
+	return structure.ResourceIDString(d, "vsphere_datastore_cluster")
+}

--- a/vsphere/resource_vsphere_datastore_cluster.go
+++ b/vsphere/resource_vsphere_datastore_cluster.go
@@ -42,7 +42,6 @@ func resourceVSphereDatastoreCluster() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name for the new storage pod.",
-				StateFunc:   folder.NormalizePath,
 			},
 			"datacenter_id": {
 				Type:        schema.TypeString,

--- a/vsphere/resource_vsphere_datastore_cluster_test.go
+++ b/vsphere/resource_vsphere_datastore_cluster_test.go
@@ -4,11 +4,21 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	testAccResourceVSphereDatastoreClusterNameStandard = "terraform-datastore-cluster-test"
+	testAccResourceVSphereDatastoreClusterNameRenamed  = "terraform-datastore-cluster-test-renamed"
+	testAccResourceVSphereDatastoreClusterFolder       = "datastore-cluster-folder-test"
 )
 
 func TestAccResourceVSphereDatastoreCluster_basic(t *testing.T) {
@@ -49,6 +59,319 @@ func TestAccResourceVSphereDatastoreCluster_sdrsEnabled(t *testing.T) {
 	})
 }
 
+func TestAccResourceVSphereDatastoreCluster_rename(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigWithName(testAccResourceVSphereDatastoreClusterNameStandard),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckName(testAccResourceVSphereDatastoreClusterNameStandard),
+				),
+			},
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigWithName(testAccResourceVSphereDatastoreClusterNameRenamed),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckName(testAccResourceVSphereDatastoreClusterNameRenamed),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_inFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigWithFolder(testAccResourceVSphereDatastoreClusterFolder),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterMatchInventoryPath(testAccResourceVSphereDatastoreClusterFolder),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_moveToFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterMatchInventoryPath(""),
+				),
+			},
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigWithFolder(testAccResourceVSphereDatastoreClusterFolder),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterMatchInventoryPath(testAccResourceVSphereDatastoreClusterFolder),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_sdrsOverrides(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigSDRSOverrides(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSDefaultAutomationLevel(string(types.StorageDrsPodConfigInfoBehaviorManual)),
+					testAccResourceVSphereDatastoreClusterCheckSDRSOverrides(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_miscTweaks(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigSDRSMiscTweaks(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSDefaultIntraVMAffinity(false),
+					testAccResourceVSphereDatastoreClusterCheckSDRSIoLatencyThreshold(5),
+					testAccResourceVSphereDatastoreClusterCheckSDRSSpaceThresholdMode(
+						string(types.StorageDrsSpaceLoadBalanceConfigSpaceThresholdModeUtilization),
+					),
+					testAccResourceVSphereDatastoreClusterCheckSDRSSpaceUtilizationThreshold(50),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_reservableIops(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigReservableIopsManual(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSReservableIopsThresholdMode(
+						string(types.StorageDrsPodConfigInfoBehaviorManual),
+					),
+					testAccResourceVSphereDatastoreClusterCheckSDRSReservableIopsThreshold(5000),
+				),
+			},
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigReservableIopsAutomatic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSReservableIopsThresholdMode(
+						string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+					),
+					testAccResourceVSphereDatastoreClusterCheckSDRSReservablePercentThreshold(40),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_freeSpace(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigSpaceManual(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSSpaceThresholdMode(
+						string(types.StorageDrsSpaceLoadBalanceConfigSpaceThresholdModeFreeSpace),
+					),
+					testAccResourceVSphereDatastoreClusterCheckSDRSFreeSpaceThresholdGB(500),
+				),
+			},
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigSDRSMiscTweaks(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSSpaceThresholdMode(
+						string(types.StorageDrsSpaceLoadBalanceConfigSpaceThresholdModeUtilization),
+					),
+					testAccResourceVSphereDatastoreClusterCheckSDRSSpaceUtilizationThreshold(50),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_singleTag(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigSingleTag(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckTags("terraform-test-tag"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_multipleTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigMultiTag(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckTags("terraform-test-tags-alt"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_switchTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigSingleTag(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckTags("terraform-test-tag"),
+				),
+			},
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigMultiTag(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckTags("terraform-test-tags-alt"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_singleCustomAttribute(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigSingleCustomAttribute(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckCustomAttributes(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_multipleCustomAttribute(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigMultiCustomAttributes(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckCustomAttributes(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_switchCustomAttribute(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigSingleCustomAttribute(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckCustomAttributes(),
+				),
+			},
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigMultiCustomAttributes(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckCustomAttributes(),
+				),
+			},
+		},
+	})
+}
+
 func testAccResourceVSphereDatastoreClusterCheckExists(expected bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, err := testGetDatastoreCluster(s, "datastore_cluster")
@@ -77,6 +400,234 @@ func testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(expected bool) resou
 			return fmt.Errorf("expected enabled to be %t, got %t", expected, actual)
 		}
 		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckName(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		pod, err := testGetDatastoreCluster(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+		actual := pod.Name()
+		if expected != actual {
+			return fmt.Errorf("expected name to be %q, got %q", expected, actual)
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterMatchInventoryPath(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		pod, err := testGetDatastoreCluster(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+
+		expected, err = folder.RootPathParticleDatastore.PathFromNewRoot(pod.InventoryPath, folder.RootPathParticleDatastore, expected)
+		actual := path.Dir(pod.InventoryPath)
+		if err != nil {
+			return fmt.Errorf("bad: %s", err)
+		}
+		if expected != actual {
+			return fmt.Errorf("expected path to be %s, got %s", expected, actual)
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSDefaultAutomationLevel(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.DefaultVmBehavior
+		if expected != actual {
+			return fmt.Errorf("expected default automation level to be %q got %q", expected, actual)
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSOverrides() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+		expected := &types.StorageDrsAutomationConfig{
+			IoLoadBalanceAutomationMode:     string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+			PolicyEnforcementAutomationMode: string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+			RuleEnforcementAutomationMode:   string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+			SpaceLoadBalanceAutomationMode:  string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+			VmEvacuationAutomationMode:      string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+		}
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.AutomationOverrides
+		if !reflect.DeepEqual(expected, actual) {
+			return fmt.Errorf("expected %#v, got %#v", expected, actual)
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSDefaultIntraVMAffinity(expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+
+		actual := *props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.DefaultIntraVmAffinity
+
+		if expected != actual {
+			return fmt.Errorf("expected DefaultIntraVmAffinity to be %t, got %t", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSIoLatencyThreshold(expected int32) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.IoLoadBalanceConfig.IoLatencyThreshold
+
+		if expected != actual {
+			return fmt.Errorf("expected IoLatencyThreshold to be %d, got %d", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSSpaceUtilizationThreshold(expected int32) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.SpaceLoadBalanceConfig.SpaceUtilizationThreshold
+
+		if expected != actual {
+			return fmt.Errorf("expected SpaceUtilizationThreshold to be %d, got %d", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSSpaceThresholdMode(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.SpaceLoadBalanceConfig.SpaceThresholdMode
+
+		if expected != actual {
+			return fmt.Errorf("expected SpaceThresholdMode to be %q, got %q", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSReservableIopsThresholdMode(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.IoLoadBalanceConfig.ReservableThresholdMode
+
+		if expected != actual {
+			return fmt.Errorf("expected SpaceThresholdMode to be %q, got %q", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSReservableIopsThreshold(expected int32) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.IoLoadBalanceConfig.ReservableIopsThreshold
+
+		if expected != actual {
+			return fmt.Errorf("expected SpaceThresholdMode to be %d, got %d", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSReservablePercentThreshold(expected int32) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.IoLoadBalanceConfig.ReservablePercentThreshold
+
+		if expected != actual {
+			return fmt.Errorf("expected SpaceThresholdMode to be %d, got %d", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSFreeSpaceThresholdGB(expected int32) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.SpaceLoadBalanceConfig.FreeSpaceThresholdGB
+
+		if expected != actual {
+			return fmt.Errorf("expected SpaceUtilizationThreshold to be %d, got %d", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckTags(tagResName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		pod, err := testGetDatastoreCluster(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+		tagsClient, err := testAccProvider.Meta().(*VSphereClient).TagsClient()
+		if err != nil {
+			return err
+		}
+		return testObjectHasTags(s, tagsClient, pod, tagResName)
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckCustomAttributes() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+		return testResourceHasCustomAttributeValues(s, "vsphere_datastore_cluster", "datastore_cluster", props.Entity())
 	}
 }
 
@@ -113,6 +664,326 @@ resource "vsphere_datastore_cluster" "datastore_cluster" {
   name          = "terraform-datastore-cluster-test"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
   sdrs_enabled  = true
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigWithName(name string) string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "%s"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		name,
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigWithFolder(f string) string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "folder" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_folder" "datastore_cluster_folder" {
+  path          = "${var.folder}"
+  type          = "datastore"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  folder        = "${vsphere_folder.datastore_cluster_folder.path}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		f,
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigSDRSOverrides() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name                                     = "terraform-datastore-cluster-test"
+  datacenter_id                            = "${data.vsphere_datacenter.dc.id}"
+  sdrs_enabled                             = true
+  sdrs_automation_level                    = "manual"
+  sdrs_space_balance_automation_level      = "automated"
+  sdrs_io_balance_automation_level         = "automated"
+  sdrs_rule_enforcement_automation_level   = "automated"
+  sdrs_policy_enforcement_automation_level = "automated"
+  sdrs_vm_evacuation_automation_level      = "automated"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigSDRSMiscTweaks() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name                             = "terraform-datastore-cluster-test"
+  datacenter_id                    = "${data.vsphere_datacenter.dc.id}"
+  sdrs_enabled                     = true
+  sdrs_default_intra_vm_affinity   = false
+  sdrs_io_latency_threshold        = 5
+  sdrs_space_utilization_threshold = 50
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigReservableIopsManual() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name                              = "terraform-datastore-cluster-test"
+  datacenter_id                     = "${data.vsphere_datacenter.dc.id}"
+  sdrs_enabled                      = true
+  sdrs_io_reservable_threshold_mode = "manual"
+  sdrs_io_reservable_iops_threshold = 5000
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigReservableIopsAutomatic() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name                                 = "terraform-datastore-cluster-test"
+  datacenter_id                        = "${data.vsphere_datacenter.dc.id}"
+  sdrs_enabled                         = true
+  sdrs_io_reservable_percent_threshold = 40
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigSpaceManual() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name                           = "terraform-datastore-cluster-test"
+  datacenter_id                  = "${data.vsphere_datacenter.dc.id}"
+  sdrs_enabled                   = true
+  sdrs_free_space_threshold_mode = "freeSpace"
+  sdrs_free_space_threshold      = 500
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigSingleTag() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_tag_category" "terraform-test-category" {
+  name        = "terraform-test-tag-category"
+  cardinality = "MULTIPLE"
+
+  associable_types = [
+    "StoragePod",
+  ]
+}
+
+resource "vsphere_tag" "terraform-test-tag" {
+  name        = "terraform-test-tag"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+
+  tags = [
+    "${vsphere_tag.terraform-test-tag.id}",
+  ]
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigMultiTag() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "extra_tags" {
+  default = [
+    "terraform-test-thing1",
+    "terraform-test-thing2",
+  ]
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_tag_category" "terraform-test-category" {
+  name        = "terraform-test-tag-category"
+  cardinality = "MULTIPLE"
+
+  associable_types = [
+    "StoragePod",
+  ]
+}
+
+resource "vsphere_tag" "terraform-test-tag" {
+  name        = "terraform-test-tag"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+
+resource "vsphere_tag" "terraform-test-tags-alt" {
+  count       = "${length(var.extra_tags)}"
+  name        = "${var.extra_tags[count.index]}"
+  category_id = "${vsphere_tag_category.terraform-test-category.id}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+
+  tags = ["${vsphere_tag.terraform-test-tags-alt.*.id}"]
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigSingleCustomAttribute() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_custom_attribute" "terraform-test-attribute" {
+  name                = "terraform-test-attribute"
+  managed_object_type = "StoragePod"
+}
+
+locals {
+  attrs = {
+    "${vsphere_custom_attribute.terraform-test-attribute.id}" = "value"
+  }
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+
+  custom_attributes = "${local.attrs}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigMultiCustomAttributes() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_custom_attribute" "terraform-test-attribute" {
+  name                = "terraform-test-attribute"
+  managed_object_type = "StoragePod"
+}
+
+resource "vsphere_custom_attribute" "terraform-test-attribute-2" {
+  name                = "terraform-test-attribute-2"
+  managed_object_type = "StoragePod"
+}
+
+locals {
+  attrs = {
+    "${vsphere_custom_attribute.terraform-test-attribute.id}" = "value"
+    "${vsphere_custom_attribute.terraform-test-attribute-2.id}" = "value-2"
+  }
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+
+  custom_attributes = "${local.attrs}"
 }
 `,
 		os.Getenv("VSPHERE_DATACENTER"),

--- a/vsphere/resource_vsphere_datastore_cluster_test.go
+++ b/vsphere/resource_vsphere_datastore_cluster_test.go
@@ -372,6 +372,43 @@ func TestAccResourceVSphereDatastoreCluster_switchCustomAttribute(t *testing.T) 
 	})
 }
 
+func TestAccResourceVSphereDatastoreCluster_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(false),
+				),
+			},
+			{
+				ResourceName:            "vsphere_datastore_cluster.datastore_cluster",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"datacenter_id", "sdrs_free_space_threshold"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					pod, err := testGetDatastoreCluster(s, "datastore_cluster")
+					if err != nil {
+						return "", err
+					}
+					return pod.InventoryPath, nil
+				},
+				Config: testAccResourceVSphereDatastoreClusterConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(false),
+				),
+			},
+		},
+	})
+}
+
 func testAccResourceVSphereDatastoreClusterCheckExists(expected bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, err := testGetDatastoreCluster(s, "datastore_cluster")

--- a/vsphere/resource_vsphere_datastore_cluster_test.go
+++ b/vsphere/resource_vsphere_datastore_cluster_test.go
@@ -1,0 +1,120 @@
+package vsphere
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
+)
+
+func TestAccResourceVSphereDatastoreCluster_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(false),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereDatastoreCluster_sdrsEnabled(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereDatastoreClusterConfigSDRSBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereDatastoreClusterCheckExists(true),
+					testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(true),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceVSphereDatastoreClusterCheckExists(expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := testGetDatastoreCluster(s, "datastore_cluster")
+		if err != nil {
+			if viapi.IsManagedObjectNotFoundError(err) && expected == false {
+				// Expected missing
+				return nil
+			}
+			return err
+		}
+		if !expected {
+			return errors.New("expected datastore cluster to be missing")
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterCheckSDRSEnabled(expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		props, err := testGetDatastoreClusterProperties(s, "datastore_cluster")
+		if err != nil {
+			return err
+		}
+		actual := props.PodStorageDrsEntry.StorageDrsConfig.PodConfig.Enabled
+		if expected != actual {
+			return fmt.Errorf("expected enabled to be %t, got %t", expected, actual)
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereDatastoreClusterConfigBasic() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccResourceVSphereDatastoreClusterConfigSDRSBasic() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  sdrs_enabled  = true
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -986,19 +986,8 @@ func applyVirtualDevices(d *schema.ResourceData, c *govmomi.Client, l object.Vir
 	return spec, nil
 }
 
-// resourceVSphereVirtualMachineIDStringInterface is a small interface so
-// that we can take ResourceData and ResourceDiff in
-// resourceVSphereVirtualMachineIDString.
-type resourceVSphereVirtualMachineIDStringInterface interface {
-	Id() string
-}
-
 // resourceVSphereVirtualMachineIDString prints a friendly string for the
 // vsphere_virtual_machine resource.
-func resourceVSphereVirtualMachineIDString(d resourceVSphereVirtualMachineIDStringInterface) string {
-	id := d.Id()
-	if id == "" {
-		id = "<new resource>"
-	}
-	return fmt.Sprintf("vsphere_virtual_machine (ID = %s)", id)
+func resourceVSphereVirtualMachineIDString(d structure.ResourceIDStringer) string {
+	return structure.ResourceIDString(d, "vsphere_virtual_machine")
 }

--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -205,6 +205,8 @@ func tagTypeForObject(obj object.Reference) (string, error) {
 		return vSphereTagTypeClusterComputeResource, nil
 	case *object.HostSystem:
 		return vSphereTagTypeHostSystem, nil
+	case *object.StoragePod:
+		return vSphereTagTypeStoragePod, nil
 	}
 	return "", fmt.Errorf("unsupported type for tagging: %T", obj)
 }

--- a/website/docs/r/datastore_cluster.html.markdown
+++ b/website/docs/r/datastore_cluster.html.markdown
@@ -1,0 +1,227 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_datastore_cluster"
+sidebar_current: "docs-vsphere-resource-storage-datastore-cluster"
+description: |-
+  Provides a vSphere datastore cluster resource. This can be used to create and manage datastore clusters.
+---
+
+# vsphere\_datastore\_cluster
+
+The `vsphere_datastore_cluster` resource can be used to create and manage
+datastore clusters. This can be used to create groups of datastores with a
+shared management interface, allowing for resource control and load balancing
+through Storage DRS.
+
+For more information on vSphere datastore clusters and Storage DRS, see [this
+page][ref-vsphere-datastore-clusters].
+
+[ref-vsphere-datastore-clusters]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-598DF695-107E-406B-9C95-0AF961FC227A.html
+
+~> **NOTE:** This resource requires vCenter and is not available on direct ESXi
+connections.
+
+~> **NOTE:** Storage DRS requires a vSphere Enterprise Plus license.
+
+## Example Usage
+
+The following example sets up a datastore cluster and enables Storage DRS with
+the default settings. It then creates two NAS datastores using the
+[`vsphere_nas_datastore` resource][ref-tf-nas-datastore] and assigns them to
+the datastore cluster.
+
+[ref-tf-nas-datastore]: /docs/providers/vsphere/r/nas_datastore.html
+
+```hcl
+variable "hosts" {
+  default = [
+    "esxi1",
+    "esxi2",
+    "esxi3",
+  ]
+}
+
+data "vsphere_datacenter" "datacenter" {}
+
+data "vsphere_host" "esxi_hosts" {
+  count         = "${length(var.hosts)}"
+  name          = "${var.hosts[count.index]}"
+  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
+  sdrs_enabled  = true
+}
+
+resource "vsphere_nas_datastore" "datastore1" {
+  name                 = "terraform-datastore-test1"
+  host_system_ids      = ["${data.vsphere_host.esxi_hosts.*.id}"]
+  datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
+
+  type         = "NFS"
+  remote_hosts = ["nfs"]
+  remote_path  = "/export/terraform-test1"
+}
+
+resource "vsphere_nas_datastore" "datastore2" {
+  name                 = "terraform-datastore-test2"
+  host_system_ids      = ["${data.vsphere_host.esxi_hosts.*.id}"]
+  datastore_cluster_id = "${vsphere_datastore_cluster.datastore_cluster.id}"
+
+  type         = "NFS"
+  remote_hosts = ["nfs"]
+  remote_path  = "/export/terraform-test2"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the datastore cluster.
+* `datacenter_id` - (Required) The [managed object ID][docs-about-morefs] of
+  the datacenter to create the datastore cluster in. Forces a new resource if
+  changed.
+* `folder` - (Optional) The relative path to a folder to put this datastore
+  cluster in.  This is a path relative to the datacenter you are deploying the
+  datastore to.  Example: for the `dc1` datacenter, and a provided `folder` of
+  `foo/bar`, Terraform will place a datastore cluster named
+  `terraform-datastore-cluster-test` in a datastore folder located at
+  `/dc1/datastore/foo/bar`, with the final inventory path being
+  `/dc1/datastore/foo/bar/terraform-datastore-cluster-test`.
+* `sdrs_enabled` - (Optional) Enable Storage DRS for this datastore cluster.
+  Default: `false`.
+* `tags` - (Optional) The IDs of any tags to attach to this resource. See
+  [here][docs-applying-tags] for a reference on how to apply tags.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
+[docs-applying-tags]: /docs/providers/vsphere/r/tag.html#using-tags-in-a-supported-resource
+
+~> **NOTE:** Tagging support requires vCenter 6.0 or higher.
+
+* `custom_attributes` - (Optional) A map of custom attribute ids to attribute
+  value strings to set for the datastore cluster. See
+  [here][docs-setting-custom-attributes] for a reference on how to set values
+  for custom attributes.
+
+[docs-setting-custom-attributes]: /docs/providers/vsphere/r/custom_attribute.html#using-custom-attributes-in-a-supported-resource
+
+~> **NOTE:** Custom attributes are unsupported on direct ESXi connections 
+and require vCenter.
+
+### Storage DRS automation options
+
+The following options control the automation levels for Storage DRS on the
+datastore cluster.
+
+All options below can either be one of two settings: `manual` for manual mode,
+where Storage DRS makes migration recommendations but does not execute them, or
+`automated` for fully automated mode, where Storage DRS executes migration
+recommendations automatically.
+
+The automation level can be further tuned for each specific SDRS subsystem.
+Specifying an override will set the automation level for that part of Storage
+DRS to the respective level. Not specifying an override infers that you want to
+use the cluster default automation level.
+
+* `sdrs_automation_level` - (Optional) The default automation level for all
+  virtual machines in this datastore cluster.
+* `sdrs_space_balance_automation_level` - (Optional) Overrides the default
+  automation settings when correcting disk space imbalances.
+* `sdrs_io_balance_automation_level` - (Optional) Overrides the default
+  automation settings when correcting I/O load imbalances.
+* `sdrs_rule_enforcement_automation_level` - (Optional) Overrides the default
+  automation settings when correcting affinity rule violations.
+* `sdrs_policy_enforcement_automation_level` - (Optional) Overrides the default
+  automation settings when correcting storage and VM policy violations.
+* `sdrs_vm_evacuation_automation_level` - (Optional) Overrides the default
+  automation settings when generating recommendations for datastore evacuation.
+
+### Storage DRS I/O load balancing settings
+
+The following options control I/O load balancing for Storage DRS on the
+datastore cluster.
+
+~> **NOTE:** All reservable IOPS settings require vSphere 6.0 or higher and are
+ignored on older versions.
+
+* `sdrs_io_load_balance_enabled` - (Optional) Enable I/O load balancing for
+  this datastore cluster. Default: `true`.
+* `sdrs_io_latency_threshold` - (Optional) The I/O latency threshold, in
+  milliseconds, that storage DRS uses to make recommendations to move disks
+  from this datastore. Default: `15` seconds.
+* `sdrs_io_load_imbalance_threshold` - (Optional) The difference between load
+  in datastores in the cluster before storage DRS makes recommendations to
+  balance the load. Default: `5` percent.
+* `sdrs_io_reservable_iops_threshold` - (Optional) The threshold of reservable
+  IOPS of all virtual machines on the datastore before storage DRS makes
+  recommendations to move VMs off of a datastore. Note that this setting should
+  only be set if `sdrs_io_reservable_percent_threshold` cannot make an accurate
+  estimate of the capacity of the datastores in your cluster, and should be set
+  to roughly 50-60% of the worst case peak performance of the backing LUNs.
+* `sdrs_io_reservable_percent_threshold` - (Optional) The threshold, in
+  percent, of actual estimated performance of the datastore (in IOPS) that
+  storage DRS uses to make recommendations to move VMs off of a datastore when
+  the total reservable IOPS exceeds the threshold. Default: `60` percent.
+* `sdrs_io_reservable_threshold_mode` - (Optional) The reservable IOPS
+  threshold setting to use, `sdrs_io_reservable_percent_threshold` in the event
+  of `automatic`, or `sdrs_io_reservable_iops_threshold` in the event of
+  `manual`. Default: `automatic`.
+
+### Storage DRS disk space load balancing settings
+
+The following options control disk space load balancing for Storage DRS on the
+datastore cluster.
+
+~> **NOTE:** Setting `sdrs_free_space_threshold_mode` to `freeSpace` and using
+the `sdrs_free_space_threshold` setting requires vSphere 6.0 or higher and is
+ignored on older versions. Using these settings on older versions may result in
+spurious diffs in Terraform.
+
+* `sdrs_free_space_utilization_difference` - (Optional) The threshold, in
+  percent of used space, that storage DRS uses to make decisions to migrate VMs
+  out of a datastore. Default: `80` percent.
+* `sdrs_free_space_utilization_difference` - (Optional) The threshold, in
+  percent, of difference between space utilization in datastores before storage
+  DRS makes decisions to balance the space. Default: `5` percent.
+* `sdrs_free_space_threshold` - (Optional) The threshold, in GB, that storage
+  DRS uses to make decisions to migrate VMs out of a datastore. Default: `50`
+  GB.
+* `sdrs_free_space_threshold` - (Optional) The free space threshold to use.
+  When set to `utilization`, `drs_space_utilization_threshold` is used, and
+  when set to `freeSpace`, `drs_free_space_threshold` is used. Default:
+  `utilization`.
+
+### Storage DRS advanced settings
+
+The following options control advanced parts of Storage DRS that may not
+require changing during basic operation:
+
+* `sdrs_default_intra_vm_affinity` - (Optional) When `true`, all disks in a
+  single virtual machine will be kept on the same datastore. Default: `true`.
+* `sdrs_load_balance_interval` - (Optional) The storage DRS poll interval, in
+  minutes. Default: `480` minutes.
+* `sdrs_advanced_options` - (Optional) A key/value map of advanced Storage DRS
+  settings that are not exposed via Terraform or the vSphere client.
+
+## Attribute Reference
+
+The only computed attribute that is exported by this resource is the resource
+`id`, which is the the [managed object reference ID][docs-about-morefs] of the
+datastore cluster.
+
+## Importing
+
+An existing datastore cluster can be [imported][docs-import] into this resource
+via the path to the cluster, via the following command:
+
+[docs-import]: https://www.terraform.io/docs/import/index.html
+
+```
+terraform import vsphere_datastore_cluster.datastore_cluster /dc1/datastore/ds-cluster
+```
+
+The above would import the datastore cluster named `ds-cluster` that is located
+in the `dc1` datacenter.

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -100,6 +100,9 @@
         <li<%= sidebar_current("docs-vsphere-resource-storage") %>>
           <a href="#">Storage Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-resource-storage-datastore-cluster") %>>
+              <a href="/docs/providers/vsphere/r/datastore_cluster.html">vsphere_datastore_cluster</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-resource-storage-file") %>>
               <a href="/docs/providers/vsphere/r/file.html">vsphere_file</a>
             </li>


### PR DESCRIPTION
This is the first part of a new push to add clustering and DRS support in the vSphere provider.

This adds `vsphere_datastore_cluster`, which can be used to create datastore clusters and configure Storage DRS for it respectively. Pretty much everything that's exposed in vSphere is exposed in the resource.

Note that the docs reference functionality that is not implemented yet - this is the `datastore_cluster_id` attribute, which will basically be a "pseudo-folder" attribute and conflict with `folder` in the `vsphere_nas_datastore` and `vsphere_vmfs_datastore` resources, allowing a datastore to be created in or moved to a datastore cluster.

After this support is in and functional we can use it to start writing datastore cluster support into the `vsphere_virtual_machine` resource to address #2.
