### PR TITLE
Capture updated device list when destroying disks

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -531,7 +531,7 @@ func DiskDestroyOperation(d *schema.ResourceData, c *govmomi.Client, l object.Vi
 		if err != nil {
 			return nil, fmt.Errorf("%s: %s", r.Addr(), err)
 		}
-		applyDeviceChange(l, dspec)
+		l = applyDeviceChange(l, dspec)
 		spec = append(spec, dspec...)
 	}
 


### PR DESCRIPTION
The procedure "applyDeviceChange" modifies the
object.VirtualDeviceList it is passed, and returns an updated
reference to the object. As an object.VirtualDeviceList is a slice,
and modifying elements of a slice modifies the underlying array,
failing to capture this return value results in an inaccurate view of
the available devices. In this case, when destroying a disk, if the
last element of the object.VirtualDeviceList is a disk,
"findVirtualDiskByUUIDOrAddress" will incorrectly report that there
are multiple disks with the same UUID.

Fixes issue #404.