### PR TITLE
Add attribute to create parent directories when creating a virtual disk

### DIFF
--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -62,3 +62,10 @@ disk controller types. This parameter will be removed in future versions of the
 vSphere provider.
 
 [docs-vsphere-virtual-machine-scsi-type]: /docs/providers/vsphere/r/virtual_machine.html#scsi_type
+
+* `create_directories` - (Optional) Create directories in `vmdk_path`
+  path parameter if any missing for disk creation operation.
+
+~> **NOTE:** Any directory created as part of the operation when
+`create_directories` is enabled will not be deleted when the resource is
+destroyed.


### PR DESCRIPTION
This PR introduces the attribute to create the parent directories in the datastore when creating a `resource_vsphere_virtualdisk`. It uses the same logic seen in `resource_vsphere_file.go` with an extra check to ensure the directory is already created before creating the disk since the 'MakeDirectory' call does not return a task we can wait on.