### PR TITLE
r/virtual_machine: Fix variable shadowing and type

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_device_subresource.go
@@ -571,9 +571,7 @@ func NormalizeSCSIBus(l object.VirtualDeviceList, ct string, count int, st strin
 			if err != nil {
 				return nil, nil, err
 			}
-			if cspec != nil {
-				spec = append(spec, cspec)
-			}
+			spec = append(spec, cspec...)
 			continue
 		}
 		cspec, err := swapSCSIDevice(l, ctlr, ct, st)
@@ -591,11 +589,12 @@ func NormalizeSCSIBus(l object.VirtualDeviceList, ct string, count int, st strin
 
 // setSCSIBusSharing takes a BaseVirtualSCSIController, sets the sharing mode,
 // and applies that change to the VirtualDeviceList.
-func setSCSIBusSharing(l *object.VirtualDeviceList, ctlr types.BaseVirtualSCSIController, st string) (types.BaseVirtualDeviceConfigSpec, error) {
-	var cspec types.BaseVirtualDeviceConfigSpec
+func setSCSIBusSharing(l *object.VirtualDeviceList, ctlr types.BaseVirtualSCSIController, st string) ([]types.BaseVirtualDeviceConfigSpec, error) {
+	var cspec []types.BaseVirtualDeviceConfigSpec
 	if ctlr.GetVirtualSCSIController().SharedBus != types.VirtualSCSISharing(st) {
 		ctlr.GetVirtualSCSIController().SharedBus = types.VirtualSCSISharing(st)
-		cspec, err := object.VirtualDeviceList{ctlr.(types.BaseVirtualDevice)}.ConfigSpec(types.VirtualDeviceConfigSpecOperationEdit)
+		var err error
+		cspec, err = object.VirtualDeviceList{ctlr.(types.BaseVirtualDevice)}.ConfigSpec(types.VirtualDeviceConfigSpecOperationEdit)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Return a slice of device config specs instead of a single spec. This matches what is returned by the ConfigSpec function and makes it unnecessary to check if the cspec is nil since the value returned by setSCSIBusSharing will only be nil if there is an error.