### PR TITLE
Change the way we detect if a VM is in a vApp

### DIFF
--- a/tf-vsphere-devrc.mk.example
+++ b/tf-vsphere-devrc.mk.example
@@ -69,5 +69,7 @@ export VSPHERE_VAPP_CONTAINER           ?= vapp-path  # Path to a vApp container
 export VSPHERE_PERSIST_SESSION          ?= true       # Session persistence
 export VSPHERE_REST_SESSION_PATH        ?= rest-path  # Path to store rest sessions
 export VSPHERE_VIM_SESSION_PATH         ?= vim-path   # Path to store vim sessions
+export VSPHERE_VAPP_RESOURCE_POOL       ?= vapp-rp-path #vSphere path to vApp's resource pool
+export VSPHERE_CLONED_VM_DISK_SIZE      ?= =32        # Size of disk attached to a cloned VM
 
 # vi: filetype=make

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -368,7 +368,13 @@ func resourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	}
 	// If the VM is part of a vApp, InventoryPath will point to a host path
 	// rather than a VM path, so this step must be skipped.
-	if !vappcontainer.IsVApp(client, vprops.ResourcePool.Value) {
+	var vmContainer string
+	if vprops.ParentVApp != nil {
+		vmContainer = vprops.ParentVApp.Value
+	} else {
+		vmContainer = vprops.ResourcePool.Value
+	}
+	if !vappcontainer.IsVApp(client, vmContainer) {
 		f, err := folder.RootPathParticleVM.SplitRelativeFolder(vm.InventoryPath)
 		if err != nil {
 			return fmt.Errorf("error parsing virtual machine path %q: %s", vm.InventoryPath, err)

--- a/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/vsphere/resource_vsphere_virtual_machine_test.go
@@ -2957,6 +2957,22 @@ func TestAccResourceVSphereVirtualMachine_importClone(t *testing.T) {
 	})
 }
 
+// testAccResourceVSphereVirtualMachineReadVappChildResourcePool
+// TestAccResourceVSphereVirtualMachine_importClone
+func TestAccResourceVSphereVirtualMachine_readVappChildResourcePool(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccResourceVSphereVirtualMachinePreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereVirtualMachineReadVappChildResourcePool(),
+			},
+		},
+	})
+}
 func testAccResourceVSphereVirtualMachinePreCheck(t *testing.T) {
 	// Note that VSPHERE_USE_LINKED_CLONE is also a variable and its presence
 	// speeds up tests greatly, but it's not a necessary variable, so we don't
@@ -13589,5 +13605,104 @@ resource "vsphere_virtual_machine" "vm" {
 		os.Getenv("VSPHERE_RESOURCE_POOL"),
 		os.Getenv("VSPHERE_NETWORK_LABEL_PXE"),
 		os.Getenv("VSPHERE_DATASTORE"),
+	)
+}
+
+func testAccResourceVSphereVirtualMachineReadVappChildResourcePool() string {
+	return fmt.Sprintf(`
+variable "dc" {default="%s"}
+variable "datastore" {default="%s"}
+variable "cluster" {default="%s"}
+variable "network" {default="%s"}
+variable "template" {default="%s"}
+variable "vm_name" {default="%s"}
+variable "disk_size" {default="%s"}
+variable "hostname" {default="%s"}
+variable "domain" {default="%s"}
+variable "ipv4address" {default="%s"}
+variable "ipv4cidrbits" {default="%s"}
+variable "ipv4gateway" {default="%s"}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.dc}"
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = "${var.datastore}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = "${var.cluster}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_network" "network" {
+  name          = "${var.network}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = "${var.template}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+data "vsphere_resource_pool" "pool" { 
+	name = "hashi-cluster1/Resources/hashi-vapp/ko-rp"
+	datacenter_id = "${data.vsphere_datacenter.dc.id}" 
+  }
+    
+resource "vsphere_virtual_machine" "vm" {
+  name             = "${var.vm_name}"
+  #resource_pool_id = "${data.vsphere_compute_cluster.cluster.resource_pool_id}"
+  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+  num_cpus = 2
+  memory   = 1024
+  guest_id = "${data.vsphere_virtual_machine.template.guest_id}"
+
+  scsi_type = "${data.vsphere_virtual_machine.template.scsi_type}"
+
+  network_interface {
+    network_id   = "${data.vsphere_network.network.id}"
+    adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+  }
+
+  disk {
+    label            = "disk0"
+    size             = "${var.disk_size}"
+  }
+
+  clone {
+    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+
+    customize {
+      linux_options {
+        host_name = "${var.hostname}"
+        domain    = "${var.domain}"
+      }
+
+      network_interface {
+        ipv4_address = "${var.ipv4address}"
+        ipv4_netmask = "${var.ipv4cidrbits}"
+      }
+
+      ipv4_gateway = "${var.ipv4gateway}"
+    }
+  }
+}`,
+		os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_DATASTORE"),
+		os.Getenv("VSPHERE_CLUSTER"),
+		os.Getenv("VSPHERE_NETWORK_LABEL"),
+		os.Getenv("VSPHERE_TEMPLATE"),
+		"terraform-test",
+		"40",
+		"terraform-test",
+		"test.internal",
+		os.Getenv("VSPHERE_IPV4_ADDRESS"),
+		os.Getenv("VSPHERE_IPV4_PREFIX"),
+		os.Getenv("VSPHERE_IPV4_GATEWAY"),
 	)
 }


### PR DESCRIPTION
The previous way of detecting if a VM belogs to a resource pool that is
inside a vApp would fail if there was an intermediate rp between the
vApp itself and the VM.

We're now checking the `ParentVApp` property of the Virtual Machine
instead of just looking up the Resource Pool it belongs to.