### PR TITLE
r/resource_pool: Correct docs

### DIFF
--- a/website/docs/r/resource_pool.html.markdown
+++ b/website/docs/r/resource_pool.html.markdown
@@ -42,7 +42,7 @@ data "vsphere_compute_cluster" "compute_cluster" {
 
 resource "vsphere_resource_pool" "resource_pool" {
   name                    = "terraform-resource-pool-test"
-  parent_resource_pool_id = "${data.vsphere_compute_cluster.compute_cluster.id}"
+  parent_resource_pool_id = "${data.vsphere_compute_cluster.compute_cluster.resource_pool_id}"
 }
 ```
 


### PR DESCRIPTION
parent_resource_pool_id should reference to the resource_pool_id output of data.vsphere_compute_cluster and not to the id.