### PR TITLE
r/virtual_machine: Ensure datastore_id will always have a diff on new disk sub-resources

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -78,7 +78,6 @@ func DiskSubresourceSchema() map[string]*schema.Schema {
 		"datastore_id": {
 			Type:          schema.TypeString,
 			Optional:      true,
-			Computed:      true,
 			ConflictsWith: []string{"datastore_cluster_id"},
 			Description:   "The datastore ID for this virtual disk, if different than the virtual machine.",
 		},
@@ -641,6 +640,9 @@ nextNew:
 		nm["uuid"] = ""
 		if a, ok := nm["attach"]; !ok || !a.(bool) {
 			nm["path"] = ""
+		}
+		if dsID, ok := nm["datastore_id"]; !ok || dsID == "" {
+			nm["datastore_id"] = diskDatastoreComputedName
 		}
 		normalized = append(normalized, nm)
 	}
@@ -1661,7 +1663,7 @@ func (r *DiskSubresource) createDisk(l object.VirtualDeviceList) (*types.Virtual
 
 func (r *DiskSubresource) assignBackingInfo(disk *types.VirtualDisk) error {
 	dsID := r.Get("datastore_id").(string)
-	if dsID == "" {
+	if dsID == "" || dsID == diskDatastoreComputedName {
 		// Default to the default datastore
 		dsID = r.rdd.Get("datastore_id").(string)
 	}

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -78,6 +78,7 @@ func DiskSubresourceSchema() map[string]*schema.Schema {
 		"datastore_id": {
 			Type:          schema.TypeString,
 			Optional:      true,
+			Computed:      true,
 			ConflictsWith: []string{"datastore_cluster_id"},
 			Description:   "The datastore ID for this virtual disk, if different than the virtual machine.",
 		},

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -1243,6 +1243,50 @@ func TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNew(t *testing.T) {
 	})
 }
 
+func TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNewWithDatastore(t *testing.T) {
+	var state *terraform.State
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereVirtualMachineConfigCloneParameterized(
+					os.Getenv("VSPHERE_DATASTORE"),
+					"terraform-test",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					copyState(&state),
+					testAccResourceVSphereVirtualMachineCheckExists(true),
+					testAccResourceVSphereVirtualMachineCheckHostname("terraform-test"),
+					testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("VSPHERE_DATASTORE")),
+					testAccResourceVSphereVirtualMachineCheckVmdkDatastore("terraform-test.vmdk", os.Getenv("VSPHERE_DATASTORE")),
+				),
+			},
+			{
+				Config: testAccResourceVSphereVirtualMachineConfigCloneParameterized(
+					os.Getenv("VSPHERE_DATASTORE2"),
+					"terraform-test-renamed",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereVirtualMachineCheckExists(true),
+					testAccResourceVSphereVirtualMachineCheckHostname("terraform-test-renamed"),
+					testAccResourceVSphereVirtualMachineCheckVmxDatastore(os.Getenv("VSPHERE_DATASTORE2")),
+					testAccResourceVSphereVirtualMachineCheckVmdkDatastore("terraform-test.vmdk", os.Getenv("VSPHERE_DATASTORE2")),
+					func(s *terraform.State) error {
+						oldID := state.RootModule().Resources["vsphere_virtual_machine.vm"].Primary.ID
+						return testCheckResourceNotAttr("vsphere_virtual_machine.vm", "id", oldID)(s)
+					},
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceVSphereVirtualMachine_datastoreClusterClone(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -11214,5 +11258,132 @@ resource "vsphere_virtual_machine" "vm" {
 		os.Getenv("VSPHERE_DATASTORE"),
 		os.Getenv("VSPHERE_TEMPLATE"),
 		datastore,
+	)
+}
+
+func testAccResourceVSphereVirtualMachineConfigCloneParameterized(datastore, hostname string) string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "ipv4_address" {
+  default = "%s"
+}
+
+variable "ipv4_netmask" {
+  default = "%s"
+}
+
+variable "ipv4_gateway" {
+  default = "%s"
+}
+
+variable "dns_server" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+variable "template" {
+  default = "%s"
+}
+
+variable "linked_clone" {
+  default = "%s"
+}
+
+variable "hostname" {
+	default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = "${var.template}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
+
+  network_interface {
+    network_id   = "${data.vsphere_network.network.id}"
+    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+  }
+
+  disk {
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+  }
+
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    linked_clone  = "${var.linked_clone != "" ? "true" : "false" }"
+
+    customize {
+      linux_options {
+        host_name = "${var.hostname}"
+        domain    = "test.internal"
+      }
+
+      network_interface {
+        ipv4_address = "${var.ipv4_address}"
+        ipv4_netmask = "${var.ipv4_netmask}"
+      }
+
+      ipv4_gateway    = "${var.ipv4_gateway}"
+      dns_server_list = ["${var.dns_server}"]
+      dns_suffix_list = ["test.internal"]
+    }
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL"),
+		os.Getenv("VSPHERE_IPV4_ADDRESS"),
+		os.Getenv("VSPHERE_IPV4_PREFIX"),
+		os.Getenv("VSPHERE_IPV4_GATEWAY"),
+		os.Getenv("VSPHERE_DNS"),
+		datastore,
+		os.Getenv("VSPHERE_TEMPLATE"),
+		os.Getenv("VSPHERE_USE_LINKED_CLONE"),
+		hostname,
 	)
 }


### PR DESCRIPTION
This is something that has been an issue for while but is now even more prominent now that datastores don't necessarily need to be specified at all. Owing in part that `datastore_id` is not populated during the initial TF apply when using the default datastore for disks, changing both the default datastore (or now, possibly, datastore clusters) and a key that forces a new resource at the same time will create a diff mismatch.

A couple of approaches can fix this issue:

* The first one being marking the `datastore_id` attribute of the `disk` sub-resource as `Computed`, but this method opens the resource up to other bugs when a new disk is taking the place of an old disk in state, and Optional/Computed ultimately results in the old datastore ID setting being grafted into the new sub-resource.
* The second is to set the datastore_id attribute for new disks that enter the diff to the same <computed> value that we give these resources otherwise when the attribute is not present (example: when the disk is not pinned to a datastore).

The latter approach is what was ultimately taken as it fixes the issue without introducing the regression mentioned in the first.