### PR TITLE
datastore.html sample code fix

### DIFF
--- a/website/docs/d/datastore.html.markdown
+++ b/website/docs/d/datastore.html.markdown
@@ -24,7 +24,7 @@ data "vsphere_datacenter" "datacenter" {
 
 data "vsphere_datastore" "datastore" {
   name          = "datastore1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
 }
 ```
 


### PR DESCRIPTION
Fixing example code so that the datacenter_id in vsphere_datastore is retrieved from the previous vsphere_datacenter block