### PR TITLE
Import host_port_group resources

### DIFF
--- a/vsphere/host_port_group_structure.go
+++ b/vsphere/host_port_group_structure.go
@@ -58,6 +58,7 @@ func expandHostPortGroupSpec(d *schema.ResourceData) *types.HostPortGroupSpec {
 // the passed in ResourceData.
 func flattenHostPortGroupSpec(d *schema.ResourceData, obj *types.HostPortGroupSpec) error {
 	d.Set("vlan_id", obj.VlanId)
+	d.Set("virtual_switch_name", obj.VswitchName)
 	if err := flattenHostNetworkPolicy(d, &obj.Policy); err != nil {
 		return err
 	}

--- a/vsphere/resource_vsphere_host_port_group.go
+++ b/vsphere/resource_vsphere_host_port_group.go
@@ -47,6 +47,10 @@ func resourceVSphereHostPortGroup() *schema.Resource {
 		Read:   resourceVSphereHostPortGroupRead,
 		Update: resourceVSphereHostPortGroupUpdate,
 		Delete: resourceVSphereHostPortGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceVSphereHostPortGroupImport,
+		},
+
 		Schema: s,
 	}
 }
@@ -145,4 +149,22 @@ func resourceVSphereHostPortGroupDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	return nil
+}
+
+func resourceVSphereHostPortGroupImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	hostID, portGroupName, err := splitHostPortGroupID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = d.Set("host_system_id", hostID)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	err = d.Set("name", portGroupName)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	return []*schema.ResourceData{d}, nil
 }

--- a/website/docs/r/host_port_group.html.markdown
+++ b/website/docs/r/host_port_group.html.markdown
@@ -129,3 +129,20 @@ The following attributes are exported:
   explaining the effective policy for this port group.
 * `key` - The key for this port group as returned from the vSphere API.
 * `ports` - A list of ports that currently exist and are used on this port group.
+
+## Importing
+
+An existing port group can be [imported][docs-import] into this resource by its ID.
+The convention of the id is a prefix, the host system [managed objectID][docs-about-morefs], and the port group
+name. An example would be `tf-HostPortGroup:host-10:PGTerraformTest`.
+Import can the be done via the following command:
+
+[docs-import]: https://www.terraform.io/docs/import/index.html
+[docs-about-morefs]: /docs/providers/vsphere/index.html#use-of-managed-object-references-by-the-vsphere-provider
+
+```
+terraform import vsphere_host_port_group.pg tf-HostPortGroup:host-10:PGTerraformTest
+```
+
+The above would import the port group named `PGTerraformTest` that is located in the `host-10`
+vSphere host.


### PR DESCRIPTION
Hello!
Currently working on a standalone esxi server with terraform, I wanted to import all my current setup.
Realising it wasn't possible to import `vsphere_host_port_group`, I decided to try and see if I could modify the provider to implement that.

Based myself on [this](https://github.com/terraform-providers/terraform-provider-vsphere/commit/5878346d7791608ab627a542c51cfab6f1cf6668) for implementation.

I believe this fixes #477 as well.

Note that this is my first update on a terraform provider. I built it and tried the binary and my import was successful; with no changes.