### PR TITLE
Mark windows_sysprep_text as sensitive

### DIFF
--- a/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
@@ -201,6 +201,7 @@ func VirtualMachineCustomizeSchema() map[string]*schema.Schema {
 		"windows_sysprep_text": {
 			Type:          schema.TypeString,
 			Optional:      true,
+			Sensitive:     true,
 			ConflictsWith: []string{cKeyPrefix + "." + "linux_options", cKeyPrefix + "." + "windows_options"},
 			Description:   "Use this option to specify a windows sysprep file directly.",
 		},


### PR DESCRIPTION
In a sysprep file it is fairly common to include passwords as part of the setup.  Our particular use case is during the domain joining step, though specifying an administrator password is another common case.  It seems that Microsoft's [official guidance](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/wsim/hide-sensitive-data-in-an-answer-file) on "hiding" this sensitive data is simply base64 encoding it which obviously is not truly protecting this information.  The PR simply marks the field as sensitive so that any passwords in the file will not be revealed during the plan phase.