### PR TITLE
Updated properties section of OVA to include an equals sign

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -319,7 +319,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   vapp {
-    properties {
+    properties = {
       "guestinfo.tf.internal.id" = "42"
     }
   }


### PR DESCRIPTION
Properties section appears incorrect in Terraform v0.12.