### PR TITLE
Allow blank networkID

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -687,7 +687,7 @@ func (r *NetworkInterfaceSubresource) Read(l object.VirtualDeviceList) error {
 	case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
 		pg, err := dvportgroup.FromKey(r.client, backing.Port.SwitchUuid, backing.Port.PortgroupKey)
 		if err != nil {
-			if strings.Contains(err.Error(), "The object or item referred to could not be found"){
+			if strings.Contains(err.Error(), "The object or item referred to could not be found") {
 				netID = ""
 			} else {
 				return err

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -686,9 +687,14 @@ func (r *NetworkInterfaceSubresource) Read(l object.VirtualDeviceList) error {
 	case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
 		pg, err := dvportgroup.FromKey(r.client, backing.Port.SwitchUuid, backing.Port.PortgroupKey)
 		if err != nil {
-			return err
+			if strings.Contains(err.Error(), "The object or item referred to could not be found"){
+				netID = ""
+			} else {
+				return err
+			}
+		} else {
+			netID = pg.Reference().Value
 		}
-		netID = pg.Reference().Value
 	default:
 		return fmt.Errorf("unknown network interface backing %T", card.Backing)
 	}


### PR DESCRIPTION
Resolves #316 by allowing a blank network name. This occurs when cloning a template to another cluster where the distributed port group on the template does not exist.