### PR TITLE
docs: Remove "sub-resource" references from related docs

### DIFF
--- a/website/docs/r/distributed_virtual_switch.html.markdown
+++ b/website/docs/r/distributed_virtual_switch.html.markdown
@@ -175,8 +175,8 @@ and require vCenter.
 
 ### Host management arguments
 
-* `host` - (Optional) Use the `host` sub-resource to declare a host
-  specification. The options are:
+* `host` - (Optional) Use the `host` block to declare a host specification. The
+  options are:
  * `host_system_id` - (Required) The host system ID of the host to add to the
    DVS.
  * `devices` - (Required) The list of NIC devices to map to uplinks on the DVS,

--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -8,11 +8,10 @@ description: |-
 
 # vsphere\_virtual\_disk
 
-The `vsphere_virtual_disk` resource can be used to create virtual disks
-outside of any given [`vsphere_virtual_machine`][docs-vsphere-virtual-machine]
+The `vsphere_virtual_disk` resource can be used to create virtual disks outside
+of any given [`vsphere_virtual_machine`][docs-vsphere-virtual-machine]
 resource. These disks can be attached to a virtual machine by creating a disk
-sub-resource with the [`attach`][docs-vsphere-virtual-machine-disk-attach]
-parameter.
+block with the [`attach`][docs-vsphere-virtual-machine-disk-attach] parameter.
 
 [docs-vsphere-virtual-machine]: /docs/providers/vsphere/r/virtual_machine.html
 [docs-vsphere-virtual-machine-disk-attach]: /docs/providers/vsphere/r/virtual_machine.html#attach

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -36,7 +36,7 @@ VMDK-backed virtual disks - it does not support other special kinds of disk
 devices like RDM disks.
 
 Disks are managed by an arbitrary label supplied to the [`label`](#label)
-attribute of a [`disk` sub-resource](#disk-options). This is separate from the
+attribute of a [`disk` block](#disk-options). This is separate from the
 automatic naming that vSphere picks for you when creating a virtual machine.
 Control over a virtual disk's name is not supported unless you are attaching an
 external disk with the [`attach`](#attach) attribute.
@@ -488,8 +488,8 @@ connections.
 
 ~> **NOTE:** Do not use `extra_config` when working with a template imported
 from OVF or OVA as more than likely your settings will be ignored. Use the
-`vapp` sub-resource's `properties` section as outlined in [Using vApp
-properties to supply OVF/OVA
+`vapp` block's `properties` section as outlined in [Using vApp properties to
+supply OVF/OVA
 configuration](#using-vapp-properties-to-supply-ovf-ova-configuration).
 
 * `scsi_type` - (Optional) The type of SCSI bus this virtual machine will have.
@@ -671,7 +671,7 @@ this value to add out-of-band devices.
 
 ### Disk options
 
-Virtual disks are managed by adding an instance of the `disk` sub-resource.
+Virtual disks are managed by adding an instance of the `disk` block.
 
 At the very least, there must be `name` and `size` attributes. `unit_number` is
 required for any disk other than the first, and there must be at least one
@@ -750,8 +750,8 @@ externally with `attach` when the `path` field is not specified.
 * `path` - (Optional) When using `attach`, this parameter controls the path of
   a virtual disk to attach externally. Otherwise, it is a computed attribute
   that contains the virtual disk's current filename.
-* `keep_on_remove` - (Optional) Keep this disk when removing the sub-resource
-  or destroying the virtual machine. Default: `false`.
+* `keep_on_remove` - (Optional) Keep this disk when removing the device or
+  destroying the virtual machine. Default: `false`.
 * `disk_mode` - (Optional) The mode of this this virtual disk for purposes of
   writes and snapshotting. Can be one of `append`, `independent_nonpersistent`,
   `independent_persistent`, `nonpersistent`, `persistent`, or `undoable`.
@@ -795,7 +795,7 @@ externally with `attach` when the `path` field is not specified.
 The `eagerly_scrub` and `thin_provisioned` options control the space allocation
 type of a virtual disk. These show up in the vSphere console as a unified
 enumeration of options, the equivalents of which are explained below. The
-defaults in the sub-resource are the equivalent of thin provisioning.
+defaults in Terraform are the equivalent of thin provisioning.
 
 * **Thick provisioned lazy zeroed:** Both `eagerly_scrub` and
   `thin_provisioned` should be set to `false`.
@@ -820,7 +820,7 @@ until the settings are corrected.
 ### Network interface options
 
 Network interfaces are managed by adding an instance of the `network_interface`
-sub-resource.
+block.
 
 Interfaces are assigned to devices in the specific order they are declared.
 This has different implications for different operating systems.
@@ -902,12 +902,12 @@ and path (for a datastore ISO backed CDROM) are required.
 ~> **NOTE:** Some CDROM drive types are currently unsupported by this resource,
 such as pass-through devices. If these drives are present in a cloned template,
 or added outside of Terraform, they will have their configurations corrected to
-that of the defined device, or removed if no `cdrom` sub-resource is present.
+that of the defined device, or removed if no `cdrom` block is present.
 
 ### Virtual device computed options
 
-Virtual device resources (`disk`, `network_interface`, and `cdrom`) all export
-the following attributes. These options help locate the sub-resource on future
+Configured virtual devices (`disk`, `network_interface`, and `cdrom`) all
+export the following attributes. These options help locate the device on future
 Terraform runs. The options are:
 
 * `key` - The ID of the device within the virtual machine.
@@ -918,10 +918,10 @@ Terraform runs. The options are:
 
 ## Creating a Virtual Machine from a Template
 
-The `clone` sub-resource can be used to create a new virtual machine from an
-existing virtual machine or template. The resource supports both making a
-complete copy of a virtual machine, or cloning from a snapshot (otherwise known
-as a linked clone).
+The `clone` block can be used to create a new virtual machine from an existing
+virtual machine or template. The resource supports both making a complete copy
+of a virtual machine, or cloning from a snapshot (otherwise known as a linked
+clone).
 
 See the [cloning and customization
 example](#cloning-and-customization-example) for a usage synopsis.
@@ -932,7 +932,7 @@ resource.
 ~> **NOTE:** Cloning requires vCenter and is not supported on direct ESXi
 connections.
 
-The options available in the `clone` sub-resource are:
+The options available in the `clone` block are:
 
 * `template_uuid` - (Required) The UUID of the source virtual machine or
   template.
@@ -954,8 +954,8 @@ settings.
 [vmware-docs-customize]: https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-58E346FF-83AE-42B8-BE58-253641D257BC.html
 
 To perform virtual machine customization as a part of the clone process,
-specify the `customize` sub-resource within the `clone` sub-resource with the
-respective customization options.  See the [cloning and customization
+specify the `customize` block with the respective customization options, nested
+within the `clone` block. See the [cloning and customization
 example](#cloning-and-customization-example) for a usage synopsis.
 
 The settings for `customize` are as follows:
@@ -968,10 +968,11 @@ The settings for `customize` are as follows:
 
 #### Network interface settings
 
-The following settings should be in a `network_interface` block in the
-`customize` sub-resource. These settings configure network interfaces on a
-per-interface basis and are matched up to `network_interface` sub-resources in
-the main block in the order they are declared.
+These settings, which should be specified in nested `network_interface` blocks
+within [`customize`](#virtual-machine-customization), configure network
+interfaces on a per-interface basis and are matched up to
+[`network_interface`](#network-interface-options) devices in the order they are
+declared.
 
 Given the following example:
 
@@ -1098,7 +1099,7 @@ settings](#network-interface-settings).
 
 #### Linux customization options
 
-The settings in the `linux_options` sub-resource pertain to Linux guest OS
+The settings in the `linux_options` block pertain to Linux guest OS
 customization. If you are customizing a Linux operating system, this section
 must be included.
 
@@ -1138,7 +1139,7 @@ The options are:
 
 #### Windows customization options
 
-The settings in the `windows_options` sub-resource pertain to Windows guest OS
+The settings in the `windows_options` block pertain to Windows guest OS
 customization. If you are customizing a Windows operating system, this section
 must be included.
 
@@ -1239,11 +1240,11 @@ included if the other is specified.
 ### Using vApp properties to supply OVF/OVA configuration
 
 Alternative to the settings in `customize`, one can use the settings in the
-`properties` section of the `vapp` sub-resource to supply configuration
-parameters to a virtual machine cloned from a template that came from an
-imported OVF or OVA file. Both GuestInfo and ISO transport methods are
-supported. For templates that use ISO transport, a CDROM backed by client
-device is required. See [CDROM options](#cdrom-options) for details. 
+`properties` section of the `vapp` block to supply configuration parameters to
+a virtual machine cloned from a template that came from an imported OVF or OVA
+file. Both GuestInfo and ISO transport methods are supported. For templates
+that use ISO transport, a CDROM backed by client device is required. See [CDROM
+options](#cdrom-options) for details. 
 
 ~> **NOTE:** The only supported usage path for vApp properties is for existing
 user-configurable keys. These generally come from an existing template that was
@@ -1281,10 +1282,9 @@ both the resource configuration and source template:
 
 * The virtual machine must not be powered on at the time of cloning.
 * All disks on the virtual machine must be SCSI disks.
-* You must specify at least the same number of `disk` sub-resources as there
-  are disks that exist in the template. These sub-resources are ordered and
-  lined up by the `unit_number` attribute. Additional disks can be added past
-  this.
+* You must specify at least the same number of `disk` devices as there are
+  disks that exist in the template. These devices are ordered and lined up by
+  the `unit_number` attribute. Additional disks can be added past this.
 * The `size` of a virtual disk must be at least the same size as its
   counterpart disk in the template.
 * When using `linked_clone`, the `size`, `thin_provisioned`, and
@@ -1343,8 +1343,8 @@ Storage migration can be done on two levels:
   `datastore_cluster_id` is in use, any disks that drift to datastores outside
   of the datastore cluster via such actions as manual modification will be
   migrated back to the datastore cluster on the next apply.
-* An individual `disk` sub-resource can be migrated by manually specifying the
-  `datastore_id` in its sub-resource. This also pins it to the specific
+* An individual `disk` device can be migrated by manually specifying the
+  `datastore_id` in its configuration block. This also pins it to the specific
   datastore that is specified - if at a later time the VM and any unpinned
   disks migrate to another host, the disk will stay on the specified datastore.
 
@@ -1473,11 +1473,11 @@ comprising of:
 * The [`imported`](#imported) flag will transition from `true` to `false`.
 * [`keep_on_remove`](#keep_on_remove) of known disks will transition from
   `true` to `false`. 
-* Configuration for the [`clone`](#clone) sub-resource block, if supplied, will
-  be persisted to state. This initial persistence operation does not perform
-  any cloning or customization actions, nor does it force a new resource. After
-  the first apply operation, further changes to `clone` will force a new
-  resource as per normal operation.
+* Configuration supplied in the [`clone`](#clone) block, if present, will be
+  persisted to state. This initial persistence operation does not perform any
+  cloning or customization actions, nor does it force a new resource. After the
+  first apply operation, further changes to `clone` will force a new resource
+  as per normal operation.
 
 ~> **NOTE:** Further to the above, do not make any configuration changes to
 `clone` after importing or upgrading from a legacy version of the provider

--- a/website/docs/r/virtual_machine_snapshot.html.markdown
+++ b/website/docs/r/virtual_machine_snapshot.html.markdown
@@ -20,7 +20,7 @@ For more information on managing snapshots and how they work in VMware, see
 can contain the actual running state of the virtual machine, data for all disks
 that have not been set to be independent from the snapshot (including ones that
 have been attached via the [attach][docs-vsphere-virtual-machine-disk-attach]
-parameter to the `vsphere_virtual_machine` `disk` sub-resource), and even the
+parameter to the `vsphere_virtual_machine` `disk` block), and even the
 configuration of the virtual machine at the time of the snapshot. Virtual
 machine, disk activity, and configuration changes post-snapshot are not
 included in the original state. Use this resource with care! Neither VMware nor


### PR DESCRIPTION
This is causing some confusion with requests coming into certain
stakeholders in support.

"sub-resources" may be correct technically, as nested configuration
blocks within the schema are implemented via `schema.Resource`, and
`vsphere_virtual_machine` device configurations follow a complex,
resource-like lifecycle, in order to ensure the device has a graceful
lifetime within a VM configuration (especially important for disks).
However, externally, these relations are not very visible, and referring
to these constructs as anything else other than configuration blocks
just gets in the way.