### PR TITLE
ha_admission_control_performance_tolerance failed to set to 0.

### DIFF
--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -489,6 +489,11 @@ func testAccResourceVSphereComputeClusterCheckAdmissionControlFailoverHost(expec
 		if expected != actual {
 			return fmt.Errorf("expected failover host name to be %s, got %s", expected, actual)
 		}
+
+		if failoverHostsPolicy.ResourceReductionToToleratePercent != 0 {
+			return fmt.Errorf("expected ha_admission_control_performance_tolerance be 0, got %d", failoverHostsPolicy.ResourceReductionToToleratePercent)
+		}
+
 		return nil
 	}
 }
@@ -735,6 +740,7 @@ resource "vsphere_compute_cluster" "compute_cluster" {
   ha_enabled                                    = true
   ha_admission_control_policy                   = "failoverHosts"
   ha_admission_control_failover_host_system_ids = "${data.vsphere_host.hosts.*.id}"
+  ha_admission_control_performance_tolerance    = 0
 
   force_evacuate_on_destroy = true
 }


### PR DESCRIPTION
ha_admission_control_performance_tolerance check added to failover host configuration and now the test is failing.

the reason behind that is govmomi library where:
`ResourceReductionToToleratePercent int32 `xml:"resourceReductionToToleratePercent,omitempty"``

that means that resourceReductionToToleratePercent will be dropped from the SOAP payload if it is 0.

I opened the issue and pull request was created https://github.com/vmware/govmomi/pull/1687
the problem is that pull request changes `ResourceReductionToToleratePercent` declaration to:
 
`ResourceReductionToToleratePercent *int32 xml:"resourceReductionToToleratePercent,omitempty"`

that will affect the code of the provider.




