### PR TITLE
Remove size attribute for attached disks

### DIFF
--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
@@ -266,6 +266,15 @@ type TestStep struct {
 	// below.
 	PreConfig func()
 
+	// Taint is a list of resource addresses to taint prior to the execution of
+	// the step. Be sure to only include this at a step where the referenced
+	// address will be present in state, as it will fail the test if the resource
+	// is missing.
+	//
+	// This option is ignored on ImportState tests, and currently only works for
+	// resources in the root module path.
+	Taint []string
+
 	//---------------------------------------------------------------
 	// Test modes. One of the following groups of settings must be
 	// set to determine what the test step will do. Ideally we would've

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -588,12 +588,10 @@
 			"versionExact": "v0.11.7"
 		},
 		{
-			"checksumSHA1": "ryCWu7RtMlYrAfSevaI7RtaXe98=",
+			"checksumSHA1": "3ml5nA9mNVoK30lE2W0DxQIPWiw=",
 			"path": "github.com/hashicorp/terraform/helper/resource",
-			"revision": "41e50bd32a8825a84535e353c3674af8ce799161",
-			"revisionTime": "2018-04-10T16:50:42Z",
-			"version": "v0.11.7",
-			"versionExact": "v0.11.7"
+			"revision": "3505769600eec4a85a3be203a9c7eba7f97c5ade",
+			"revisionTime": "2018-05-25T14:50:30Z"
 		},
 		{
 			"checksumSHA1": "JHxGzmxcIS8NyLX9pGhK5beIra4=",

--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -644,6 +644,11 @@ nextNew:
 		nm["uuid"] = ""
 		if a, ok := nm["attach"]; !ok || !a.(bool) {
 			nm["path"] = ""
+		} else {
+			_, ok := nm["size"]
+			if ok {
+				delete(nm, "size")
+			}
 		}
 		if dsID, ok := nm["datastore_id"]; !ok || dsID == "" {
 			nm["datastore_id"] = diskDatastoreComputedName

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -939,6 +939,34 @@ func TestAccResourceVSphereVirtualMachine_attachExistingVmdk(t *testing.T) {
 	})
 }
 
+func TestAccResourceVSphereVirtualMachine_attachExistingVmdkTaint(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVSphereVirtualMachineCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereVirtualMachineConfigExistingVmdk(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereVirtualMachineCheckExists(true),
+					testAccResourceVSphereVirtualMachineCheckExistingVmdk(),
+				),
+			},
+			{
+				Taint:  []string{"vsphere_virtual_machine.vm"},
+				Config: testAccResourceVSphereVirtualMachineConfigExistingVmdk(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVSphereVirtualMachineCheckExists(true),
+					testAccResourceVSphereVirtualMachineCheckExistingVmdk(),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceVSphereVirtualMachine_inFolder(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {


### PR DESCRIPTION
**Current Problem**
When creating a disk resource and attaching it to a VM resource the `terraform apply` operation shows this plan below (**notice the size set to zero**):

```
disk.2.attach:                                      "true"
disk.2.datastore_id:                                "datastore-1160"
disk.2.device_address:                              <computed>
disk.2.disk_mode:                                   "persistent"
disk.2.disk_sharing:                                "sharingNone"
disk.2.eagerly_scrub:                               "false"
disk.2.io_limit:                                    "-1"
disk.2.io_reservation:                              "0"
disk.2.io_share_count:                              "0"
disk.2.io_share_level:                              "normal"
disk.2.keep_on_remove:                              "false"
disk.2.key:                                         "0"
disk.2.label:                                       "disk2"
disk.2.path:                                        "mypath/disk2.vmdk"
disk.2.size:                                        "0"
disk.2.thin_provisioned:                            "true"
disk.2.unit_number:                                 "2"
disk.2.uuid:                                        <computed>
disk.2.write_through:                               "false"
```

If the VM resource is then tainted to force a replacement using `terraform taint` the plan is then displayed as below (**notice no size attribute present**)
```
disk.2.attach:                                      "true" => "true"
disk.2.datastore_id:                                "datastore-1160" => "datastore-1160"
disk.2.device_address:                              "scsi:0:2" => <computed>
disk.2.disk_mode:                                   "persistent" => "persistent"
disk.2.disk_sharing:                                "sharingNone" => "sharingNone"
disk.2.eagerly_scrub:                               "false" => "false"
disk.2.io_limit:                                    "-1" => "-1"
disk.2.io_reservation:                              "0" => "0"
disk.2.io_share_count:                              "1000" => "0"
disk.2.io_share_level:                              "normal" => "normal"
disk.2.keep_on_remove:                              "false" => "false"
disk.2.key:                                         "2002" => <computed>
disk.2.label:                                       "disk2" => "disk2"
disk.2.path:                                        "mypath/disk2.vmdk" => "mypath/disk2.vmdk"
disk.2.thin_provisioned:                            "true" => "true"
disk.2.unit_number:                                 "2" => "2"
disk.2.uuid:                                        "6000C299-a45d-a4b9-51c6-7107ec6816a2" => <computed>
disk.2.write_through:                               "false" => "false"
```

This goes on to fail with an error `Mismatch reason: extra attributes: disk.2.size` producing an output with two sections`Diff One (usually from plan):` and `Diff Two (usually from apply):`. Comparing the two shows that `Diff Two (usually from apply):` contains this extra part:
```
"disk.2.size":*terraform.ResourceAttrDiff{Old:"", New:"0", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0},
```
This happens when running with `Terraform Version: 0.11.7` and `provider.vsphere = 1.5.0`

**My Fix**

Since both the documentation and the code itself mention that when attaching a disk the `size` attribute can't be used, I force that attribute to be removed if it is set and the operation is attach.

Destroying everything and starting fresh with the fix applied results in the below (**No size is set**):
```
disk.2.attach:                                      "true"
disk.2.datastore_id:                                "datastore-1160"
disk.2.device_address:                              <computed>
disk.2.disk_mode:                                   "persistent"
disk.2.disk_sharing:                                "sharingNone"
disk.2.eagerly_scrub:                               "false"
disk.2.io_limit:                                    "-1"
disk.2.io_reservation:                              "0"
disk.2.io_share_count:                              "0"
disk.2.io_share_level:                              "normal"
disk.2.keep_on_remove:                              "false"
disk.2.key:                                         "0"
disk.2.label:                                       "disk2"
disk.2.path:                                        "mypath/disk2.vmdk"
disk.2.thin_provisioned:                            "true"
disk.2.unit_number:                                 "2"
disk.2.uuid:                                        <computed>
disk.2.write_through:                               "false"
```

And then tainting the VM and running the apply again results in the below (**No size is set**).

```
disk.2.attach:                                      "true" => "true"
disk.2.datastore_id:                                "datastore-1160" => "datastore-1160"
disk.2.device_address:                              "scsi:0:2" => <computed>
disk.2.disk_mode:                                   "persistent" => "persistent"
disk.2.disk_sharing:                                "sharingNone" => "sharingNone"
disk.2.eagerly_scrub:                               "false" => "false"
disk.2.io_limit:                                    "-1" => "-1"
disk.2.io_reservation:                              "0" => "0"
disk.2.io_share_count:                              "1000" => "0"
disk.2.io_share_level:                              "normal" => "normal"
disk.2.keep_on_remove:                              "false" => "false"
disk.2.key:                                         "2002" => <computed>
disk.2.label:                                       "disk2" => "disk2"
disk.2.path:                                        "mypath/disk2.vmdk" => "mypath/disk2.vmdk"
disk.2.thin_provisioned:                            "true" => "true"
disk.2.unit_number:                                 "2" => "2"
disk.2.uuid:                                        "6000C293-6c39-40fd-231e-699b461843ce" => <computed>
disk.2.write_through:                               "false" => "false"
```

And this time the VM replacement finishes without errors and the disk is reattached correctly.