### PR TITLE
Unmount ISO when switching CDROM backends for a VM

### DIFF
--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -558,7 +558,7 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 			}
 		}
 
-		// Start goroutine here that checks for qusestions
+		// Start goroutine here that checks for questions
 		gChan := make(chan bool)
 
 		questions := map[string]string{


### PR DESCRIPTION
If the guest OS mounts the virtual cdrom device then vsphere expects
someone to confirm that it should be "unlocked" first.

This is done via a VirtualMachineQuestionInfo object that we need to
find and then respond to via the "AnswerVM" method. We start a goroutine
right before we attempt any VM modifications and signal we're done right
after we're done. If a known question appears in the mean time, we will
send the appropriate answer.