### PR TITLE
Return correct tag or tag category for given name

### DIFF
--- a/vsphere/tags_helper.go
+++ b/vsphere/tags_helper.go
@@ -137,9 +137,9 @@ func tagCategoryByName(tm *tags.Manager, name string) (string, error) {
 	}
 
 	cats := []*tags.Category{}
-	for _, cat := range allCats {
+	for i, cat := range allCats {
 		if cat.Name == name {
-			cats = append(cats, &cat)
+			cats = append(cats, &allCats[i])
 		}
 	}
 
@@ -169,9 +169,9 @@ func tagByName(tm *tags.Manager, name, categoryID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not get tag for name %q: %s", name, err)
 	}
-	for _, tag := range allTags {
+	for i, tag := range allTags {
 		if tag.Name == name {
-			tags = append(tags, &tag)
+			tags = append(tags, &allTags[i])
 		}
 	}
 


### PR DESCRIPTION
Pointers to Go range variables assigned inside a range end up pointing
to the last element iterated to. See
https://medium.com/golangspec/range-clause-and-the-address-of-iteration-variable-b1796885d2b7.
I don't know if the category slice is sorted alphabetically or
otherwise, but if your category is not the last in the list, you will
get an unexpected result.

Fixes #909