### PR TITLE
r/virtual_machine: Ignore validation when interpolation not available

### DIFF
--- a/vsphere/internal/helper/structure/structure_helper.go
+++ b/vsphere/internal/helper/structure/structure_helper.go
@@ -613,3 +613,16 @@ func (s MoRefSorter) Less(i, j int) bool {
 func (s MoRefSorter) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
+
+// ValuesAvailable takes a subresource path and a list of keys and checks that
+// the value for each key is available at CustomizeDiff time. This function
+// will return false if any of they values are based on computed values from
+// other new or updated resources.
+func ValuesAvailable(base string, keys []string, d *schema.ResourceDiff) bool {
+	for _, k := range keys {
+		if !d.NewValueKnown(fmt.Sprintf("%s%s", base, k)) {
+			return false
+		}
+	}
+	return true
+}

--- a/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_cdrom_subresource.go
@@ -407,6 +407,10 @@ func CdromDiffOperation(d *schema.ResourceDiff, c *govmomi.Client) error {
 	for ci, ce := range cr.([]interface{}) {
 		cm := ce.(map[string]interface{})
 		r := NewCdromSubresource(c, d, cm, nil, ci)
+		if !structure.ValuesAvailable(fmt.Sprintf("%s.%d.", subresourceTypeCdrom, ci), []string{"datastore_id", "path"}, d) {
+			log.Printf("[DEBUG] CdromDiffOperation: Cdrom contains a value that depends on a computed value from another resource. Skipping validation")
+			return nil
+		}
 		if err := r.ValidateDiff(); err != nil {
 			return fmt.Errorf("%s: %s", r.Addr(), err)
 		}

--- a/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
@@ -483,9 +483,9 @@ func ExpandCustomizationSpec(d *schema.ResourceData, family string) types.Custom
 // spec. It should be called during diff customization to veto invalid configs.
 func ValidateCustomizationSpec(d *schema.ResourceDiff, family string) error {
 	// Validate that the proper section exists for OS family suboptions.
-	linuxExists := len(d.Get(cKeyPrefix+"."+"linux_options").([]interface{})) > 0
-	windowsExists := len(d.Get(cKeyPrefix+"."+"windows_options").([]interface{})) > 0
-	sysprepExists := d.Get(cKeyPrefix+"."+"windows_sysprep_text").(string) != ""
+	linuxExists := len(d.Get(cKeyPrefix+"."+"linux_options").([]interface{})) > 0 || !structure.ValuesAvailable(cKeyPrefix+"."+"linux_options.", []string{"host_name", "domain"}, d)
+	windowsExists := len(d.Get(cKeyPrefix+"."+"windows_options").([]interface{})) > 0 || !structure.ValuesAvailable(cKeyPrefix+"."+"windows_options.", []string{"computer_name"}, d)
+	sysprepExists := d.Get(cKeyPrefix+"."+"windows_sysprep_text").(string) != "" || !structure.ValuesAvailable(cKeyPrefix+".", []string{"windows_sysprep_text"}, d)
 	switch {
 	case family == string(types.VirtualMachineGuestOsFamilyLinuxGuest) && !linuxExists:
 		return errors.New("linux_options must exist in VM customization options for Linux operating systems")

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -783,6 +783,10 @@ func resourceVSphereVirtualMachineCustomizeDiffResourcePoolOperation(d *schema.R
 }
 
 func datastoreClusterDiffOperation(d *schema.ResourceDiff, client *govmomi.Client) error {
+	if !structure.ValuesAvailable("", []string{"datastore_cluster_id", "datastore_id"}, d) {
+		log.Printf("[DEBUG] DatastoreClusterDiffOperation: datastore_id or datastore_cluster_id value depends on a computed value from another resource. Skipping validation.")
+		return nil
+	}
 	podID, podOk := d.GetOk("datastore_cluster_id")
 	podKnown := d.NewValueKnown("datastore_cluster_id")
 	dsID, dsOk := d.GetOk("datastore_id")

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -57,6 +57,23 @@ func TestAccResourceVSphereVirtualMachine_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceVSphereVirtualMachine_ignoreValidationOnComputedValue(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccResourceVSphereVirtualMachineConfigComputedValue(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceVSphereVirtualMachine_highLatencySensitivity(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -516,6 +533,23 @@ func TestAccResourceVSphereVirtualMachine_disksKeepOnRemove(t *testing.T) {
 					testAccResourceVSphereVirtualMachineCheckExists(false),
 					testAccResourceVSphereVirtualMachineDeletePersistentDisks(&disks),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereVirtualMachine_cdromComputedValue(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccResourceVSphereVirtualMachineConfigCdromComputedValue(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -1456,6 +1490,23 @@ func TestAccResourceVSphereVirtualMachine_cloneCustomizeWithNewResourcePool(t *t
 				Check: resource.ComposeTestCheckFunc(
 					testAccResourceVSphereVirtualMachineCheckExists(true),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourceVSphereVirtualMachine_cloneCustomizeComputedValue(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccResourceVSphereVirtualMachineConfigCloneComputedValue(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -3950,6 +4001,74 @@ func testAccResourceVSphereVirtualMachineCheckLatencySensitivity(
 	}
 }
 
+func testAccResourceVSphereVirtualMachineConfigComputedValue() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_resource_pool" "pool" {
+  name = "test_pool"
+	parent_resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${vsphere_resource_pool.pool.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinux64Guest"
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    label = "disk0"
+    size  = 20
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
+		os.Getenv("VSPHERE_DATASTORE"),
+	)
+}
+
 func testAccResourceVSphereVirtualMachineConfigBasic() string {
 	return fmt.Sprintf(`
 variable "datacenter" {
@@ -4877,6 +4996,96 @@ resource "vsphere_virtual_machine" "vm" {
 		os.Getenv("VSPHERE_RESOURCE_POOL"),
 		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
 		os.Getenv("VSPHERE_DATASTORE"),
+	)
+}
+
+func testAccResourceVSphereVirtualMachineConfigCdromComputedValue() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+variable "iso_datastore" {
+  default = "%s"
+}
+
+variable "iso_path" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_datastore" "iso_datastore" {
+  name          = "${var.iso_datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_resource_pool" "pool" {
+	name                    = "terraform_test_resource_pool"
+	parent_resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "other3xLinux64Guest"
+
+  wait_for_guest_net_timeout = -1
+
+  network_interface {
+    network_id = "${data.vsphere_network.network.id}"
+  }
+
+  disk {
+    label = "disk0"
+    size  = 20
+  }
+
+  cdrom {
+    datastore_id = "${data.vsphere_datastore.iso_datastore.id}"
+    path         = "${vsphere_resource_pool.pool.id}/test.iso"
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
+		os.Getenv("VSPHERE_DATASTORE"),
+		os.Getenv("VSPHERE_ISO_DATASTORE"),
+		os.Getenv("VSPHERE_ISO_FILE"),
 	)
 }
 
@@ -7059,6 +7268,135 @@ resource "vsphere_virtual_machine" "vm" {
 		os.Getenv("VSPHERE_RESOURCE_POOL"),
 		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
 		os.Getenv("VSPHERE_DATASTORE"),
+	)
+}
+
+func testAccResourceVSphereVirtualMachineConfigCloneComputedValue() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+variable "resource_pool" {
+  default = "%s"
+}
+
+variable "network_label" {
+  default = "%s"
+}
+
+variable "ipv4_address" {
+  default = "%s"
+}
+
+variable "ipv4_netmask" {
+  default = "%s"
+}
+
+variable "ipv4_gateway" {
+  default = "%s"
+}
+
+variable "dns_server" {
+  default = "%s"
+}
+
+variable "datastore" {
+  default = "%s"
+}
+
+variable "template" {
+  default = "%s"
+}
+
+variable "linked_clone" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = "${var.resource_pool}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network_label}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = "${var.template}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_resource_pool" "pool" {
+  name                    = "terraform-test-resource-pool"
+  parent_resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  name             = "terraform-test"
+  resource_pool_id = "${vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 2048
+  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
+
+  wait_for_guest_net_timeout = -1
+
+  network_interface {
+    network_id   = "${data.vsphere_network.network.id}"
+    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+  }
+
+  disk {
+    label            = "disk0"
+    size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+    eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+    thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+  }
+
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    linked_clone  = "${var.linked_clone != "" ? "true" : "false" }"
+
+    customize {
+      linux_options {
+        host_name = "${vsphere_resource_pool.pool.id}_terraform-test"
+        domain    = "test.internal"
+      }
+
+      network_interface {
+        ipv4_address = "${var.ipv4_address}"
+        ipv4_netmask = "${var.ipv4_netmask}"
+      }
+
+      ipv4_gateway    = "${var.ipv4_gateway}"
+      dns_server_list = ["${var.dns_server}"]
+      dns_suffix_list = ["test.internal"]
+    }
+  }
+}
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_RESOURCE_POOL"),
+		os.Getenv("VSPHERE_NETWORK_LABEL"),
+		os.Getenv("VSPHERE_IPV4_ADDRESS"),
+		os.Getenv("VSPHERE_IPV4_PREFIX"),
+		os.Getenv("VSPHERE_IPV4_GATEWAY"),
+		os.Getenv("VSPHERE_DNS"),
+		os.Getenv("VSPHERE_DATASTORE"),
+		os.Getenv("VSPHERE_TEMPLATE"),
+		os.Getenv("VSPHERE_USE_LINKED_CLONE"),
 	)
 }
 


### PR DESCRIPTION
Use NewValueKnown to check if value is empty because of interpolation not being available at diff time. Specifically to fix issues where CustomizeDiff function returns an error because values that are based on computed values from new resources appear empty during diff.

Fixes #778 
