### PR TITLE
NetworkHelper: Limit the returned scope as workaround for govmomi reflection issue

### DIFF
--- a/vsphere/internal/helper/network/network_helper.go
+++ b/vsphere/internal/helper/network/network_helper.go
@@ -55,7 +55,7 @@ func FromID(client *govmomi.Client, id string) (object.NetworkReference, error) 
 	}()
 
 	var networks []mo.Network
-	err = v.Retrieve(vctx, []string{"Network"}, nil, &networks)
+	err = v.Retrieve(vctx, []string{"Network"}, []string{"name"}, &networks)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When trying to clone a machine and then adding/changing the network interface, the result is a `panic: reflect.Value.Addr of unaddressable value` in the govmomi xml decoder. This is partially solved in this provider by only returning a limited scope.

I have not been able to reproduce this with https://github.com/vmware/govmomi/blob/master/examples/networks/main.go. 

It could be that this also solves #822 

```
2019-09-12T12:17:17.630+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: 2019/09/12 12:17:17 DEBUGGING: val=<nil>, pval=&{DvsNetworkRuleQualifier:{DynamicData:{} Key:30_31_ _61305613_12142737_30325633} TypeOfSystemTraffic:0xc000b5dba0}, valtype=types.BaseDvsNetworkRuleQualifier
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: panic: reflect.Value.Addr of unaddressable value
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: goroutine 246 [running]:
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: reflect.Value.Addr(0x150af60, 0xc000b5dae0, 0x16, 0x3, 0x3, 0x16)
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:      /usr/local/go/src/reflect/value.go:258 +0x96
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: github.com/vmware/govmomi/vim25/xml.(*Decoder).unmarshal(0xc000742f00, 0x1536220, 0xc000a87e80, 0x194, 0xc000a87e40, 0xc000a87e80,
 0x194)
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:      /home//code/github/govmomi/vim25/xml/read.go:354 +0x2ffd
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: github.com/vmware/govmomi/vim25/xml.(*Decoder).unmarshal(0xc000742f00, 0x141dc60, 0xc000162508, 0x197, 0xc000a87e40, 0xc000162508,
 0x197)
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:      /home//code/github/govmomi/vim25/xml/read.go:449 +0x2432
2019-09-12T12:17:17.672+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: github.com/vmware/govmomi/vim25/xml.(*Decoder).unmarshalPath(0xc000742f00, 0xc000b828e0, 0x17312a0, 0xc0001624e0, 0x199, 0x0, 0x0,
 0x0, 0xc000a87e40, 0x15ab101, ...)
...
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:      /home//code/github/govmomi/view/container_view.go:82 +0x5d8
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/network.FromID(0xc00023ab60, 0xc00083c5e0, 0x12, 0x0, 0x0, 0x0, 0x0)
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:      /home//code/github/terraform-provider-vsphere/vsphere/internal/helper/network/network_helper.go:58 +0x458
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/virtualdevice.(*NetworkInterfaceSubresource).Create(0xc000792c50, 0xc000b1ca00, 0xb, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0)
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:      /home//code/github/terraform-provider-vsphere/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go:588 +0x1b4
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/virtualdevice.NetworkInterfacePostCloneOperation(0xc0004229a0, 0xc00023ab60, 0xc000b1ca00, 0xb, 0x10, 0x1, 0xc0008cc6b0, 0x1, 0x1, 0x1, ...)
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:      /home//code/github/terraform-provider-vsphere/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go:438 +0x9a4
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: github.com/terraform-providers/terraform-provider-vsphere/vsphere.resourceVSphereVirtualMachineCreateClone(0xc0004229a0, 0x14bdcc0, 0xc0002090b0, 0x1427a20, 0xc000388020, 0x1)
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:      /home//code/github/terraform-provider-vsphere/vsphere/resource_vsphere_virtual_machine.go:1164 +0xe24
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4: github.com/terraform-providers/terraform-provider-vsphere/vsphere.resourceVSphereVirtualMachineCreate(0xc0004229a0, 0x14bdcc0, 0xc0002090b0, 0x2, 0x2744ea0)
2019-09-12T12:17:17.674+0200 [DEBUG] plugin.terraform-provider-vsphere_v1.12.0_x4:      /home//code/github/terraform-provider-vsphere/vsphere/resource_vsphere_virtual_machine.go:258 +0x1
...