### PR TITLE
r/virtual_machine: Controllable routable network waiter behavior

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine_migrate.go
+++ b/vsphere/resource_vsphere_virtual_machine_migrate.go
@@ -211,6 +211,7 @@ func migrateVSphereVirtualMachineStateV2(is *terraform.InstanceState, meta inter
 	is.Attributes["migrate_wait_timeout"] = fmt.Sprintf("%v", rs["migrate_wait_timeout"].Default)
 	is.Attributes["shutdown_wait_timeout"] = fmt.Sprintf("%v", rs["shutdown_wait_timeout"].Default)
 	is.Attributes["wait_for_guest_net_timeout"] = guestNetTimeout
+	is.Attributes["wait_for_guest_net_routable"] = fmt.Sprintf("%v", rs["wait_for_guest_net_routable"].Default)
 	is.Attributes["scsi_controller_count"] = fmt.Sprintf("%v", maxBus+1)
 
 	// Populate our disk data from the fake state.

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -1210,6 +1210,27 @@ func TestAccResourceVSphereVirtualMachine_cloneFromTemplate(t *testing.T) {
 	})
 }
 
+func TestAccResourceVSphereVirtualMachine_cloneNoGateway(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereVirtualMachineConfigCloneNoGateway(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereVirtualMachineCheckExists(true),
+					resource.TestCheckResourceAttr("vsphere_virtual_machine.vm", "default_ip_address", os.Getenv("VSPHERE_IPV4_ADDRESS")),
+					resource.TestCheckResourceAttrSet("vsphere_virtual_machine.vm", "guest_ip_addresses.#"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceVSphereVirtualMachine_cloneCustomizeForceNew(t *testing.T) {
 	var state *terraform.State
 
@@ -11214,5 +11235,123 @@ resource "vsphere_virtual_machine" "vm" {
 		os.Getenv("VSPHERE_DATASTORE"),
 		os.Getenv("VSPHERE_TEMPLATE"),
 		datastore,
+	)
+}
+
+func testAccResourceVSphereVirtualMachineConfigCloneNoGateway() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "ipv4_address" {
+  default = "%s"
+}
+
+variable "ipv4_netmask" {
+  default = "%s"
+}
+
+variable "dns_server" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+variable "template" {
+  default = "%s"
+}
+
+variable "linked_clone" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = "${var.template}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
+
+	wait_for_guest_net_routable = false
+
+  network_interface {
+    network_id   = "${data.vsphere_network.network.id}"
+    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+  }
+
+  disk {
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+  }
+
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    linked_clone  = "${var.linked_clone != "" ? "true" : "false" }"
+
+    customize {
+      linux_options {
+        host_name = "terraform-test"
+        domain    = "test.internal"
+      }
+
+      network_interface {
+        ipv4_address = "${var.ipv4_address}"
+        ipv4_netmask = "${var.ipv4_netmask}"
+      }
+
+      dns_server_list = ["${var.dns_server}"]
+      dns_suffix_list = ["test.internal"]
+    }
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL"),
+		os.Getenv("VSPHERE_IPV4_ADDRESS"),
+		os.Getenv("VSPHERE_IPV4_PREFIX"),
+		os.Getenv("VSPHERE_DNS"),
+		os.Getenv("VSPHERE_DATASTORE"),
+		os.Getenv("VSPHERE_TEMPLATE"),
+		os.Getenv("VSPHERE_USE_LINKED_CLONE"),
 	)
 }

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -75,14 +75,14 @@ Two waiters of note are:
   the timeout or turn it off. This can be controlled by the
   [`timeout`](#timeout-1) setting in the [customization
   settings](#virtual-machine-customization) block.
-* **The network waiter:** This waiter waits for a _routeable_ interface to show
-  up on a guest virtual machine close to the end of both VM creation and
-  update. This waiter is necessary to ensure that correct IP information gets
-  reported to the guest virtual machine, mainly to facilitate the availability
-  of a valid, routeable default IP address for any
-  [provisioners][tf-docs-provisioners]. This option can be managed or turned
-  off via the [`wait_for_guest_net_timeout`](#wait_for_guest_net_timeout)
-  top-level setting.
+* **The network waiter:** This waiter waits for interfaces to show up on a
+  guest virtual machine close to the end of both VM creation and update. This
+  waiter is necessary to ensure that correct IP information gets reported to
+  the guest virtual machine, mainly to facilitate the availability of a valid,
+  reachable default IP address for any [provisioners][tf-docs-provisioners].
+  The behavior of the waiter can be controlled with the
+  [`wait_for_guest_net_timeout`](#wait_for_guest_net_timeout) and
+  [`wait_for_guest_net_routable`](#wait_for_guest_net_routable) settings.
 
 [tf-docs-provisioners]: /docs/provisioners/index.html
 
@@ -621,8 +621,12 @@ behavior.
   virtual machine. Can be one of `inherit`, `hostLocal`, or `vmDirectory`.
   Default: `inherit`.
 * `wait_for_guest_net_timeout` - (Optional) The amount of time, in minutes, to
-  wait for a routeable IP address on this virtual machine. A value less than 1
-  disables the waiter. Defualt: 5 minutes.
+  wait for an available IP address on this virtual machine. A value less than 1
+  disables the waiter. Default: 5 minutes.
+* `wait_for_guest_net_routable` - (Optional) Controls whether or not the guest
+  network waiter waits for a routable address. When `false`, the waiter does
+  not wait for a default gateway, nor are IP addresses checked against any
+  discovered default gateways as part of its success criteria. Default: `true`.
 * `shutdown_wait_timeout` - (Optional) The amount of time, in minutes, to wait
   for a graceful guest shutdown when making necessary updates to the virtual
   machine. If `force_power_off` is set to true, the VM will be force powered-off


### PR DESCRIPTION
This adds the wait_for_guest_net_routable setting, which allows for the
modification of the behavior of the network waiter with relation to
whether or not it compares IP addresses it discovers against the default
gateway.

When false, the waiter will ignore any gateways - it will exit
successfully on discovery of any "real" address - in other words, one
that is not link-local/loopback/multicast, regardless of if the address
does not match a discovered default gateway, or regardless if a gateway
has even been discovered yet.

-----

Related: #462, #446, #337, #231, #207.