### PR TITLE
d/datastore_cluster: New data source

### DIFF
--- a/vsphere/data_source_vsphere_datastore_cluster.go
+++ b/vsphere/data_source_vsphere_datastore_cluster.go
@@ -1,0 +1,35 @@
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceVSphereDatastoreCluster() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereDatastoreClusterRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name or absolute path to the datastore cluster.",
+			},
+			"datacenter_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The managed object ID of the datacenter the cluster is located in. Not required if using an absolute path.",
+			},
+		},
+	}
+}
+
+func dataSourceVSphereDatastoreClusterRead(d *schema.ResourceData, meta interface{}) error {
+	pod, err := resourceVSphereDatastoreClusterGetPodFromPath(meta, d.Get("name").(string), d.Get("datacenter_id").(string))
+	if err != nil {
+		return fmt.Errorf("error loading datastore cluster: %s", err)
+	}
+	d.SetId(pod.Reference().Value)
+	return nil
+}

--- a/vsphere/data_source_vsphere_datastore_cluster_test.go
+++ b/vsphere/data_source_vsphere_datastore_cluster_test.go
@@ -1,0 +1,98 @@
+package vsphere
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceVSphereDatastoreCluster_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDatastoreClusterConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_datastore_cluster.datastore_cluster_data", "id",
+						"vsphere_datastore_cluster.datastore_cluster", "id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVSphereDatastoreCluster_absolutePathNoDatacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereDatastoreClusterConfigAbsolutePath(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_datastore_cluster.datastore_cluster_data", "id",
+						"vsphere_datastore_cluster.datastore_cluster", "id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVSphereDatastoreClusterConfigBasic() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_datastore_cluster" "datastore_cluster_data" {
+  name          = "${vsphere_datastore_cluster.datastore_cluster.name}"
+  datacenter_id = "${vsphere_datastore_cluster.datastore_cluster.datacenter_id}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccDataSourceVSphereDatastoreClusterConfigAbsolutePath() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_datastore_cluster" "datastore_cluster_data" {
+  name          = "/${var.datacenter}/datastore/${vsphere_datastore_cluster.datastore_cluster.name}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -111,6 +111,7 @@ func Provider() terraform.ResourceProvider {
 			"vsphere_custom_attribute":           dataSourceVSphereCustomAttribute(),
 			"vsphere_datacenter":                 dataSourceVSphereDatacenter(),
 			"vsphere_datastore":                  dataSourceVSphereDatastore(),
+			"vsphere_datastore_cluster":          dataSourceVSphereDatastoreCluster(),
 			"vsphere_distributed_virtual_switch": dataSourceVSphereDistributedVirtualSwitch(),
 			"vsphere_host":                       dataSourceVSphereHost(),
 			"vsphere_network":                    dataSourceVSphereNetwork(),

--- a/vsphere/resource_vsphere_datastore_cluster_test.go
+++ b/vsphere/resource_vsphere_datastore_cluster_test.go
@@ -25,6 +25,7 @@ func TestAccResourceVSphereDatastoreCluster_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -44,6 +45,7 @@ func TestAccResourceVSphereDatastoreCluster_sdrsEnabled(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -63,6 +65,7 @@ func TestAccResourceVSphereDatastoreCluster_rename(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -89,6 +92,7 @@ func TestAccResourceVSphereDatastoreCluster_inFolder(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -108,6 +112,7 @@ func TestAccResourceVSphereDatastoreCluster_moveToFolder(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -134,6 +139,7 @@ func TestAccResourceVSphereDatastoreCluster_sdrsOverrides(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -155,6 +161,7 @@ func TestAccResourceVSphereDatastoreCluster_miscTweaks(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -180,6 +187,7 @@ func TestAccResourceVSphereDatastoreCluster_reservableIops(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -214,6 +222,7 @@ func TestAccResourceVSphereDatastoreCluster_freeSpace(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -248,6 +257,7 @@ func TestAccResourceVSphereDatastoreCluster_singleTag(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -267,6 +277,7 @@ func TestAccResourceVSphereDatastoreCluster_multipleTags(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -286,6 +297,7 @@ func TestAccResourceVSphereDatastoreCluster_switchTags(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -312,6 +324,7 @@ func TestAccResourceVSphereDatastoreCluster_singleCustomAttribute(t *testing.T) 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -331,6 +344,7 @@ func TestAccResourceVSphereDatastoreCluster_multipleCustomAttribute(t *testing.T
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -350,6 +364,7 @@ func TestAccResourceVSphereDatastoreCluster_switchCustomAttribute(t *testing.T) 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -376,6 +391,7 @@ func TestAccResourceVSphereDatastoreCluster_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccResourceVSphereDatastoreClusterPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccResourceVSphereDatastoreClusterCheckExists(false),
@@ -407,6 +423,12 @@ func TestAccResourceVSphereDatastoreCluster_import(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccResourceVSphereDatastoreClusterPreCheck(t *testing.T) {
+	if os.Getenv("VSPHERE_DATACENTER") == "" {
+		t.Skip("set VSPHERE_DATACENTER to run vsphere_datastore_cluster acceptance tests")
+	}
 }
 
 func testAccResourceVSphereDatastoreClusterCheckExists(expected bool) resource.TestCheckFunc {

--- a/website/docs/d/datastore_cluster.html.markdown
+++ b/website/docs/d/datastore_cluster.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_datastore_cluster"
+sidebar_current: "docs-vsphere-data-source-cluster-datastore"
+description: |-
+  Provides a vSphere datastore cluster data source. This can be used to get the general attributes of a vSphere datastore cluster.
+---
+
+# vsphere\_datastore\_cluster
+
+The `vsphere_datastore_cluster` data source can be used to discover the ID of a
+datastore cluster in vSphere. This is useful to fetch the ID of a datastore
+cluster that you want to use to assign datastores to using the
+[`vsphere_nas_datastore`][docs-nas-datastore-resource] or
+[`vsphere_vmfs_datastore`][docs-vmfs-datastore-resource] resources, or create
+virtual machines in using the
+[`vsphere_virtual_machine`][docs-virtual-machine-resource] resource. 
+
+[docs-nas-datastore-resource]: /docs/providers/vsphere/r/nas_datastore.html
+[docs-vmfs-datastore-resource]: /docs/providers/vsphere/r/vmfs_datastore.html
+[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html
+
+## Example Usage
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name = "dc1"
+}
+
+data "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "datastore-cluster1"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name or absolute path to the datastore cluster.
+* `datacenter_id` - (Optional) The [managed object reference
+  ID][docs-about-morefs] of the datacenter the datastore cluster is located in.
+  This can be omitted if the search path used in `name` is an absolute path.
+  For default datacenters, use the id attribute from an empty
+  `vsphere_datacenter` data source.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
+
+## Attribute Reference
+
+Currently, the only exported attribute from this data source is `id`, which
+represents the ID of the datastore cluster that was looked up.

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -22,6 +22,9 @@
             <li<%= sidebar_current("docs-vsphere-data-source-datastore") %>>
               <a href="/docs/providers/vsphere/d/datastore.html">vsphere_datastore</a>
             </li>
+            <li<%= sidebar_current("docs-vsphere-data-source-cluster-datastore") %>>
+              <a href="/docs/providers/vsphere/d/datastore_cluster.html">vsphere_datastore_cluster</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-data-source-distributed-virtual-switch") %>>
               <a href="/docs/providers/vsphere/d/distributed_virtual_switch.html">vsphere_distributed_virtual_switch</a>
             </li>


### PR DESCRIPTION
This is a data source counterpart to the `vsphere_datastore_cluster`
resource, designed to fetch the ID of a datastore cluster only as we
want to be able to provide a data source avenue for this data, to ensure
that people can use existing infrastructure that was not created in
Terraform.