### PR TITLE
d/virtual_machine: Nil check for empty VM configuration

### DIFF
--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -100,6 +100,10 @@ func dataSourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("error fetching virtual machine properties: %s", err)
 	}
 
+	if props.Config == nil {
+		return fmt.Errorf("no configuration returned for virtual machine %q", vm.InventoryPath)
+	}
+
 	d.SetId(props.Config.Uuid)
 	d.Set("guest_id", props.Config.GuestId)
 	d.Set("alternate_guest_name", props.Config.AlternateGuestName)


### PR DESCRIPTION
This handles a crash case when there is no configuration for a specified
virtual machine.

This unfortunately is an edge case and hard for us to test for, as cases
like this where the VM lack a `config` attribute are usually due to issues
with importing the VM, or an orphaned virtual machine in vSphere.

Ref: #432