### PR TITLE
Test pipeline changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1448,10 +1448,9 @@ workflows:
     jobs:
       - linters
       - build
-      - revert_snapshot
       - test_acc_Client:
           requires:
-            - revert_snapshot
+            - build
       - test_acc_DataSourceVSphereComputeCluster:
           requires:
             - test_acc_Client

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,6 @@
--include $(HOME)/.tf-vsphere-devrc.mk
+CFG ?= $(HOME)/.tf-vsphere-devrc.mk
+
+-include $(CFG)
 
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)

--- a/scripts/test_runner.sh
+++ b/scripts/test_runner.sh
@@ -13,21 +13,22 @@ main () {
 }
 
 runTest () {
-  # eCode=0
-  # for try in {1..2}; do
-  #   res=$(TF_ACC=1 go test github.com/terraform-providers/terraform-provider-vsphere/vsphere -v -count=1 -run="$1\$" -timeout 240m)
-  #   if grep PASS <<< "$res" &> /dev/null; then
-  #     eCode=0
-  #   else
-  #     revertAndWait
-  #     sleep 30
-  #     eCode=1
-  #   fi
-  # done
-  # echo "$res"
-  # return $eCode
-  TF_ACC=1 go test github.com/terraform-providers/terraform-provider-vsphere/vsphere -v -count=1 -run="$1\$" -timeout 240m
-  return $?
+  eCode=0
+  logfile="/tmp/tpv-build.log.$$"
+  for try in {1..2}; do
+    TF_ACC=1 go test github.com/terraform-providers/terraform-provider-vsphere/vsphere -v -count=1 -run="$1\$" -timeout 240m 2>&1 | tee $logfile
+    if grep PASS $logfile &> /dev/null; then
+      eCode=0
+      break
+    else
+      echo "test failed. reverting"
+      revertAndWait
+      sleep 30
+      eCode=1
+    fi
+  done
+  rm $logfile
+  return $eCode
 }
 
 
@@ -35,8 +36,9 @@ revertAndWait () {
   $GOPATH/src/github.com/terraform-providers/terraform-provider-vsphere/scripts/esxi_restore_snapshot.sh $VSPHERE_ESXI_SNAPSHOT
   sleep 30
   until curl -k "https://$VSPHERE_SERVER/rest/vcenter/datacenter" -i -m 10 2> /dev/null | grep "401 Unauthorized" &> /dev/null; do
-    sleep 30
+    echo -n . ;sleep 30
   done
+  echo ' Done!'
 }
 
 main $1


### PR DESCRIPTION
- Unfortunately due to the current effect the test have on the lab
we're stuck with having to revert everytime we fail and try again. We
will have to write a script that ingests the test output and reports
actual failures or potential "random" failures.

- Minor change to the Makefile to allow for alternative config file