### PR TITLE
r/datastore_cluster: Change default SDRS automation level to manual

### DIFF
--- a/vsphere/resource_vsphere_datastore_cluster.go
+++ b/vsphere/resource_vsphere_datastore_cluster.go
@@ -64,7 +64,7 @@ func resourceVSphereDatastoreCluster() *schema.Resource {
 			"sdrs_automation_level": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      string(types.StorageDrsPodConfigInfoBehaviorAutomated),
+				Default:      string(types.StorageDrsPodConfigInfoBehaviorManual),
 				Description:  "The default automation level for all virtual machines in this storage cluster.",
 				ValidateFunc: validation.StringInSlice(storageDrsPodConfigInfoBehaviorAllowedValues, false),
 			},

--- a/website/docs/r/datastore_cluster.html.markdown
+++ b/website/docs/r/datastore_cluster.html.markdown
@@ -126,8 +126,8 @@ Specifying an override will set the automation level for that part of Storage
 DRS to the respective level. Not specifying an override infers that you want to
 use the cluster default automation level.
 
-* `sdrs_automation_level` - (Optional) The default automation level for all
-  virtual machines in this datastore cluster.
+* `sdrs_automation_level` - (Optional) The global automation level for all
+  virtual machines in this datastore cluster. Default: `manual`.
 * `sdrs_space_balance_automation_level` - (Optional) Overrides the default
   automation settings when correcting disk space imbalances.
 * `sdrs_io_balance_automation_level` - (Optional) Overrides the default


### PR DESCRIPTION
This was mistakenly set to automated - the actual default as per the
vSphere documentation is manual. Changed to be consistent.

Reference: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.resmgmt.doc/GUID-563D504F-DEC3-430A-8294-7135CBBADB83.html

> Manual is the default automation level.