### PR TITLE
vendor: Update TF to @v0.11.7

### DIFF
--- a/vendor/github.com/hashicorp/terraform/terraform/interpolate.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/interpolate.go
@@ -789,7 +789,8 @@ func (i *Interpolater) resourceCountMax(
 	// If we're NOT applying, then we assume we can read the count
 	// from the state. Plan and so on may not have any state yet so
 	// we do a full interpolation.
-	if i.Operation != walkApply {
+	// Don't forget walkDestroy, which is a special case of walkApply
+	if !(i.Operation == walkApply || i.Operation == walkDestroy) {
 		if cr == nil {
 			return 0, nil
 		}

--- a/vendor/github.com/hashicorp/terraform/version/version.go
+++ b/vendor/github.com/hashicorp/terraform/version/version.go
@@ -16,7 +16,7 @@ const Version = "0.11.7"
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
-var Prerelease = "dev"
+var Prerelease = ""
 
 // SemVer is an instance of version.Version. This has the secondary
 // benefit of verifying during tests and init time that our version is a

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -486,188 +486,250 @@
 		{
 			"checksumSHA1": "D2qVXjDywJu6wLj/4NCTsFnRrvw=",
 			"path": "github.com/hashicorp/terraform/config",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "WzQP2WfiCYlaALKZVqEFsxZsG1o=",
 			"path": "github.com/hashicorp/terraform/config/configschema",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "3V7300kyZF+AGy/cOKV0+P6M3LY=",
 			"path": "github.com/hashicorp/terraform/config/hcl2shim",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "HayBWvFE+t9aERoz9kpE2MODurk=",
 			"path": "github.com/hashicorp/terraform/config/module",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "mPbjVPD2enEey45bP4M83W2AxlY=",
 			"path": "github.com/hashicorp/terraform/dag",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "P8gNPDuOzmiK4Lz9xG7OBy4Rlm8=",
 			"path": "github.com/hashicorp/terraform/flatmap",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "zx5DLo5aV0xDqxGTzSibXg7HHAA=",
 			"path": "github.com/hashicorp/terraform/helper/acctest",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "uT6Q9RdSRAkDjyUgQlJ2XKJRab4=",
 			"path": "github.com/hashicorp/terraform/helper/config",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "Vbo55GDzPgG/L/+W2pcvDhxrPZc=",
 			"path": "github.com/hashicorp/terraform/helper/experiment",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "KNvbU1r5jv0CBeQLnEtDoL3dRtc=",
 			"path": "github.com/hashicorp/terraform/helper/hashcode",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "B267stWNQd0/pBTXHfI/tJsxzfc=",
 			"path": "github.com/hashicorp/terraform/helper/hilmapstructure",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "BAXV9ruAyno3aFgwYI2/wWzB2Gc=",
 			"path": "github.com/hashicorp/terraform/helper/logging",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "ImyqbHM/xe3eAT2moIjLI8ksuks=",
 			"path": "github.com/hashicorp/terraform/helper/pathorcontents",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "ryCWu7RtMlYrAfSevaI7RtaXe98=",
 			"path": "github.com/hashicorp/terraform/helper/resource",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "JHxGzmxcIS8NyLX9pGhK5beIra4=",
 			"path": "github.com/hashicorp/terraform/helper/schema",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "1yCGh/Wl4H4ODBBRmIRFcV025b0=",
 			"path": "github.com/hashicorp/terraform/helper/shadow",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "Fzbv+N7hFXOtrR6E7ZcHT3jEE9s=",
 			"path": "github.com/hashicorp/terraform/helper/structure",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "nEC56vB6M60BJtGPe+N9rziHqLg=",
 			"path": "github.com/hashicorp/terraform/helper/validation",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "kD1ayilNruf2cES1LDfNZjYRscQ=",
 			"path": "github.com/hashicorp/terraform/httpclient",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "yFWmdS6yEJZpRJzUqd/mULqCYGk=",
 			"path": "github.com/hashicorp/terraform/moduledeps",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "DqaoG++NXRCfvH/OloneLWrM+3k=",
 			"path": "github.com/hashicorp/terraform/plugin",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "tx5xrdiUWdAHqoRV5aEfALgT1aU=",
 			"path": "github.com/hashicorp/terraform/plugin/discovery",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "f6wDpr0uHKZqQw4ztvxMrtiuvQo=",
 			"path": "github.com/hashicorp/terraform/registry",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "cR87P4V5aiEfvF+1qoBi2JQyQS4=",
 			"path": "github.com/hashicorp/terraform/registry/regsrc",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "y9IXgIJQq9XNy1zIYUV2Kc0KsnA=",
 			"path": "github.com/hashicorp/terraform/registry/response",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "VXlzRRDVOqeMvnnrbUcR9H64OA4=",
 			"path": "github.com/hashicorp/terraform/svchost",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "GzcKNlFL0N77JVjU8qbltXE4R3k=",
 			"path": "github.com/hashicorp/terraform/svchost/auth",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "jiDWmQieUE6OoUBMs53hj9P/JDQ=",
 			"path": "github.com/hashicorp/terraform/svchost/disco",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
-			"checksumSHA1": "JeSgWy3Rmeb3GOUnI0asmfsGMzA=",
+			"checksumSHA1": "lHCKONqlaHsn5cEaYltad7dvRq8=",
 			"path": "github.com/hashicorp/terraform/terraform",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "+K+oz9mMTmQMxIA3KVkGRfjvm9I=",
 			"path": "github.com/hashicorp/terraform/tfdiags",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
-			"checksumSHA1": "fhEXjiBnW+4M+C3iPCWHzO1E7B0=",
+			"checksumSHA1": "+attjxAt9nwFpCjxWEL08YwpGD8=",
 			"path": "github.com/hashicorp/terraform/version",
-			"revision": "d7048cb640c53294df36283e297316751e113fcd",
-			"revisionTime": "2018-04-07T20:06:47Z"
+			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
+			"revisionTime": "2018-04-10T16:50:42Z",
+			"version": "v0.11.7",
+			"versionExact": "v0.11.7"
 		},
 		{
 			"checksumSHA1": "ZhK6IO2XN81Y+3RAjTcVm1Ic7oU=",


### PR DESCRIPTION
Our copy was mostly up to date already, but this ensures that we are
vendoring at a tag versus a commit.