### PR TITLE
d/compute_cluster: New data source

### DIFF
--- a/vsphere/data_source_vsphere_compute_cluster.go
+++ b/vsphere/data_source_vsphere_compute_cluster.go
@@ -1,0 +1,50 @@
+package vsphere
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource"
+)
+
+func dataSourceVSphereComputeCluster() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVSphereComputeClusterRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name or absolute path to the cluster.",
+			},
+			"datacenter_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The managed object ID of the datacenter the cluster is located in. Not required if using an absolute path.",
+			},
+			"resource_pool_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The managed object ID of the cluster's root resource pool.",
+			},
+		},
+	}
+}
+
+func dataSourceVSphereComputeClusterRead(d *schema.ResourceData, meta interface{}) error {
+	cluster, err := resourceVSphereComputeClusterGetClusterFromPath(meta, d.Get("name").(string), d.Get("datacenter_id").(string))
+	if err != nil {
+		return fmt.Errorf("error loading cluster: %s", err)
+	}
+	props, err := clustercomputeresource.Properties(cluster)
+	if err != nil {
+		return fmt.Errorf("error loading cluster properties: %s", err)
+	}
+
+	d.SetId(cluster.Reference().Value)
+	if err := d.Set("resource_pool_id", props.ResourcePool.Value); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vsphere/data_source_vsphere_compute_cluster_test.go
+++ b/vsphere/data_source_vsphere_compute_cluster_test.go
@@ -1,0 +1,106 @@
+package vsphere
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceVSphereComputeCluster_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereComputeClusterPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereComputeClusterConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_compute_cluster.compute_cluster_data", "id",
+						"vsphere_compute_cluster.compute_cluster", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_compute_cluster.compute_cluster_data", "resource_pool_id",
+						"vsphere_compute_cluster.compute_cluster", "resource_pool_id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceVSphereComputeCluster_absolutePathNoDatacenter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereComputeClusterPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereComputeClusterConfigAbsolutePath(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_compute_cluster.compute_cluster_data", "id",
+						"vsphere_compute_cluster.compute_cluster", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_compute_cluster.compute_cluster_data", "resource_pool_id",
+						"vsphere_compute_cluster.compute_cluster", "resource_pool_id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVSphereComputeClusterConfigBasic() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_compute_cluster" "compute_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_compute_cluster" "compute_cluster_data" {
+  name          = "${vsphere_compute_cluster.compute_cluster.name}"
+  datacenter_id = "${vsphere_compute_cluster.compute_cluster.datacenter_id}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}
+
+func testAccDataSourceVSphereComputeClusterConfigAbsolutePath() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_compute_cluster" "compute_cluster" {
+  name          = "terraform-datastore-cluster-test"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_compute_cluster" "compute_cluster_data" {
+  name          = "/${var.datacenter}/host/${vsphere_compute_cluster.compute_cluster.name}"
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+	)
+}

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -110,6 +110,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"vsphere_compute_cluster":            dataSourceVSphereComputeCluster(),
 			"vsphere_custom_attribute":           dataSourceVSphereCustomAttribute(),
 			"vsphere_datacenter":                 dataSourceVSphereDatacenter(),
 			"vsphere_datastore":                  dataSourceVSphereDatastore(),

--- a/website/docs/d/compute_cluster.html.markdown
+++ b/website/docs/d/compute_cluster.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_compute_cluster"
+sidebar_current: "docs-vsphere-data-source-compute-cluster"
+description: |-
+  Provides a vSphere cluster data source. This can be used to get the general attributes of a vSphere cluster.
+---
+
+# vsphere\_compute\_cluster
+
+The `vsphere_compute_cluster` data source can be used to discover the ID of a
+cluster in vSphere. This is useful to fetch the ID of a cluster that you want
+to use for virtual machine placement via the
+[`vsphere_virtual_machine`][docs-virtual-machine-resource] resource, allowing
+you to specify the cluster's root resource pool directly versus using the alias
+available through the [`vsphere_resource_pool`][docs-resource-pool-data-source]
+data source.
+
+[docs-virtual-machine-resource]: /docs/providers/vsphere/r/virtual_machine.html
+[docs-resource-pool-data-source]: /docs/providers/vsphere/d/resource_pool.html
+
+-> You may also wish to see the
+[`vsphere_compute_cluster`][docs-compute-cluster-resource] resource for further
+details about clusters or how to work with them in Terraform.
+
+[docs-compute-cluster-resource]: /docs/providers/vsphere/r/compute_cluster.html
+
+## Example Usage
+
+```hcl
+data "vsphere_datacenter" "datacenter" {
+  name = "dc1"
+}
+
+data "vsphere_compute_cluster" "compute_cluster" {
+  name          = "compute-cluster1"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name or absolute path to the cluster.
+* `datacenter_id` - (Optional) The [managed object reference
+  ID][docs-about-morefs] of the datacenter the cluster is located in.  This can
+  be omitted if the search path used in `name` is an absolute path.  For
+  default datacenters, use the id attribute from an empty `vsphere_datacenter`
+  data source.
+
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id`: The [managed object reference ID][docs-about-morefs] of the cluster.
+* `resource_pool_id`: The [managed object reference ID][docs-about-morefs] of
+  the root resource pool for the cluster.

--- a/website/docs/d/resource_pool.html.markdown
+++ b/website/docs/d/resource_pool.html.markdown
@@ -28,16 +28,22 @@ data "vsphere_resource_pool" "pool" {
 }
 ```
 
-### Specifying the root resource pool for a cluster or standalone host
+### Specifying the root resource pool for a standalone host
 
-All clusters and standalone hosts have a resource pool, even if one has not
-been explicitly created. This resource pool is referred to as the _root
-resource pool_ and can be looked up by specifying the path as per the example
-below:
+-> **NOTE:** Fetching the root resource pool for a cluster can now be done
+directly via the [`vsphere_compute_cluster`][docs-compute-cluster-data-source]
+data source.
+
+[docs-compute-cluster-data-source]: /docs/providers/vsphere/d/compute_cluster.html
+
+All compute resources in vSphere (clusters, standalone hosts, and standalone
+ESXi) have a resource pool, even if one has not been explicitly created. This
+resource pool is referred to as the _root resource pool_ and can be looked up
+by specifying the path as per the example below:
 
 ```
 data "vsphere_resource_pool" "pool" {
-  name          = "cluster1/Resources"
+  name          = "esxi1/Resources"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 ```

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -131,8 +131,8 @@ data "vsphere_datastore" "datastore" {
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
-data "vsphere_resource_pool" "pool" {
-  name          = "cluster1/Resources"
+data "vsphere_compute_cluster" "cluster" {
+  name          = "cluster1"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
@@ -143,7 +143,7 @@ data "vsphere_network" "network" {
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-test"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
   datastore_id     = "${data.vsphere_datastore.datastore.id}"
 
   num_cpus = 2
@@ -185,8 +185,8 @@ data "vsphere_datastore" "datastore" {
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
-data "vsphere_resource_pool" "pool" {
-  name          = "cluster1/Resources"
+data "vsphere_compute_cluster" "cluster" {
+  name          = "cluster1"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
@@ -202,7 +202,7 @@ data "vsphere_virtual_machine" "template" {
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-test"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
   datastore_id     = "${data.vsphere_datastore.datastore.id}"
 
   num_cpus = 2
@@ -274,8 +274,8 @@ data "vsphere_datastore" "datastore" {
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
-data "vsphere_resource_pool" "pool" {
-  name          = "cluster1/Resources"
+data "vsphere_compute_cluster" "cluster" {
+  name          = "cluster1"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
@@ -291,7 +291,7 @@ data "vsphere_virtual_machine" "tempate_from_ovf" {
 
 resource "vsphere_virtual_machine" "vm" {
   name             = "terraform-test"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
   datastore_id     = "${data.vsphere_datastore.datastore.id}"
 
   num_cpus = 2
@@ -366,8 +366,8 @@ data "vsphere_datastore_cluster" "datastore_cluster" {
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
-data "vsphere_resource_pool" "pool" {
-  name          = "cluster1/Resources"
+data "vsphere_compute_cluster" "cluster" {
+  name          = "cluster1"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
@@ -378,7 +378,7 @@ data "vsphere_network" "network" {
 
 resource "vsphere_virtual_machine" "vm" {
   name                 = "terraform-test"
-  resource_pool_id     = "${data.vsphere_resource_pool.pool.id}"
+  resource_pool_id     = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
   datastore_cluster_id = "${data.vsphere_datastore_cluster.datastore_cluster.id}"
 
   num_cpus = 2
@@ -415,12 +415,11 @@ options:
 
 ~> **NOTE:** All clusters and standalone hosts have a resource pool, even if
 one has not been explicitly created. For more information, see the section on
-[specifying the root resource pool for a cluster or standalone
-host][docs-resource-pool-cluster-default] in the `vsphere_resource_pool` data
-source documentation. This resource does not take a cluster or standalone host
-resource directly.
+[specifying the root resource pool ][docs-resource-pool-cluster-default] in the
+`vsphere_resource_pool` data source documentation. This resource does not take
+a cluster or standalone host resource directly.
 
-[docs-resource-pool-cluster-default]: /docs/providers/vsphere/d/resource_pool.html#specifying-the-default-resource-pool-for-a-cluster
+[docs-resource-pool-cluster-default]: /docs/providers/vsphere/d/resource_pool.html#specifying-the-root-resource-pool-for-a-standalone-host
 
 * `datastore_id` - (Optional) The [managed object reference
   ID][docs-about-morefs] of the virtual machine's datastore. The virtual

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-vsphere-data-source") %>>
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-data-source-compute-cluster.html") %>>
+              <a href="/docs/providers/vsphere/d/compute_cluster.html">vsphere_compute_cluster</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-data-source-custom-attribute") %>>
               <a href="/docs/providers/vsphere/d/custom_attribute.html">vsphere_custom_attribute</a>
             </li>


### PR DESCRIPTION
This adds the `vsphere_compute_cluster` data source, which allows one to
look up an existing cluster.

It also closes a convenience gap in the provider which has been a point
of confusion since around 1.0, in that people looking to supply the
`resource_pool_id` for a virtual machine were confused in that they didn't
think they had a resource pool. This now allows someone to specify a
cluster directly, and then use the `resource_pool_id` attribute from this
data source as the input to `vsphere_virtual_machine`.