### PR TITLE
helper/structure: Handle nil interface

### DIFF
--- a/vsphere/internal/helper/structure/structure_helper.go
+++ b/vsphere/internal/helper/structure/structure_helper.go
@@ -32,7 +32,9 @@ func ResourceIDString(d ResourceIDStringer, name string) string {
 func SliceInterfacesToStrings(s []interface{}) []string {
 	var d []string
 	for _, v := range s {
-		d = append(d, v.(string))
+		if o, ok := v.(string); ok {
+			d = append(d, o)
+		}
 	}
 	return d
 }


### PR DESCRIPTION
Ignore nil interfaces when converting a slice of interfaces into a slice
of strings. This becomes an issue when a list with an empty string is 
passed to SliceInterfacesToStrings.

Fixes #643 