### PR TITLE
r/virtual_machine: Use zero instead of nil in memory allocation

### DIFF
--- a/vsphere/internal/helper/structure/structure_helper.go
+++ b/vsphere/internal/helper/structure/structure_helper.go
@@ -249,6 +249,16 @@ func GetInt64Ptr(d *schema.ResourceData, key string) *int64 {
 	return nil
 }
 
+// GetInt64PtrEmptyZero reads a ResourceData and returns an appropriate *int64
+// for the state of the definition. 0 is returned if it does not exist.
+func GetInt64PtrEmptyZero(d *schema.ResourceData, key string) *int64 {
+	i := GetInt64Ptr(d, key)
+	if i != nil {
+		return i
+	}
+	return Int64Ptr(int64(0))
+}
+
 // SetInt64Ptr sets a ResourceData field depending on if an *int64 exists or
 // not.  The field is not set if it's nil.
 func SetInt64Ptr(d *schema.ResourceData, key string, val *int64) error {

--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -431,8 +431,8 @@ func expandVirtualMachineResourceAllocation(d *schema.ResourceData, key string) 
 	reservationKey := fmt.Sprintf("%s_reservation", key)
 
 	obj := &types.ResourceAllocationInfo{
-		Limit:       structure.GetInt64Ptr(d, limitKey),
-		Reservation: structure.GetInt64Ptr(d, reservationKey),
+		Limit:       structure.GetInt64PtrEmptyZero(d, limitKey),
+		Reservation: structure.GetInt64PtrEmptyZero(d, reservationKey),
 	}
 	shares := &types.SharesInfo{
 		Level:  types.SharesLevel(d.Get(shareLevelKey).(string)),


### PR DESCRIPTION
Use zero instead of nil for memory allocation in virtual machines.
Memory allocation cannot be removed when using nil because it causes the
parameter to be left our of the API XML.