### PR TITLE
Fix handling of child vApp containers

### DIFF
--- a/vsphere/resource_vsphere_vapp_container.go
+++ b/vsphere/resource_vsphere_vapp_container.go
@@ -154,26 +154,32 @@ func resourceVSphereVAppContainerCreate(d *schema.ResourceData, meta interface{}
 	rpSpec := expandVAppContainerConfigSpec(d)
 	vcSpec := &types.VAppConfigSpec{}
 	var f *object.Folder
-	if pf, ok := d.GetOk("parent_folder_id"); ok {
-		f, err = folder.FromID(client, pf.(string))
-		if err != nil {
-			return err
-		}
+
+	if vappcontainer.IsVApp(client, d.Get("parent_resource_pool_id").(string)) {
+		f = nil
 	} else {
-		p := strings.Split(prp.InventoryPath, "/")
-		if len(p) > 2 {
-			return fmt.Errorf("unable to locate datacenter name from parent resource pool")
-		}
-		var dc *object.Datacenter
-		dc, err = getDatacenter(client, p[1])
-		if err != nil {
-			return err
-		}
-		f, err = folder.FromPath(client, "", folder.VSphereFolderTypeVM, dc)
-		if err != nil {
-			return err
+		if pf, ok := d.GetOk("parent_folder_id"); ok {
+			f, err = folder.FromID(client, pf.(string))
+			if err != nil {
+				return err
+			}
+		} else {
+			p := strings.Split(prp.InventoryPath, "/")
+			if len(p) < 2 {
+				return fmt.Errorf("unable to locate datacenter name from parent resource pool")
+			}
+			var dc *object.Datacenter
+			dc, err = getDatacenter(client, p[1])
+			if err != nil {
+				return err
+			}
+			f, err = folder.FromPath(client, "", folder.VSphereFolderTypeVM, dc)
+			if err != nil {
+				return err
+			}
 		}
 	}
+
 	vc, err := vappcontainer.Create(prp, d.Get("name").(string), rpSpec, vcSpec, f)
 	if err != nil {
 		return err
@@ -211,11 +217,16 @@ func resourceVSphereVAppContainerRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	if err = d.Set("parent_resource_pool_id", vcProps.Parent.Value); err != nil {
-		return err
+	if vcProps.Parent != nil {
+		if err = d.Set("parent_resource_pool_id", vcProps.Parent.Value); err != nil {
+			return err
+		}
 	}
-	if err = d.Set("parent_folder_id", vcProps.ParentFolder.Value); err != nil {
-		return err
+
+	if vcProps.ParentFolder != nil {
+		if err = d.Set("parent_folder_id", vcProps.ParentFolder.Value); err != nil {
+			return err
+		}
 	}
 	if err = flattenVAppContainerConfigSpec(d, vcProps.Config); err != nil {
 		return err


### PR DESCRIPTION
- Child vApp containers do not need folders
- Child vApp containers do not have parent Folders set either, which unless
checked will cause a panic when importing.
- Add test case for importing child vApp containers.

Fixes #939