### PR TITLE
r/virtual_machine: Restore ID availability to rollback functionality

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -975,8 +975,12 @@ func resourceVSphereVirtualMachineCreateClone(d *schema.ResourceData, meta inter
 	}
 
 	// The VM has been created. We still need to do post-clone configuration, and
-	// the resource cannot have an ID until this is done. All of the operations
-	// here need to roll back if there is an error.
+	// while the resource should have an ID until this is done, we need it to go
+	// through post-clone rollback workflows. All rollback functions will remove
+	// the ID after it has done its rollback.
+	//
+	// It's generally safe to not rollback after the initial re-configuration is
+	// fully complete and we move on to sending the customization spec.
 	vprops, err := virtualmachine.Properties(vm)
 	if err != nil {
 		return nil, resourceVSphereVirtualMachineRollbackCreate(
@@ -987,6 +991,7 @@ func resourceVSphereVirtualMachineCreateClone(d *schema.ResourceData, meta inter
 		)
 	}
 	log.Printf("[DEBUG] VM %q - UUID is %q", vm.InventoryPath, vprops.Config.Uuid)
+	d.SetId(vprops.Config.Uuid)
 
 	// Before starting or proceeding any further, we need to normalize the
 	// configuration of the newly cloned VM. This is basically a subset of update
@@ -1069,10 +1074,6 @@ func resourceVSphereVirtualMachineCreateClone(d *schema.ResourceData, meta inter
 		)
 	}
 
-	// It's safe to set the UUID here now. Any changes past this should not
-	// create any irrecoverable state issues.
-	d.SetId(vprops.Config.Uuid)
-
 	var cw *virtualMachineCustomizationWaiter
 	// Send customization spec if any has been defined.
 	if len(d.Get("clone.0.customize").([]interface{})) > 0 {
@@ -1153,6 +1154,7 @@ func resourceVSphereVirtualMachineRollbackCreate(
 	vm *object.VirtualMachine,
 	origErr error,
 ) error {
+	defer d.SetId("")
 	// Updates are largely atomic, so more than likely no disks with
 	// keep_on_remove were attached, but just in case, we run this through delete
 	// to make sure to safely remove any disk that may have been attached as part


### PR DESCRIPTION
The ID of the resource is actually necessary for rollback as we send the
VM through full resource deletion during rollback (this is to safely
detach any disks that may have been attached already). This commit moves
the ID step back to where it previously was. However, we clear the ID no
matter what in the rollback function (via a defer at the start of the
rollback function).