### PR TITLE
Extend ignored_guest_ips to support CIDR networks

### DIFF
--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -358,20 +358,15 @@ func skipIPAddrForWaiter(ip net.IP, ignoredGuestIPs []interface{}) bool {
 	case ip.IsMulticast():
 		return true
 	default:
+		// ignoredGuestIPs pre-validated by Schema!
 		for _, ignoredGuestIP := range ignoredGuestIPs {
 			if strings.Contains(ignoredGuestIP.(string), "/") {
-				_, ignoredIPNet, err := net.ParseCIDR(ignoredGuestIP.(string))
-				if err != nil {
-					log.Printf("[ERROR] Failed to parse ignored_guest_ips entry: %q", ignoredGuestIP)
-					continue
-				} else if ignoredIPNet.Contains(ip) {
+				_, ignoredIPNet, _ := net.ParseCIDR(ignoredGuestIP.(string))
+				if ignoredIPNet.Contains(ip) {
 					return true
 				}
-			} else {
-				ignoredIP := net.ParseIP(ignoredGuestIP.(string))
-				if ignoredIP != nil && ignoredIP.Equal(ip) {
-					return true
-				}
+			} else if net.ParseIP(ignoredGuestIP.(string)).Equal(ip) {
+				return true
 			}
 		}
 	}

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -112,7 +112,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 		"ignored_guest_ips": {
 			Type:        schema.TypeList,
 			Optional:    true,
-			Description: "List of IP addresses to ignore while waiting for an IP",
+			Description: "List of IP addresses and CIDR networks to ignore while waiting for an IP",
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		"shutdown_wait_timeout": {

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -656,10 +656,10 @@ amount of memory provisioned for the virtual machine.
   only be used if your version of VMware Tools does not allow the
   [`wait_for_guest_net_timeout`](#wait_for_guest_net_timeout) waiter to be
   used. A value less than 1 disables the waiter. Default: 0.
-* `ignored_guest_ips` - (Optional) List of IP addresses to ignore while waiting
-  for an available IP address using either of the waiters. Any IP addresses in
-  this list will be ignored if they show up so that the waiter will continue to
-  wait for a real IP address. Default: [].
+* `ignored_guest_ips` - (Optional) List of IP addresses and CIDR networks to
+  ignore while waiting for an available IP address using either of the waiters.
+  Any IP addresses in this list will be ignored if they show up so that the
+  waiter will continue to wait for a real IP address. Default: [].
 * `shutdown_wait_timeout` - (Optional) The amount of time, in minutes, to wait
   for a graceful guest shutdown when making necessary updates to the virtual
   machine. If `force_power_off` is set to true, the VM will be force powered-off


### PR DESCRIPTION
* Correctly parse CIDR networks included in the `ignored_guest_ips` list, allowing entire arbitrary IP ranges to be ignored.
* Compare guest IP addresses to `ignored_guest_ips` using `net.IP.Equal()` rather than raw string comparison, enhancing support for variations in IPv6 representation.