### PR TITLE
tests: Add missing ENV variable checks

### DIFF
--- a/vsphere/provider_test.go
+++ b/vsphere/provider_test.go
@@ -55,6 +55,14 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func testAccCheckEnvVariables(t *testing.T, variableNames []string) {
+	for _, name := range variableNames {
+		if v := os.Getenv(name); v == "" {
+			t.Skipf("%s must be set for this acceptance test", name)
+		}
+	}
+}
+
 // testAccProviderMeta returns a instantiated VSphereClient for this provider.
 // It's useful in state migration tests where a provider connection is actually
 // needed, and we don't want to go through the regular provider configure

--- a/vsphere/resource_vsphere_file_test.go
+++ b/vsphere/resource_vsphere_file_test.go
@@ -31,7 +31,10 @@ func TestAccResourceVSphereFile_basic(t *testing.T) {
 	sourceFile := testVmdkFile
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"VSPHERE_DATACENTER", "VSPHERE_DATASTORE"})
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVSphereFileDestroy,
 		Steps: []resource.TestStep{
@@ -75,7 +78,10 @@ func TestAccResourceVSphereFile_basicUploadAndCopy(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"VSPHERE_DATACENTER", "VSPHERE_DATASTORE"})
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVSphereFileDestroy,
 		Steps: []resource.TestStep{
@@ -126,7 +132,10 @@ func TestAccResourceVSphereFile_renamePostCreation(t *testing.T) {
 	sourceFile := testVmdkFile
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"VSPHERE_DATACENTER", "VSPHERE_DATASTORE"})
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVSphereFileDestroy,
 		Steps: []resource.TestStep{
@@ -187,7 +196,10 @@ func TestAccResourceVSphereFile_uploadAndCopyAndUpdate(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"VSPHERE_DATACENTER", "VSPHERE_DATASTORE"})
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVSphereFileDestroy,
 		Steps: []resource.TestStep{

--- a/vsphere/resource_vsphere_vapp_entity_test.go
+++ b/vsphere/resource_vsphere_vapp_entity_test.go
@@ -210,13 +210,19 @@ func TestAccResourceVSphereVAppEntity_import(t *testing.T) {
 
 func testAccResourceVSphereVAppEntityPreCheck(t *testing.T) {
 	if os.Getenv("VSPHERE_DATACENTER") == "" {
-		t.Skip("set VSPHERE_DATACENTER to run vsphere_resource_pool acceptance tests")
+		t.Skip("set VSPHERE_DATACENTER to run vsphere_vapp_entity acceptance tests")
 	}
 	if os.Getenv("VSPHERE_CLUSTER") == "" {
-		t.Skip("set VSPHERE_CLUSTER to run vsphere_resource_pool acceptance tests")
+		t.Skip("set VSPHERE_CLUSTER to run vsphere_vapp_entity acceptance tests")
 	}
 	if os.Getenv("VSPHERE_ESXI_HOST5") == "" {
-		t.Skip("set VSPHERE_ESXI_HOST5 to run vsphere_resource_pool acceptance tests")
+		t.Skip("set VSPHERE_ESXI_HOST5 to run vsphere_vapp_entity acceptance tests")
+	}
+	if os.Getenv("VSPHERE_NETWORK_LABEL_PXE") == "" {
+		t.Skip("set VSPHERE_NETWORK_LABEL_PXE to run vsphere_vapp_entity acceptance tests")
+	}
+	if os.Getenv("VSPHERE_DATASTORE") == "" {
+		t.Skip("set VSPHERE_DATASTORE to run vsphere_vapp_entity acceptance tests")
 	}
 }
 


### PR DESCRIPTION
Previously these tests would fail if the ENV variables aren't set, which is presumably not desirable, according to checks in all other test cases.