### PR TITLE
Add subcategories to docs for Terraform Registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,11 @@ jobs:
           cd $GOPATH/src/github.com/terraform-providers/terraform-provider-vsphere
           make test
     - run:
+        name: "Run docscheck script "
+        command: |
+          cd $GOPATH/src/github.com/terraform-providers/terraform-provider-vsphere
+          make docscheck
+    - run:
         name: "Run Build"
         command: |
           cd $GOPATH/src/github.com/terraform-providers/terraform-provider-vsphere

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,6 +34,9 @@ vet:
 fmt:
 	gofmt -w $(GOFMT_FILES)
 
+docscheck:
+	@sh -c "'$(CURDIR)/scripts/docscheck.sh'"
+
 fmtcheck:
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
@@ -62,5 +65,5 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
+.PHONY: build test testacc vet docscheck fmt fmtcheck errcheck test-compile website website-test
 

--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -15,9 +15,9 @@ for doc in $docs; do
       ;;
 
     "d")
-			# Data sources have no requirements
-			continue
-			;;
+      # Data sources have no requirements
+      continue
+      ;;
 
 		"r")
       # Resources require a subcategory

--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+docs=$(ls website/docs/**/*.markdown)
+error=false
+
+for doc in $docs; do
+  dirname=$(dirname "$doc")
+  category=$(basename "$dirname")
+
+
+  case "$category" in
+    "guides")
+      # Guides have no requirements
+      continue
+      ;;
+
+    "d")
+			# Data sources have no requirements
+			continue
+			;;
+
+		"r")
+      # Resources require a subcategory
+      grep "^subcategory: " "$doc" > /dev/null
+      if [[ "$?" == "1" ]]; then
+        echo "Doc is missing a subcategory: $doc"
+        error=true
+      fi
+      ;;
+
+    *)
+      # Docs
+      error=true
+      echo "Unknown category \"$category\". " \
+        "Docs can only exist in r/, d/, or guides/ folders."
+      ;;
+  esac
+done
+
+if $error; then
+  exit 1
+fi
+
+exit 0

--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster"
 sidebar_current: "docs-vsphere-resource-compute-compute-cluster"

--- a/website/docs/r/compute_cluster_host_group.html.markdown
+++ b/website/docs/r/compute_cluster_host_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster_host_group"
 sidebar_current: "docs-vsphere-resource-compute-cluster-host-group"

--- a/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_affinity_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster_vm_affinity_rule"
 sidebar_current: "docs-vsphere-resource-compute-cluster-vm-affinity-rule"

--- a/website/docs/r/compute_cluster_vm_anti_affinity_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_anti_affinity_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster_vm_anti_affinity_rule"
 sidebar_current: "docs-vsphere-resource-compute-cluster-vm-anti-affinity-rule"

--- a/website/docs/r/compute_cluster_vm_dependency_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_dependency_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster_vm_dependency_rule"
 sidebar_current: "docs-vsphere-resource-compute-cluster-vm-dependency-rule"

--- a/website/docs/r/compute_cluster_vm_group.html.markdown
+++ b/website/docs/r/compute_cluster_vm_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster_vm_group"
 sidebar_current: "docs-vsphere-resource-compute-cluster-vm-group"

--- a/website/docs/r/compute_cluster_vm_host_rule.html.markdown
+++ b/website/docs/r/compute_cluster_vm_host_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_compute_cluster_vm_host_rule"
 sidebar_current: "docs-vsphere-resource-compute-cluster-vm-host-rule"

--- a/website/docs/r/custom_attribute.html.markdown
+++ b/website/docs/r/custom_attribute.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Inventory"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_custom_attribute"
 sidebar_current: "docs-vsphere-resource-inventory-custom-attribute"

--- a/website/docs/r/datacenter.html.markdown
+++ b/website/docs/r/datacenter.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Inventory"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_datacenter"
 sidebar_current: "docs-vsphere-resource-inventory-datacenter"

--- a/website/docs/r/datastore_cluster.html.markdown
+++ b/website/docs/r/datastore_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Storage"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_datastore_cluster"
 sidebar_current: "docs-vsphere-resource-storage-datastore-cluster"

--- a/website/docs/r/datastore_cluster_vm_anti_affinity_rule.html.markdown
+++ b/website/docs/r/datastore_cluster_vm_anti_affinity_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Storage"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_datastore_cluster_vm_anti_affinity_rule"
 sidebar_current: "docs-vsphere-resource-storage-cluster-datastore-vm-anti-affinity-rule"

--- a/website/docs/r/distributed_port_group.html.markdown
+++ b/website/docs/r/distributed_port_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Networking"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_distributed_port_group"
 sidebar_current: "docs-vsphere-resource-networking-distributed-port-group"

--- a/website/docs/r/distributed_virtual_switch.html.markdown
+++ b/website/docs/r/distributed_virtual_switch.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Networking"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_distributed_virtual_switch"
 sidebar_current: "docs-vsphere-resource-networking-distributed-virtual-switch"

--- a/website/docs/r/dpm_host_override.html.markdown
+++ b/website/docs/r/dpm_host_override.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_dpm_host_override"
 sidebar_current: "docs-vsphere-resource-compute-dpm-host-override"

--- a/website/docs/r/drs_vm_override.html.markdown
+++ b/website/docs/r/drs_vm_override.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_drs_vm_override"
 sidebar_current: "docs-vsphere-resource-compute-drs-vm-override"

--- a/website/docs/r/file.html.markdown
+++ b/website/docs/r/file.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Storage"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_file"
 sidebar_current: "docs-vsphere-resource-storage-file"

--- a/website/docs/r/folder.html.markdown
+++ b/website/docs/r/folder.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Inventory"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_folder"
 sidebar_current: "docs-vsphere-resource-inventory-folder"

--- a/website/docs/r/ha_vm_override.html.markdown
+++ b/website/docs/r/ha_vm_override.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_ha_vm_override"
 sidebar_current: "docs-vsphere-resource-compute-ha-vm-override"

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_host"
 sidebar_current: "docs-vsphere-resource-compute-host"

--- a/website/docs/r/host_port_group.html.markdown
+++ b/website/docs/r/host_port_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Networking"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_host_port_group"
 sidebar_current: "docs-vsphere-resource-networking-host-port-group"

--- a/website/docs/r/host_virtual_switch.html.markdown
+++ b/website/docs/r/host_virtual_switch.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Networking"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_host_virtual_switch"
 sidebar_current: "docs-vsphere-resource-networking-host-virtual-switch"

--- a/website/docs/r/license.html.markdown
+++ b/website/docs/r/license.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Administration"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_license"
 sidebar_current: "docs-vsphere-resource-admin-license"

--- a/website/docs/r/nas_datastore.html.markdown
+++ b/website/docs/r/nas_datastore.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Storage"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_nas_datastore"
 sidebar_current: "docs-vsphere-resource-storage-nas-datastore"

--- a/website/docs/r/resource_pool.html.markdown
+++ b/website/docs/r/resource_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Host and Cluster Management"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_resource_pool"
 sidebar_current: "docs-vsphere-resource-compute-resource-pool"

--- a/website/docs/r/storage_drs_vm_override.html.markdown
+++ b/website/docs/r/storage_drs_vm_override.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Storage"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_storage_drs_vm_override"
 sidebar_current: "docs-vsphere-resource-storage-storage-drs-vm-override"

--- a/website/docs/r/tag.html.markdown
+++ b/website/docs/r/tag.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Inventory"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_tag"
 sidebar_current: "docs-vsphere-resource-inventory-tag-resource"

--- a/website/docs/r/tag_category.html.markdown
+++ b/website/docs/r/tag_category.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Inventory"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_tag_category"
 sidebar_current: "docs-vsphere-resource-inventory-tag-category"

--- a/website/docs/r/vapp_container.html.markdown
+++ b/website/docs/r/vapp_container.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Virtual Machine"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_vapp_container"
 sidebar_current: "docs-vsphere-resource-compute-vapp-container"

--- a/website/docs/r/vapp_entity.html.markdown
+++ b/website/docs/r/vapp_entity.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Virtual Machine"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_vapp_entity"
 sidebar_current: "docs-vsphere-resource-compute-vapp-entity"

--- a/website/docs/r/virtual_disk.html.markdown
+++ b/website/docs/r/virtual_disk.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Virtual Machine"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_virtual_disk"
 sidebar_current: "docs-vsphere-resource-vm-virtual-disk"

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Virtual Machine"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_virtual_machine"
 sidebar_current: "docs-vsphere-resource-vm-virtual-machine-resource"

--- a/website/docs/r/virtual_machine_snapshot.html.markdown
+++ b/website/docs/r/virtual_machine_snapshot.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Virtual Machine"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_virtual_machine_snapshot"
 sidebar_current: "docs-vsphere-resource-vm-virtual-machine-snapshot"

--- a/website/docs/r/vmfs_datastore.html.markdown
+++ b/website/docs/r/vmfs_datastore.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Storage"
 layout: "vsphere"
 page_title: "VMware vSphere: vsphere_vmfs_datastore"
 sidebar_current: "docs-vsphere-resource-storage-vmfs-datastore"


### PR DESCRIPTION
We will soon be displaying documentation for this provider both on
[terraform.io](https://www.terraform.io/docs/providers/index.html) and on [the Terraform Registry](https://registry.terraform.io/providers).

Documentation displayed on the Terraform Registry will not use the ERB
layout containing the existing navigation, and will instead build the
navigation dynamically based on the directory and YAML frontmatter of a file.
For providers that group similar resources and data sources by service or
use case (subcategories), we'll need to add this information to the
Markdown source file.

This PR modifies Resource and Data Source documentation source files by
adding a subcategory to the metadata if those files were grouped previously.

For more information about how documentation is rendered on the
Terraform Registry, please see this reference:
[Terraform Registry - Provider Documentation](https://www.terraform.io/docs/registry/providers/docs.html).