### PR TITLE
fix for compute cluster delete when Admission Policy is set to FailoverHost issue #891

### DIFF
--- a/vsphere/resource_vsphere_compute_cluster.go
+++ b/vsphere/resource_vsphere_compute_cluster.go
@@ -578,6 +578,26 @@ func resourceVSphereComputeClusterDelete(d *schema.ResourceData, meta interface{
 		return err
 	}
 
+	client, err := resourceVSphereComputeClusterClient(meta)
+	if err != nil {
+		return err
+	}
+
+	version := viapi.ParseVersionFromClient(client)
+	spec := expandClusterConfigSpecEx(d, version)
+
+	if *spec.DasConfig.Enabled && *spec.DasConfig.AdmissionControlEnabled {
+		switch v := spec.DasConfig.AdmissionControlPolicy.(type) {
+		case *types.ClusterFailoverHostAdmissionControlPolicy:
+			_ = v
+			log.Printf("[DEBUG] if Admission Control Policy set to Failover Host than turn HA OFF before removing hosts")
+			spec.DasConfig.Enabled = structure.BoolPtr(false)
+			if err := clustercomputeresource.Reconfigure(cluster, spec); err != nil {
+				return err
+			}
+		}
+	}
+
 	if err := resourceVSphereComputeClusterDeleteProcessForceRemoveHosts(d, meta, cluster); err != nil {
 		return err
 	}
@@ -1276,7 +1296,7 @@ func expandBaseClusterDasAdmissionControlPolicy(
 	}
 
 	if version.Newer(viapi.VSphereVersion{Product: version.Product, Major: 6, Minor: 5}) {
-		obj.GetClusterDasAdmissionControlPolicy().ResourceReductionToToleratePercent = int32(d.Get("ha_admission_control_host_failure_tolerance").(int))
+		obj.GetClusterDasAdmissionControlPolicy().ResourceReductionToToleratePercent = int32(d.Get("ha_admission_control_performance_tolerance").(int))
 	}
 
 	return obj

--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -101,16 +101,6 @@ func TestAccResourceVSphereComputeCluster_explicitFailoverHost(t *testing.T) {
 					testAccResourceVSphereComputeClusterCheckAdmissionControlFailoverHost(os.Getenv("VSPHERE_ESXI_HOST4")),
 				),
 			},
-			{
-				// This step is required to remove the dedicated failover host in
-				// admission control - otherwise cleanup will fail.
-				Config: testAccResourceVSphereComputeClusterConfigDRSHABasic(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccResourceVSphereComputeClusterCheckExists(true),
-					testAccResourceVSphereComputeClusterCheckDRSEnabled(true),
-					testAccResourceVSphereComputeClusterCheckHAEnabled(true),
-				),
-			},
 		},
 	})
 }


### PR DESCRIPTION
ResourceReductionToToleratePercent should be set to ha_admission_control_performance_tolerance
compute cluster delete should set HA to OFF for Admission Control Failover host policy before the delete