### PR TITLE
r/virtual_machine: Prevent eagerly_scrub and thin_provisioned from both being true

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1461,6 +1461,12 @@ func (r *DiskSubresource) DiffGeneral() error {
 			return fmt.Errorf("multi-writer disk_sharing is only supported on vSphere 6 and higher")
 		}
 	}
+	// Prevent eagerly_scrub and thin_provisioned from both being set to true. A
+	// thin_provisioned disk cannot be eagerly scrubbed since it would then be
+	// allocating the entire disk.
+	if r.Get("eagerly_scrub").(bool) && r.Get("thin_provisioned").(bool) {
+		return fmt.Errorf("%s: eagerly_scrub and thin_provisioned cannot both be set to true", name)
+	}
 	log.Printf("[DEBUG] %s: Diff validation complete", r)
 	return nil
 }

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -760,11 +760,12 @@ externally with `attach` when the `path` field is not specified.
 
 * `eagerly_scrub` - (Optional) If set to `true`, the disk space is zeroed out
   on VM creation. This will delay the creation of the disk or virtual machine.
-  See the section on [picking a disk type](#picking-a-disk-type).  Default:
-  `false`.
-* `thin_provisioned` - (Optional) If `true`, this disk is thin provisioned, with
-  space for the file being allocated on an as-needed basis. See the section on
-  [picking a disk type](#picking-a-disk-type). Default: `true`. 
+  Cannot be set to `true` when `thin_provisioned` is `true`.  See the section
+  on [picking a disk type](#picking-a-disk-type).  Default: `false`.
+* `thin_provisioned` - (Optional) If `true`, this disk is thin provisioned,
+  with space for the file being allocated on an as-needed basis. Cannot be set
+  to `true` when `eagerly_scrub` is `true`. See the section on [picking a disk
+  type](#picking-a-disk-type). Default: `true`. 
 * `disk_sharing` - (Optional) The sharing mode of this virtual disk. Can be one
   of `sharingMultiWriter` or `sharingNone`. Default: `sharingNone`.
 


### PR DESCRIPTION
A thin provisioned disk cannot be eagerly scrubbed or the entire disk
would be allocated. When eagerlyScrub is set to true in the API, VMware
will change thinProvisioned to false, which will cause a diff on the
next run.