### PR TITLE
r/virtual_machine: Fix vApp ISO tests

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -3933,6 +3933,8 @@ resource "vsphere_virtual_machine" "vm" {
   memory   = 2048
   guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
 
+  wait_for_guest_net_timeout = 10
+
   network_interface {
     network_id   = "${data.vsphere_network.network.id}"
     adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
@@ -3946,14 +3948,14 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   cdrom {
-    datastore_id  = "${data.vsphere_datastore.cdrom_datastore.id}"
-    path          = "${var.cdrom_iso}"
+    datastore_id = "${data.vsphere_datastore.cdrom_datastore.id}"
+    path         = "${var.cdrom_iso}"
   }
 
   vapp {
     properties {
       "user-data" = "${base64encode(data.template_file.config_data.rendered)}"
-      "hostname" = "custom-hostname"
+      "hostname"  = "custom-hostname"
     }
   }
 
@@ -4070,6 +4072,8 @@ resource "vsphere_virtual_machine" "vm" {
   memory   = 2048
   guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
 
+  wait_for_guest_net_timeout = 10
+
   network_interface {
     network_id   = "${data.vsphere_network.network.id}"
     adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
@@ -4085,7 +4089,7 @@ resource "vsphere_virtual_machine" "vm" {
   vapp {
     properties {
       "user-data" = "${base64encode(data.template_file.config_data.rendered)}"
-      "hostname" = "custom-hostname"
+      "hostname"  = "custom-hostname"
     }
   }
 
@@ -4200,6 +4204,8 @@ resource "vsphere_virtual_machine" "vm" {
   memory   = 2048
   guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
 
+  wait_for_guest_net_timeout = 10
+
   network_interface {
     network_id   = "${data.vsphere_network.network.id}"
     adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
@@ -4219,7 +4225,7 @@ resource "vsphere_virtual_machine" "vm" {
   vapp {
     properties {
       "user-data" = "${base64encode(data.template_file.config_data.rendered)}"
-      "hostname" = "custom-hostname"
+      "hostname"  = "custom-hostname"
     }
   }
 


### PR DESCRIPTION
This fixes the vApp ISO tests, which were failing because the Ubuntu
OVAs do not have a way of getting a static network configuration, hence
they wait 5 minutes on DHCP on our static network.

We had an image we hacked to lower this timeout, but the template was
recently re-uploaded, and the hacking process is cumbersome (involving
mounting the VMDK in the OVA to add an override to networking.service),
and is not easily repeatable with our current process.

As the acceptance tests are automated, waiting the extra time for the
DHCP timeout is not a big deal. Hence we've just upped
`wait_for_guest_net_timeout` to 10 minutes on the appropriate fixtures.