### PR TITLE
Check if portgroup failure criteria is nil

### DIFF
--- a/vsphere/host_network_policy_structure.go
+++ b/vsphere/host_network_policy_structure.go
@@ -195,8 +195,10 @@ func flattenHostNicTeamingPolicy(d *schema.ResourceData, obj *types.HostNicTeami
 		d.Set("notify_switches", obj.NotifySwitches)
 	}
 	d.Set("teaming_policy", obj.Policy)
-	if err := flattenHostNicFailureCriteria(d, obj.FailureCriteria); err != nil {
-		return err
+	if obj.FailureCriteria != nil {
+		if err := flattenHostNicFailureCriteria(d, obj.FailureCriteria); err != nil {
+			return err
+		}
 	}
 	if err := flattenHostNicOrderPolicy(d, obj.NicOrder); err != nil {
 		return err


### PR DESCRIPTION
Sometimes govmomi will return a PortGroup spec where the failure
criteria property of the nic teaming policy can be nil.

When this happens we crash because the code doesn't check for this case.

Addresses the crash in #869