### PR TITLE
Add vSphere host resource

### DIFF
--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -126,6 +126,7 @@ func Provider() terraform.ResourceProvider {
 			"vsphere_vapp_entity":                             resourceVSphereVAppEntity(),
 			"vsphere_vmfs_datastore":                          resourceVSphereVmfsDatastore(),
 			"vsphere_virtual_machine_snapshot":                resourceVSphereVirtualMachineSnapshot(),
+			"vsphere_host":                                    resourceVsphereHost(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/vsphere/resource_vsphere_host.go
+++ b/vsphere/resource_vsphere_host.go
@@ -1,0 +1,700 @@
+package vsphere
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
+	"github.com/vmware/govmomi/license"
+	"github.com/vmware/govmomi/property"
+
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource"
+
+	"github.com/vmware/govmomi/object"
+	gtask "github.com/vmware/govmomi/task"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceVsphereHost() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVsphereHostCreate,
+		Read:   resourceVsphereHostRead,
+		Update: resourceVsphereHostUpdate,
+		Delete: resourceVsphereHostDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"datacenter": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "ID of the vSphere datacenter the host will belong to.",
+			},
+			"cluster": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "ID of the vSphere cluster the host will belong to.",
+			},
+			"hostname": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "FQDN or IP address of the host.",
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Username of the administration account of the host.",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Password of the administration account of the host.",
+				Sensitive:   true,
+			},
+			"thumbprint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Host's certificate SHA-1 thumbprint. If not set then the CA that signed the host's certificate must be trusted.",
+			},
+			"license": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "License key that will be applied to this host.",
+			},
+			"force": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Force add the host to vsphere, even if it's already managed by a different vSphere instance.",
+				Default:     false,
+			},
+			"connected": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Set the state of the host. If set to false then the host will be asked to disconnect.",
+				Default:     true,
+			},
+			"maintenance": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Set the host's maintenance mode. Default is false",
+				Default:     false,
+			},
+			"lockdown": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Set the host's lockdown status. Default is disabled. Valid options are 'disabled', 'normal', 'strict'",
+				Default:     "disabled",
+			},
+		},
+	}
+}
+
+func resourceVsphereHostRead(d *schema.ResourceData, meta interface{}) error {
+
+	// NOTE: Destroying the host without telling vsphere about it will result in us not
+	// knowing that the host does not exist any more.
+
+	// Look for host
+	client := meta.(*VSphereClient).vimClient
+	hostID := d.Id()
+
+	// Find host and get reference to it.
+	hs, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		if viapi.IsManagedObjectNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		log.Printf("[DEBUG] Error while searching host %s. Error: %s", hostID, err)
+		return err
+	}
+
+	maintenanceState, err := hostsystem.HostInMaintenance(hs)
+	if err != nil {
+		return err
+	}
+	d.Set("maintenance", maintenanceState)
+
+	// Retrieve host's properties.
+	log.Printf("[DEBUG] Got host %s", hs.String())
+	host, err := hostsystem.Properties(hs)
+	if err != nil {
+		log.Printf("[DEBUG] Error while retrieving properties for host %s. Error: %s", hostID, err)
+		return err
+	}
+
+	if host.Parent != nil && host.Parent.Type == "ClusterComputeResource" {
+		d.Set("cluster", host.Parent.Value)
+	} else {
+		d.Set("cluster", "")
+	}
+
+	connectionState, err := hostsystem.GetConnectionState(hs)
+	if err != nil {
+		return err
+	}
+
+	if connectionState == types.HostSystemConnectionStateDisconnected {
+		// Config and LicenseManager cannot be used while the host is
+		// disconnected.
+		d.Set("connected", false)
+		return nil
+	}
+	d.Set("connected", true)
+
+	lockdownMode, err := hostLockdownString(host.Config.LockdownMode)
+	if err != nil {
+		return nil
+	}
+
+	log.Printf("Setting lockdown to %s", lockdownMode)
+	d.Set("lockdown", lockdownMode)
+
+	lm := license.NewManager(client.Client)
+	am, err := lm.AssignmentManager(context.TODO())
+	if err != nil {
+		return err
+	}
+	licenses, err := am.QueryAssigned(context.TODO(), hostID)
+	if err != nil {
+		return err
+	}
+
+	licenseKey := d.Get("license").(string)
+	licFound := false
+	for _, lic := range licenses {
+		if licenseKey == lic.AssignedLicense.LicenseKey {
+			licFound = true
+			break
+		}
+	}
+
+	if !licFound {
+		d.Set("license", "")
+	}
+
+	return nil
+}
+
+func resourceVsphereHostCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+
+	hcs := buildHostConnectSpec(d)
+
+	licenseKey := d.Get("license").(string)
+
+	lm := license.NewManager(client.Client)
+	ll, err := lm.List(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	licFound := false
+	for _, l := range ll {
+		if l.LicenseKey == licenseKey {
+			licFound = true
+			break
+		}
+	}
+	if !licFound {
+		return fmt.Errorf("license key supplied (%s) did not match against known license keys", licenseKey)
+	}
+
+	var connectedState bool
+	val := d.Get("connected")
+	if val == nil {
+		connectedState = true
+	} else {
+		connectedState = val.(bool)
+	}
+
+	var task *object.Task
+	clusterID := d.Get("cluster").(string)
+	if clusterID != "" {
+		ccr, err := clustercomputeresource.FromID(client, clusterID)
+		if err != nil {
+			log.Printf("[DEBUG] Error while searching cluster %s. Error: %s", clusterID, err)
+			return err
+		}
+
+		task, err = ccr.AddHost(context.TODO(), hcs, connectedState, &licenseKey, nil)
+		if err != nil {
+			log.Printf("[DEBUG] Error while adding host with hostname %s to cluster %s.  Error: %s", d.Get("hostname").(string), clusterID, err)
+		}
+	} else {
+		dcId := d.Get("datacenter").(string)
+		dc, err := datacenterFromID(client, dcId)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), defaultAPITimeout)
+		defer cancel()
+		var dcProps mo.Datacenter
+		if err := dc.Properties(ctx, dc.Reference(), nil, &dcProps); err != nil {
+			return err
+		}
+
+		hostFolder := object.NewFolder(client.Client, dcProps.HostFolder)
+		task, err = hostFolder.AddStandaloneHost(context.TODO(), hcs, connectedState, &licenseKey, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	p := property.DefaultCollector(client.Client)
+	res, err := gtask.Wait(context.TODO(), task.Reference(), p, nil)
+	if err != nil {
+		return fmt.Errorf("Host addition failed. %s", err)
+	}
+	taskResult := res.Result
+
+	var hostID string
+	taskResultType := taskResult.(types.ManagedObjectReference).Type
+	switch taskResultType {
+	case "ComputeResource":
+		computeResource := object.NewComputeResource(client.Client, taskResult.(types.ManagedObjectReference))
+		crHosts, err := computeResource.Hosts(context.TODO())
+		if err != nil {
+			log.Printf("[DEBUG] Failed to retrieve resulting computeResource Hosts. Error: %s", err)
+			return err
+		}
+		hostID = crHosts[0].Reference().Value
+		log.Printf("[DEBUG] standalone hostID: %s", hostID)
+	case "HostSystem":
+		hostID = taskResult.(types.ManagedObjectReference).Value
+	default:
+		return fmt.Errorf("Unexpected task result type encountered. Got %s while waiting ComputeResourceType or Hostsystem", taskResultType)
+	}
+	log.Printf("[DEBUG] Host added with ID %s", hostID)
+	d.SetId(hostID)
+
+	host, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		log.Printf("[DEBUG] Failed while retrieving host object. Error: %s", err)
+		return err
+	}
+
+	lockdownModeString := d.Get("lockdown").(string)
+	lockdownMode, err := hostLockdownType(lockdownModeString)
+	if err != nil {
+		return err
+	}
+
+	if connectedState {
+		hostProps, err := hostsystem.Properties(host)
+		if err != nil {
+			return err
+		}
+
+		hamRef := hostProps.ConfigManager.HostAccessManager.Reference()
+		ham := NewHostAccessManager(client.Client, hamRef)
+		err = ham.ChangeLockdownMode(context.TODO(), lockdownMode)
+		if err != nil {
+			return err
+		}
+	}
+
+	maintenanceMode := d.Get("maintenance").(bool)
+	if maintenanceMode {
+		err = hostsystem.EnterMaintenanceMode(host, int(defaultAPITimeout), true)
+	} else {
+		err = hostsystem.ExitMaintenanceMode(host, int(defaultAPITimeout))
+	}
+	if err != nil {
+		return err
+	}
+
+	return resourceVsphereHostRead(d, meta)
+}
+
+func resourceVsphereHostUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+
+	// First let's establish where we are and where we want to go
+	var desiredConnectionState bool
+	if d.HasChange("connected") {
+		_, newVal := d.GetChange("connected")
+		desiredConnectionState = newVal.(bool)
+	} else {
+		desiredConnectionState = d.Get("connected").(bool)
+	}
+
+	hostID := d.Id()
+	hostObject, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		return err
+	}
+
+	actualConnectionState, err := hostsystem.GetConnectionState(hostObject)
+	if err != nil {
+		return err
+	}
+
+	// Have there been any changes that warrant a reconnect?
+	reconnect := false
+	connectionKeys := []string{"hostname", "username", "password", "thumbprint"}
+	for _, k := range connectionKeys {
+		if d.HasChange(k) {
+			reconnect = true
+			break
+		}
+	}
+
+	// Decide if we're going to reconnect or not
+	reconnectNeeded, err := shouldReconnect(d, meta, actualConnectionState, desiredConnectionState, reconnect)
+	if err != nil {
+		return err
+	}
+
+	switch reconnectNeeded {
+	case 1:
+		err := resourceVSphereHostReconnect(d, meta)
+		if err != nil {
+			return err
+		}
+	case -1:
+		err := resourceVSphereHostDisconnect(d, meta)
+		if err != nil {
+			return err
+		}
+	case 0:
+		break
+	}
+
+	mutableKeys := map[string]func(*schema.ResourceData, interface{}, interface{}, interface{}) error{
+		"license":     resourceVSphereHostUpdateLicense,
+		"cluster":     resourceVSphereHostUpdateCluster,
+		"maintenance": resourceVSphereHostUpdateMaintenanceMode,
+		"lockdown":    resourceVSphereHostUpdateLockdownMode,
+		"thumbprint":  resourceVSphereHostUpdateThumbprint,
+	}
+	for k, v := range mutableKeys {
+		log.Printf("[DEBUG] Checking if key %s changed", k)
+		if !d.HasChange(k) {
+			continue
+		}
+		log.Printf("[DEBUG] Key %s has change, processing", k)
+		old, newVal := d.GetChange(k)
+		err := v(d, meta, old, newVal)
+		if err != nil {
+			return fmt.Errorf("error while updating %s: %s", k, err)
+		}
+	}
+	return resourceVsphereHostRead(d, meta)
+}
+
+func resourceVsphereHostDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	hostID := d.Id()
+
+	hs, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		return err
+	}
+
+	connectionState, err := hostsystem.GetConnectionState(hs)
+	if err != nil {
+		return err
+	}
+
+	if connectionState != types.HostSystemConnectionStateDisconnected {
+		// We cannot put a disconnected server in maintenance mode.
+		err = hostsystem.EnterMaintenanceMode(hs, int(defaultAPITimeout), true)
+		if err != nil {
+			return fmt.Errorf("error while putting host to maintenance mode: %s", err.Error())
+		}
+	}
+
+	hostProps, err := hostsystem.Properties(hs)
+	if err != nil {
+		log.Printf("Error while retrieving properties fort host %s. Error: %s", hostID, err)
+		return err
+	}
+
+	// If this is a standalone host we need to destroy the ComputeResource object
+	// and not the Hostsystem itself.
+	var task *object.Task
+	if hostProps.Parent.Type == "ComputeResource" {
+		cr := object.NewComputeResource(client.Client, *hostProps.Parent)
+		task, err = cr.Destroy(context.TODO())
+		if err != nil {
+			log.Printf("[DEBUG] Error while submitting destroy task for compute resource %s. Error: %s", hostProps.Parent.Value, err)
+			return nil
+		}
+	} else {
+		task, err = hs.Destroy(context.TODO())
+		if err != nil {
+			log.Printf("[DEBUG] Error while submitting destroy task for host system %s. Error: %s", hostProps.Parent.Value, err)
+			return err
+		}
+	}
+	p := property.DefaultCollector(client.Client)
+	_, err = gtask.Wait(context.TODO(), task.Reference(), p, nil)
+	if err != nil {
+		return fmt.Errorf("Error while waiting for host (%s) to be removed: %s", hostID, err)
+	}
+	return nil
+}
+
+func resourceVSphereHostUpdateLockdownMode(d *schema.ResourceData, meta, old, newVal interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	hostID := d.Id()
+	host, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		return err
+	}
+	lockdownModeString := newVal.(string)
+	lockdownMode, err := hostLockdownType(lockdownModeString)
+	if err != nil {
+		return err
+	}
+
+	var hostProps mo.HostSystem
+	err = host.Properties(context.TODO(), host.ConfigManager().Reference(), []string{"configManager.hostAccessManager"}, &hostProps)
+	if err != nil {
+		return err
+	}
+
+	hamRef := hostProps.ConfigManager.HostAccessManager.Reference()
+	ham := NewHostAccessManager(client.Client, hamRef)
+	err = ham.ChangeLockdownMode(context.TODO(), lockdownMode)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceVSphereHostUpdateMaintenanceMode(d *schema.ResourceData, meta, old, newVal interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	hostID := d.Id()
+
+	host, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		return err
+	}
+
+	maintenanceMode := newVal.(bool)
+	if maintenanceMode {
+		err = hostsystem.EnterMaintenanceMode(host, int(defaultAPITimeout), true)
+	} else {
+		err = hostsystem.ExitMaintenanceMode(host, int(defaultAPITimeout))
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceVSphereHostUpdateLicense(d *schema.ResourceData, meta, old, newVal interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	lm := license.NewManager(client.Client)
+	lam, err := lm.AssignmentManager(context.TODO())
+	if err != nil {
+		return err
+	}
+	lam.Update(context.TODO(), d.Id(), newVal.(string), "")
+	return nil
+}
+
+func resourceVSphereHostUpdateCluster(d *schema.ResourceData, meta, old, newVal interface{}) error {
+	client := meta.(*VSphereClient).vimClient
+	hostID := d.Id()
+	newClusterID := newVal.(string)
+
+	newCluster, err := clustercomputeresource.FromID(client, newClusterID)
+	if err != nil {
+		log.Printf("[DEBUG] Error while searching newVal cluster %s. Error: %s.", newClusterID, err)
+		return err
+	}
+
+	hs, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		return err
+	}
+
+	err = hostsystem.EnterMaintenanceMode(hs, int(defaultAPITimeout), true)
+	if err != nil {
+		return fmt.Errorf("error while putting host to maintenance mode: %s", err.Error())
+	}
+
+	task, err := newCluster.MoveInto(context.TODO(), hs)
+	if err != nil {
+		return err
+	}
+	p := property.DefaultCollector(client.Client)
+	_, err = gtask.Wait(context.TODO(), task.Reference(), p, nil)
+	if err != nil {
+		return fmt.Errorf("Error while moving host to new cluster (%s): %s", newClusterID, err)
+	}
+
+	err = hostsystem.ExitMaintenanceMode(hs, int(defaultAPITimeout))
+	if err != nil {
+		return fmt.Errorf("error while taking host out of maintenance mode: %s", err.Error())
+	}
+
+	return nil
+}
+
+func resourceVSphereHostUpdateThumbprint(d *schema.ResourceData, meta, old, newVal interface{}) error {
+	return resourceVSphereHostReconnect(d, meta)
+}
+
+func resourceVSphereHostReconnect(d *schema.ResourceData, meta interface{}) error {
+	hostID := d.Id()
+	client := meta.(*VSphereClient).vimClient
+	host := object.NewHostSystem(client.Client, types.ManagedObjectReference{Type: "HostSystem", Value: d.Id()})
+	hcs := buildHostConnectSpec(d)
+
+	task, err := host.Reconnect(context.TODO(), &hcs, nil)
+	if err != nil {
+		return err
+	}
+
+	p := property.DefaultCollector(client.Client)
+	_, err = gtask.Wait(context.TODO(), task.Reference(), p, nil)
+	if err != nil {
+		return fmt.Errorf("Error while reconnecting host(%s): %s", hostID, err)
+	}
+
+	maintenanceState, err := hostsystem.HostInMaintenance(host)
+	if err != nil {
+		return nil
+	}
+
+	maintenanceConfig := d.Get("maintenance").(bool)
+	if maintenanceState && !maintenanceConfig {
+		err := hostsystem.ExitMaintenanceMode(host, int(defaultAPITimeout))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resourceVSphereHostDisconnect(d *schema.ResourceData, meta interface{}) error {
+	hostID := d.Id()
+	client := meta.(*VSphereClient).vimClient
+	host := object.NewHostSystem(client.Client, types.ManagedObjectReference{Type: "HostSystem", Value: d.Id()})
+	task, err := host.Disconnect(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	p := property.DefaultCollector(client.Client)
+	_, err = gtask.Wait(context.TODO(), task.Reference(), p, nil)
+	if err != nil {
+		return fmt.Errorf("Error while disconnecting host(%s): %s", hostID, err)
+	}
+	return nil
+}
+
+func shouldReconnect(d *schema.ResourceData, meta interface{}, actual types.HostSystemConnectionState, desired, shouldReconnect bool) (int, error) {
+	log.Printf("[DEBUG] Figuring out if we need to do something about the host's connection")
+
+	// desired state is connected and one of the connectionKeys has changed
+	if shouldReconnect && desired {
+		log.Printf("[DEBUG] Desired state is connected and one of the settings relevant to the connection changed. Reconnecting")
+		return 1, nil
+	}
+
+	// desired state is connected and actual state is disconnected
+	if desired && (actual != types.HostSystemConnectionStateConnected) {
+		log.Printf("[DEBUG] Desired state is connected but host is not connected. Reconnecting")
+		return 1, nil
+	}
+
+	// desired state is connected and actual state is connected (or host is missing heartbeats) and
+	// none of the connectionKeys have changed.
+	if desired && (actual != types.HostSystemConnectionStateDisconnected) && !shouldReconnect {
+		log.Printf("[DEBUG] Desired state is connected and host is connected and no changes in config. Noop")
+		return 0, nil
+	}
+
+	// desired state is disconnected and host is disconnected
+	if !desired && (actual == types.HostSystemConnectionStateDisconnected) {
+		log.Printf("[DEBUG] Desired state is disconnected and host is disconnected")
+		return 0, nil
+	}
+
+	if !desired && (actual != types.HostSystemConnectionStateDisconnected) {
+		log.Printf("[DEBUG] Desired state is disconnected but host is not disconnected. Disconnecting")
+		return -1, nil
+	}
+
+	log.Printf("[DEBUG] Unexpected combination of desired and actual states, not sure how to handle. Please submit a bug report.")
+	return 255, fmt.Errorf("Unexpected combination of connection states")
+}
+
+func hostLockdownType(lockdownMode string) (types.HostLockdownMode, error) {
+	lockdownModes := map[string]types.HostLockdownMode{
+		"disabled": types.HostLockdownModeLockdownDisabled,
+		"normal":   types.HostLockdownModeLockdownNormal,
+		"strict":   types.HostLockdownModeLockdownStrict,
+	}
+
+	log.Printf("Looking for mode %s in lockdown modes %#v", lockdownMode, lockdownModes)
+	if modeString, ok := lockdownModes[lockdownMode]; ok {
+		log.Printf("Found match for %s. Returning %s.", lockdownMode, modeString)
+		return modeString, nil
+	}
+	return "", fmt.Errorf("Unknwown Lockdown mode encountered")
+}
+
+func hostLockdownString(lockdownMode types.HostLockdownMode) (string, error) {
+	lockdownModes := map[types.HostLockdownMode]string{
+		types.HostLockdownModeLockdownDisabled: "disabled",
+		types.HostLockdownModeLockdownNormal:   "normal",
+		types.HostLockdownModeLockdownStrict:   "strict",
+	}
+
+	log.Printf("Looking for mode %s in lockdown modes %#v", lockdownMode, lockdownModes)
+	if modeString, ok := lockdownModes[lockdownMode]; ok {
+		log.Printf("Found match for %s. Returning %s.", lockdownMode, modeString)
+		return modeString, nil
+	}
+	return "", fmt.Errorf("Unknwown Lockdown mode encountered")
+}
+
+func buildHostConnectSpec(d *schema.ResourceData) types.HostConnectSpec {
+	hcs := types.HostConnectSpec{
+		HostName:      d.Get("hostname").(string),
+		UserName:      d.Get("username").(string),
+		Password:      d.Get("password").(string),
+		SslThumbprint: d.Get("thumbprint").(string),
+		Force:         d.Get("force").(bool),
+	}
+	return hcs
+}
+
+// --------------
+// Implementing stuff govmomi should provide for us
+//
+//
+
+type HostAccessManager struct {
+	object.Common
+}
+
+func NewHostAccessManager(c *vim25.Client, ref types.ManagedObjectReference) *HostAccessManager {
+	return &HostAccessManager{
+		Common: object.NewCommon(c, ref),
+	}
+}
+
+func (h HostAccessManager) ChangeLockdownMode(ctx context.Context, mode types.HostLockdownMode) error {
+	req := types.ChangeLockdownMode{
+		This: h.Reference(),
+		Mode: mode,
+	}
+	_, err := methods.ChangeLockdownMode(ctx, h.Client(), &req)
+	return err
+}

--- a/vsphere/resource_vsphere_host_test.go
+++ b/vsphere/resource_vsphere_host_test.go
@@ -1,0 +1,532 @@
+package vsphere
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/vmware/govmomi"
+
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/hostsystem"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/viapi"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccResourceVsphereHost_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"ESX_HOSTNAME", "ESX_USERNAME", "ESX_PASSWORD"})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereHostConfig_import(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+				),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+}
+
+func TestAccResourceVSphereHost_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"ESX_HOSTNAME", "ESX_USERNAME", "ESX_PASSWORD"})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereHostConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccResourceVSphereHost_rootFolder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"ESX_HOSTNAME", "ESX_USERNAME", "ESX_PASSWORD"})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereHostConfig_rootFolder(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccResourceVSphereHost_connection(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"ESX_HOSTNAME", "ESX_USERNAME", "ESX_PASSWORD"})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereHostConfig_connection(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+					testAccVSphereHostConnected("vsphere_host.h1", false),
+				),
+			},
+			{
+				Config: testAccVSphereHostConfig_connection(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+					testAccVSphereHostConnected("vsphere_host.h1", true),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccResourceVSphereHost_maintenance(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"ESX_HOSTNAME", "ESX_USERNAME", "ESX_PASSWORD"})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereHostConfig_maintenance(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+					testAccVSphereHostMaintenanceState("vsphere_host.h1", true),
+				),
+			},
+			{
+				Config: testAccVSphereHostConfig_maintenance(false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+					testAccVSphereHostMaintenanceState("vsphere_host.h1", false),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccResourceVSphereHost_lockdown(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"ESX_HOSTNAME", "ESX_USERNAME", "ESX_PASSWORD"})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVSphereHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVSphereHostConfig_lockdown("strict"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+					testAccVSphereHostLockdownState("vsphere_host.h1", "strict"),
+				),
+			},
+			{
+				Config: testAccVSphereHostConfig_lockdown("normal"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+					testAccVSphereHostLockdownState("vsphere_host.h1", "normal"),
+				),
+			},
+			{
+				Config: testAccVSphereHostConfig_lockdown("disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccVSphereHostExists("vsphere_host.h1"),
+					testAccVSphereHostLockdownState("vsphere_host.h1", "disabled"),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccVSphereHostExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("%s key not found on the server", name)
+		}
+		hostID := rs.Primary.ID
+		client := testAccProvider.Meta().(*VSphereClient).vimClient
+		res, err := hostExists(client, hostID)
+		if err != nil {
+			return err
+		}
+
+		if !res {
+			return fmt.Errorf("Host with ID %s not found", hostID)
+		}
+
+		return nil
+	}
+}
+
+func testAccVSphereHostConnected(name string, shouldBeConnected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("%s key not found on the server", name)
+		}
+		hostID := rs.Primary.ID
+		client := testAccProvider.Meta().(*VSphereClient).vimClient
+		res, err := hostConnected(client, hostID)
+		if err != nil {
+			return err
+		}
+
+		if res != shouldBeConnected {
+			return fmt.Errorf("Host with ID %s connection: %t, expected %t", hostID, res, shouldBeConnected)
+		}
+
+		return nil
+	}
+}
+
+func testAccVSphereHostMaintenanceState(name string, inMaintenance bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("%s key not found on the server", name)
+		}
+		hostID := rs.Primary.ID
+		client := testAccProvider.Meta().(*VSphereClient).vimClient
+		res, err := hostInMaintenance(client, hostID)
+		if err != nil {
+			return err
+		}
+
+		if res != inMaintenance {
+			return fmt.Errorf("Host with ID %s in maintenance : %t, expected %t", hostID, res, inMaintenance)
+		}
+
+		return nil
+	}
+}
+
+func testAccVSphereHostLockdownState(name string, lockdown string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("%s key not found on the server", name)
+		}
+		hostID := rs.Primary.ID
+		client := testAccProvider.Meta().(*VSphereClient).vimClient
+		res, err := checkHostLockdown(client, hostID, lockdown)
+		if err != nil {
+			return err
+		}
+
+		if !res {
+			return fmt.Errorf("Host with ID %s not in desired lockdown state. Current state: %s", hostID, lockdown)
+		}
+
+		return nil
+	}
+}
+
+func testAccVSphereHostDestroy(s *terraform.State) error {
+	message := ""
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vsphere_host" {
+			continue
+		}
+		hostID := rs.Primary.ID
+		client := testAccProvider.Meta().(*VSphereClient).vimClient
+		res, err := hostExists(client, hostID)
+		if err != nil {
+			return err
+		}
+
+		if res {
+			message += fmt.Sprintf("Host with ID %s was found", hostID)
+		}
+	}
+	if message != "" {
+		return errors.New(message)
+	}
+	return nil
+}
+
+func hostExists(client *govmomi.Client, hostID string) (bool, error) {
+	hs, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		if viapi.IsManagedObjectNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if hs.Reference().Value != hostID {
+		return false, nil
+	}
+	return true, nil
+}
+
+func hostConnected(client *govmomi.Client, hostID string) (bool, error) {
+	hs, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		return false, err
+	}
+
+	connectionState, err := hostsystem.GetConnectionState(hs)
+	if err != nil {
+		return false, err
+	}
+	return (connectionState == types.HostSystemConnectionStateConnected), nil
+}
+
+func hostInMaintenance(client *govmomi.Client, hostID string) (bool, error) {
+	hs, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		return false, err
+	}
+
+	maintenanceState, err := hostsystem.HostInMaintenance(hs)
+	if err != nil {
+		return false, err
+	}
+	return maintenanceState, nil
+}
+
+func checkHostLockdown(client *govmomi.Client, hostID, lockdownMode string) (bool, error) {
+	host, err := hostsystem.FromID(client, hostID)
+	if err != nil {
+		return false, err
+	}
+	hostProps, err := hostsystem.Properties(host)
+	if err != nil {
+		return false, err
+	}
+
+	lockdownModes := map[types.HostLockdownMode]string{
+		types.HostLockdownModeLockdownDisabled: "disabled",
+		types.HostLockdownModeLockdownNormal:   "normal",
+		types.HostLockdownModeLockdownStrict:   "strict",
+	}
+
+	modeString, ok := lockdownModes[hostProps.Config.LockdownMode]
+	if !ok {
+		return false, fmt.Errorf("Unknown lockdown mode found: %s", hostProps.Config.LockdownMode)
+	}
+
+	return (modeString == lockdownMode), nil
+}
+
+func testAccVSphereHostConfig() string {
+	return fmt.Sprintf(`
+	data "vsphere_datacenter" "dc" {
+	  name = "%s"
+	}
+
+	data "vsphere_compute_cluster" "c1" {
+	  name = "%s"
+	  datacenter_id = data.vsphere_datacenter.dc.id
+	}
+
+	resource "vsphere_host" "h1" {
+	  # Useful only for connection
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
+	  thumbprint = "%s"
+
+	  # Makes sense to update
+	  license = "%s"
+	  cluster = data.vsphere_compute_cluster.c1.id
+	}
+	`, os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_CLUSTER"),
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
+		os.Getenv("ESX_THUMBPRINT"),
+		os.Getenv("VSPHERE_LICENSE"))
+}
+
+func testAccVSphereHostConfig_rootFolder() string {
+	return fmt.Sprintf(`
+	data "vsphere_datacenter" "dc" {
+	  name = "%s"
+	}
+
+	resource "vsphere_host" "h1" {
+	  # Useful only for connection
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
+	  thumbprint = "%s"
+
+	  # Makes sense to update
+	  license = "%s"
+	  datacenter = data.vsphere_datacenter.dc.id
+	}
+	`, os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
+		os.Getenv("ESX_THUMBPRINT"),
+		os.Getenv("VSPHERE_LICENSE"))
+}
+
+func testAccVSphereHostConfig_import() string {
+	return fmt.Sprintf(`
+	data "vsphere_datacenter" "dc" {
+	  name = "%s"
+	}
+		
+	data "vsphere_compute_cluster" "c1" {
+	  name = "%s"
+	  datacenter_id = data.vsphere_datacenter.dc.id
+	}
+		
+	resource "vsphere_host" "h1" {
+	  # Useful only for connection
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
+	  thumbprint = "%s"
+	
+	  # Makes sense to update
+	  license = "%s"
+	  cluster = data.vsphere_compute_cluster.c1.id
+	}	  
+	`, os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_CLUSTER"),
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
+		os.Getenv("ESX_THUMBPRINT"),
+		os.Getenv("VSPHERE_LICENSE"))
+}
+
+func testAccVSphereHostConfig_connection(connection bool) string {
+	return fmt.Sprintf(`
+	data "vsphere_datacenter" "dc" {
+	  name = "%s"
+	}
+		
+	data "vsphere_compute_cluster" "c1" {
+	  name = "%s"
+	  datacenter_id = data.vsphere_datacenter.dc.id
+	}
+		
+	resource "vsphere_host" "h1" {
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
+	  thumbprint = "%s"
+	
+	  license = "%s"
+	  connected = "%s"
+	  cluster = data.vsphere_compute_cluster.c1.id
+	}	  
+	`, os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_CLUSTER"),
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
+		os.Getenv("ESX_THUMBPRINT"),
+		os.Getenv("VSPHERE_LICENSE"),
+		strconv.FormatBool(connection))
+}
+
+func testAccVSphereHostConfig_maintenance(maintenance bool) string {
+	return fmt.Sprintf(`
+	data "vsphere_datacenter" "dc" {
+	  name = "%s"
+	}
+		
+	data "vsphere_compute_cluster" "c1" {
+	  name = "%s"
+	  datacenter_id = data.vsphere_datacenter.dc.id
+	}
+		
+	resource "vsphere_host" "h1" {
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
+	  thumbprint = "%s"
+	
+	  license = "%s"
+	  connected = "true"
+	  maintenance = "%s"
+	  cluster = data.vsphere_compute_cluster.c1.id
+	}	  
+	`, os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_CLUSTER"),
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
+		os.Getenv("ESX_THUMBPRINT"),
+		os.Getenv("VSPHERE_LICENSE"),
+		strconv.FormatBool(maintenance))
+}
+
+func testAccVSphereHostConfig_lockdown(lockdown string) string {
+	return fmt.Sprintf(`
+	data "vsphere_datacenter" "dc" {
+	  name = "%s"
+	}
+		
+	data "vsphere_compute_cluster" "c1" {
+	  name = "%s"
+	  datacenter_id = data.vsphere_datacenter.dc.id
+	}
+		
+	resource "vsphere_host" "h1" {
+	  hostname = "%s"
+	  username = "%s"
+	  password = "%s"
+	  thumbprint = "%s"
+	
+	  license = "%s"
+	  connected = "true"
+	  maintenance = "false"
+	  lockdown = "%s"
+	  cluster = data.vsphere_compute_cluster.c1.id
+	}	  
+	`, os.Getenv("VSPHERE_DATACENTER"),
+		os.Getenv("VSPHERE_CLUSTER"),
+		os.Getenv("ESX_HOSTNAME"),
+		os.Getenv("ESX_USERNAME"),
+		os.Getenv("ESX_PASSWORD"),
+		os.Getenv("ESX_THUMBPRINT"),
+		os.Getenv("VSPHERE_LICENSE"),
+		lockdown)
+}

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -1,0 +1,95 @@
+---
+layout: "vsphere"
+page_title: "VMware vSphere: vsphere_host"
+sidebar_current: "docs-vsphere-resource-inventory-host"
+description: |-
+  Provides a VMware vSphere host resource. This represents an ESXi host that can be used either as part of a Compute Cluster or Standalone.
+---
+
+# vsphere\_host
+
+Provides a VMware vSphere host resource. This represents an ESXi host that
+can be used either as part of a Compute Cluster or Standalone.
+
+## Example Usages
+
+**Create a standalone host:**
+
+```hcl
+data "vsphere_datacenter" "dc" {
+  name = "my-datacenter"
+}
+
+resource "vsphere_host" "h1" {
+  hostname = "10.10.10.1"
+  username = "root"
+  password = "password"
+  license = "00000-00000-00000-00000i-00000"
+  datacenter = data.vsphere_datacenter.dc.id
+}
+```
+
+**Create host in a compute cluster:**
+
+```hcl
+data "vsphere_datacenter" "dc" {
+  name = "TfDatacenter"
+}
+
+data "vsphere_compute_cluster" "c1" {
+  name = "DC0_C0"
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+resource "vsphere_host" "h1" {
+  hostname = "10.10.10.1"
+  username = "root"
+  password = "password"
+  license = "00000-00000-00000-00000i-00000"
+  cluster = data.vsphere_compute_cluster.c1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `hostname` - (Required) FQDN or IP address of the host to be added.
+* `username` - (Required) Username that will be used by vSphere to authenticate
+  to the host.
+* `password` - (Required) Password that will be used by vSphere to authenticate
+  to the host.
+* `datacenter` - (Optional) The ID of the datacenter this host should
+  be added to. This should not be set if `cluster` is set.
+* `cluster` - (Optional) The ID of the Compute Cluster this host should
+  be added to. This should not be set if `datacenter` is set.
+* `thumbprint` - (Optional) Host's certificate SHA-1 thumbprint. If not set the the
+  CA that signed the host's certificate should be trusted. If the CA is not trusted
+  and no thumbprint is set then the operation will fail.
+* `license` - (Optional) The license key that will be applied to the host.
+  The license key is expected to be present in vSphere.
+* `force` - (Optional) If set to true then it will force the host to be added, even
+  if the host is already connected to a different vSphere instance. Default is `false`
+* `connected` - (Optional) If set to false then the host will be disconected.
+  Default is `false`.
+* `maintenance` - (Optional) Set the management state of the host. Default is `false`.
+* `lockdown` - (Optional) Set the lockdown state of the host. Valid options are
+  `disabled`, `normal`, and `strict`. Default is `disabled`.
+
+## Attribute Reference
+
+* `id` - The ID of the host.
+
+
+## Importing 
+
+An existing host can be [imported][docs-import] into this resource
+via supplying the host's ID. An example is below:
+
+[docs-import]: /docs/import/index.html
+
+```
+terraform import vsphere_host.vm host-123
+```
+
+The above would import the host with ID `host-123`.


### PR DESCRIPTION
This is a first draft of a resource that allows terraform users to add new ESXi hosts to a vsphere cluster and manage things like:

[x] connection status
[x] maintenance status
[x] lockdown mode

Once we settle on what it should look like we can work on adding more features.