### PR TITLE
fix typo on no snapshots error check

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine_snapshot.go
+++ b/vsphere/resource_vsphere_virtual_machine_snapshot.go
@@ -144,7 +144,7 @@ func resourceVSphereVirtualMachineSnapshotRead(d *schema.ResourceData, meta inte
 	defer cancel()
 	snapshot, err := vm.FindSnapshot(ctx, d.Id())
 	if err != nil {
-		if strings.Contains(err.Error(), "No snapshots for this VM") || strings.Contains(err.Error(), "snapshot \""+d.Get("snapshot_name").(string)+"\" not found") {
+		if strings.Contains(err.Error(), "no snapshots for this VM") || strings.Contains(err.Error(), "snapshot \""+d.Get("snapshot_name").(string)+"\" not found") {
 			log.Printf("[DEBUG] Error While finding the Snapshot: %v", err)
 			d.SetId("")
 			return nil


### PR DESCRIPTION
Currently, if a snapshot is manually deleted, the following error will happen:

```
Error: Error while finding the Snapshot :no snapshots for this VM
```

The `strings.Contains` being used to compare is case sensitive, so the comparison is never `true`

