### PR TITLE
r/host: Fix sidebar links

### DIFF
--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_host"
-sidebar_current: "docs-vsphere-resource-inventory-host"
+sidebar_current: "docs-vsphere-resource-compute-host"
 description: |-
   Provides a VMware vSphere host resource. This represents an ESXi host that can be used either as part of a Compute Cluster or Standalone.
 ---

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -67,6 +67,9 @@
         <li<%= sidebar_current("docs-vsphere-resource-compute") %>>
           <a href="#">Host and Cluster Management Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-vsphere-resource-compute-host") %>>
+              <a href="/docs/providers/vsphere/r/host.html">vsphere_host</a>
+            </li>
             <li<%= sidebar_current("docs-vsphere-resource-compute-compute-cluster") %>>
               <a href="/docs/providers/vsphere/r/compute_cluster.html">vsphere_compute_cluster</a>
             </li>


### PR DESCRIPTION
Link to the resource's docs is missing from the index. Unless someone
knows the page exists they are will not be able to access it.