### PR TITLE
Fixing example code (documentation)

### DIFF
--- a/website/docs/d/resource_pool.html.markdown
+++ b/website/docs/d/resource_pool.html.markdown
@@ -24,7 +24,7 @@ data "vsphere_datacenter" "datacenter" {
 
 data "vsphere_resource_pool" "pool" {
   name          = "resource-pool-1"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
 }
 ```
 

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -25,7 +25,7 @@ data "vsphere_datacenter" "datacenter" {
 
 data "vsphere_virtual_machine" "template" {
   name          = "test-vm-template"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  datacenter_id = "${data.vsphere_datacenter.datacenter.id}"
 }
 ```
 


### PR DESCRIPTION
Fixing example code so that the datacenter_id is retrieved from the previous vsphere_datacenter block. Similar to #459 but in two other pages - I think this is them all