### PR TITLE
ha_admission_control_performance_tolerance check added to failover host configuration and now test is failing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/terraform-providers/terraform-provider-null v1.0.0
 	github.com/terraform-providers/terraform-provider-random v2.0.0+incompatible
 	github.com/terraform-providers/terraform-provider-template v1.0.0
-	github.com/vmware/govmomi v0.21.0
+	github.com/vmware/govmomi v0.20.3
 	github.com/vmware/vic v1.5.4
 	google.golang.org/genproto v0.0.0-20200117163144-32f20d992d24 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,12 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmware/govmomi v0.20.3 h1:gpw/0Ku+6RgF3jsi7fnCLmlcikBHfKBCUcu1qgc16OU=
+github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.21.0 h1:jc8uMuxpcV2xMAA/cnEDlnsIjvqcMra5Y8onh/U3VuY=
 github.com/vmware/govmomi v0.21.0/go.mod h1:zbnFoBQ9GIjs2RVETy8CNEpb+L+Lwkjs3XZUL0B3/m0=
+github.com/vmware/govmomi v0.22.1 h1:ZIEYmBdAS2i+s7RctapqdHfbeGiUcL8LRN05uS4TfPc=
+github.com/vmware/govmomi v0.22.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vic v1.5.4 h1:y546pkye0aes2j2h2n6fWz++v8WxMZTLFl1mLOMzqYQ=
 github.com/vmware/vic v1.5.4/go.mod h1:AiTDrZuV13NkqRzseA5ZmF2QqLpTydaaGN75xgV6Ork=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=

--- a/vsphere/resource_vsphere_compute_cluster_test.go
+++ b/vsphere/resource_vsphere_compute_cluster_test.go
@@ -471,6 +471,11 @@ func testAccResourceVSphereComputeClusterCheckAdmissionControlFailoverHost(expec
 		if expected != actual {
 			return fmt.Errorf("expected failover host name to be %s, got %s", expected, actual)
 		}
+
+		if failoverHostsPolicy.ResourceReductionToToleratePercent != 0 {
+			return fmt.Errorf("expected ha_admission_control_performance_tolerance be 0, got %d", failoverHostsPolicy.ResourceReductionToToleratePercent)
+		}
+
 		return nil
 	}
 }
@@ -717,6 +722,7 @@ resource "vsphere_compute_cluster" "compute_cluster" {
   ha_enabled                                    = true
   ha_admission_control_policy                   = "failoverHosts"
   ha_admission_control_failover_host_system_ids = "${data.vsphere_host.hosts.*.id}"
+  ha_admission_control_performance_tolerance    = 0
 
   force_evacuate_on_destroy = true
 }


### PR DESCRIPTION
Recreating PR #899 since it was reverted. We will need to wait until govmomi releases a stable version containing https://github.com/vmware/govmomi/pull/1687.