### PR TITLE
Add support for using guest.ipAddress for older versions of VM Tools

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -109,6 +109,12 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			Default:     true,
 			Description: "Controls whether or not the guest network waiter waits for a routable address. When false, the waiter does not wait for a default gateway, nor are IP addresses checked against any discovered default gateways as part of its success criteria.",
 		},
+		"ignored_guest_ips": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "List of IP addresses to ignore while waiting for an IP",
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
 		"shutdown_wait_timeout": {
 			Type:         schema.TypeInt,
 			Optional:     true,
@@ -301,6 +307,7 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		client,
 		vm,
 		d.Get("wait_for_guest_ip_timeout").(int),
+		d.Get("ignored_guest_ips").([]interface{}),
 	)
 	if err != nil {
 		return err
@@ -312,6 +319,7 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		vm,
 		d.Get("wait_for_guest_net_routable").(bool),
 		d.Get("wait_for_guest_net_timeout").(int),
+		d.Get("ignored_guest_ips").([]interface{}),
 	)
 	if err != nil {
 		return err
@@ -562,6 +570,7 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 				client,
 				vm,
 				d.Get("wait_for_guest_ip_timeout").(int),
+				d.Get("ignored_guest_ips").([]interface{}),
 			)
 			if err != nil {
 				return err
@@ -571,6 +580,7 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 				vm,
 				d.Get("wait_for_guest_net_routable").(bool),
 				d.Get("wait_for_guest_net_timeout").(int),
+				d.Get("ignored_guest_ips").([]interface{}),
 			)
 			if err != nil {
 				return err
@@ -901,6 +911,7 @@ func resourceVSphereVirtualMachineImport(d *schema.ResourceData, meta interface{
 	d.Set("wait_for_guest_ip_timeout", rs["wait_for_guest_ip_timeout"].Default)
 	d.Set("wait_for_guest_net_timeout", rs["wait_for_guest_net_timeout"].Default)
 	d.Set("wait_for_guest_net_routable", rs["wait_for_guest_net_routable"].Default)
+	d.Set("ignored_guest_ips", []string{})
 
 	log.Printf("[DEBUG] %s: Import complete, resource is ready for read", resourceVSphereVirtualMachineIDString(d))
 	return []*schema.ResourceData{d}, nil

--- a/vsphere/virtual_machine_guest_structure.go
+++ b/vsphere/virtual_machine_guest_structure.go
@@ -79,6 +79,14 @@ func buildAndSelectGuestIPs(d *schema.ResourceData, guest types.GuestInfo) error
 	addrs := make([]string, 0)
 	addrs = append(addrs, v4addrs...)
 	addrs = append(addrs, v6addrs...)
+
+	// Fall back to the IpAddress property in GuestInfo directly when the
+	// IpStack and Net properties are not populated. This generally means that
+	// an older version of VMTools is in use.
+	if len(addrs) < 1 && guest.IpAddress != "" {
+		addrs = append(addrs, guest.IpAddress)
+	}
+
 	if len(addrs) < 1 {
 		// No IP addresses were discovered. This more than likely means that the VM
 		// is powered off, or VMware tools is not installed. We can return here,

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -81,8 +81,10 @@ Two waiters of note are:
   the guest virtual machine, mainly to facilitate the availability of a valid,
   reachable default IP address for any [provisioners][tf-docs-provisioners].
   The behavior of the waiter can be controlled with the
-  [`wait_for_guest_net_timeout`](#wait_for_guest_net_timeout) and
-  [`wait_for_guest_net_routable`](#wait_for_guest_net_routable) settings.
+  [`wait_for_guest_net_timeout`](#wait_for_guest_net_timeout),
+  [`wait_for_guest_net_routable`](#wait_for_guest_net_routable),
+  [`wait_for_guest_ip_timeout`](#wait_for_guest_ip_timeout), and
+  [`ignored_guest_ips`](#ignored_guest_ips) settings.
 
 [tf-docs-provisioners]: /docs/provisioners/index.html
 
@@ -641,12 +643,26 @@ you may have to adjust [`memory_reservation`](#memory_reservation) to the full
 amount of memory provisioned for the virtual machine.
 
 * `wait_for_guest_net_timeout` - (Optional) The amount of time, in minutes, to
-  wait for an available IP address on this virtual machine. A value less than 1
-  disables the waiter. Default: 5 minutes.
+  wait for an available IP address on this virtual machine's NICs. Older
+  versions of VMware Tools do not populate this property. In those cases, this
+  waiter can be disabled and the
+  [`wait_for_guest_ip_timeout`](#wait_for_guest_ip_timeout) waiter can be used
+  instead. A value less than 1 disables the waiter. Default: 5 minutes.
 * `wait_for_guest_net_routable` - (Optional) Controls whether or not the guest
   network waiter waits for a routable address. When `false`, the waiter does
   not wait for a default gateway, nor are IP addresses checked against any
-  discovered default gateways as part of its success criteria. Default: `true`.
+  discovered default gateways as part of its success criteria. This property is
+  ignored if the [`wait_for_guest_ip_timeout`](#wait_for_guest_ip_timeout)
+  waiter is used. Default: `true`.
+* `wait_for_guest_ip_timeout` - (Optional) The amount of time, in minutes, to
+  wait for an available guest IP address on this virtual machine. This should
+  only be used if your version of VMware Tools does not allow the
+  [`wait_for_guest_net_timeout`](#wait_for_guest_net_timeout) waiter to be
+  used. A value less than 1 disables the waiter. Default: 0.
+* `ignored_guest_ips` - (Optional) List of IP addresses to ignore while waiting
+  for an available IP address using either of the waiters. Any IP addresses in
+  this list will be ignored if they show up so that the waiter will continue to
+  wait for a real IP address. Default: [].
 * `shutdown_wait_timeout` - (Optional) The amount of time, in minutes, to wait
   for a graceful guest shutdown when making necessary updates to the virtual
   machine. If `force_power_off` is set to true, the VM will be force powered-off


### PR DESCRIPTION
### Description
There are two parts to this change:

- Add a new waiter that waits for guest.ipAddress to be populated. This waiter is controlled via the `wait_for_guest_ip_timeout` property that is disabled by default. This waiter is intended to be used in place of the `wait_for_guest_net_timeout` waiter.
- Regardless of which waiter is enabled, the code that populates `default_ip_address` and `guest_ip_addresses` will first look at `guest.net` and `guest.ipStack` to find the IP address. Only if no IP address is found via that method will it then fall back to looking at the `guest.ipAddress` property instead.

### Use Case
The VMs I am creating unfortunately have an older version of VM Tools that does not populate the `guest.net` or `guest.ipStack` properties. However, the VMs I am creating do populate the `guest.ipAddress` property which can be used for this same purpose. This change allows me to just wait for `guest.ipAddress` and use that IP address to proceed with provisioning.

### Todo

- Tests
- Documentation updates

I wanted to see if there was a chance of getting something like this in before I spent time adding those as well.