### PR TITLE
Enhancement to virtual machine data source

### DIFF
--- a/vsphere/data_source_vsphere_virtual_machine.go
+++ b/vsphere/data_source_vsphere_virtual_machine.go
@@ -77,6 +77,27 @@ func dataSourceVSphereVirtualMachine() *schema.Resource {
 					},
 				},
 			},
+			"network_interfaces": {
+				Type:        schema.TypeList,
+				Description: "The network interfaces found on the virtual machine, sorted by unit number.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"adapter_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mac_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"network_interface_types": {
 				Type:        schema.TypeList,
 				Description: "The types of network interfaces found on the virtual machine, sorted by unit number.",
@@ -132,11 +153,18 @@ func dataSourceVSphereVirtualMachineRead(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return fmt.Errorf("error reading network interface types: %s", err)
 	}
+	networkInterfaces, err := virtualdevice.ReadNetworkInterfaces(object.VirtualDeviceList(props.Config.Hardware.Device))
+	if err != nil {
+		return fmt.Errorf("error reading network interfaces: %s", err)
+	}
 	if d.Set("disks", disks); err != nil {
 		return fmt.Errorf("error setting disk sizes: %s", err)
 	}
 	if d.Set("network_interface_types", nics); err != nil {
 		return fmt.Errorf("error setting network interface types: %s", err)
+	}
+	if d.Set("network_interfaces", networkInterfaces); err != nil {
+		return fmt.Errorf("error setting network interfaces: %s", err)
 	}
 	log.Printf("[DEBUG] VM search for %q completed successfully (UUID %q)", name, props.Config.Uuid)
 	return nil

--- a/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_network_interface_subresource.go
@@ -525,6 +525,60 @@ func ReadNetworkInterfaceTypes(l object.VirtualDeviceList) ([]string, error) {
 	return out, nil
 }
 
+// ReadNetworkInterfaces returns a list of network interfaces. This is used
+// in the VM data source to discover the properties of the network interfaces on the
+// virtual machine. The list is sorted by the order that they would be added in
+// if a clone were to be done.
+func ReadNetworkInterfaces(l object.VirtualDeviceList) ([]map[string]interface{}, error) {
+	log.Printf("[DEBUG] ReadNetworkInterfaces: Fetching network interfaces")
+	devices := l.Select(func(device types.BaseVirtualDevice) bool {
+		if _, ok := device.(types.BaseVirtualEthernetCard); ok {
+			return true
+		}
+		return false
+	})
+	log.Printf("[DEBUG] ReadNetworkInterface: Network devices located: %s", DeviceListString(devices))
+	// Sort the device list, in case it's not sorted already.
+	devSort := virtualDeviceListSorter{
+		Sort:       devices,
+		DeviceList: l,
+	}
+	sort.Sort(devSort)
+	devices = devSort.Sort
+	log.Printf("[DEBUG] ReadNetworkInterfaceTypes: Network devices order after sort: %s", DeviceListString(devices))
+	var out []map[string]interface{}
+	for _, device := range devices {
+		m := make(map[string]interface{})
+
+		ethernetCard := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+
+		// Determine the network from the backing object
+		var networkID string
+
+		switch backing := ethernetCard.Backing.(type) {
+		case *types.VirtualEthernetCardNetworkBackingInfo:
+			if backing.Network != nil {
+				networkID = backing.Network.Value
+			}
+		case *types.VirtualEthernetCardOpaqueNetworkBackingInfo:
+			networkID = backing.OpaqueNetworkId
+		case *types.VirtualEthernetCardDistributedVirtualPortBackingInfo:
+			networkID = backing.Port.PortgroupKey
+		default:
+		}
+
+		// Set properties
+
+		m["network_id"] = networkID
+		m["adapter_type"] = virtualEthernetCardString(device.(types.BaseVirtualEthernetCard))
+		m["mac_address"] = ethernetCard.MacAddress
+
+		out = append(out, m)
+	}
+	log.Printf("[DEBUG] ReadNetworkInterfaces: Network interfaces returned: %+v", out)
+	return out, nil
+}
+
 // baseVirtualEthernetCardToBaseVirtualDevice converts a
 // BaseVirtualEthernetCard value into a BaseVirtualDevice.
 func baseVirtualEthernetCardToBaseVirtualDevice(v types.BaseVirtualEthernetCard) types.BaseVirtualDevice {


### PR DESCRIPTION
Adds new property 'network_interfaces' to vSphere Virtual Machine data source which returns information about each network interface on the virtual machine or template.

This is useful for discovering certain network interfaces while performing a linked clone, specifically where the desired state is to replicate the network settings of the source virtual machine on the destination.

The sub-attributes which are exported are as follows:

- network_id: The managed object reference ID of the network backing the interface.
- adapter_type: The network interface type, i.e.  e1000, e1000e, or vmxnet3. (deprecates requirement for separate 'network_interfaces_types' property)
- mac_address: The mac_address of the network interface

Properties can be referenced as follows:

"${data.vsphere_virtual_machine.source.network_interfaces.0.adapter_type}"

Resolves: #809
