### PR TITLE
b/virtual_disk: enforce vmdk suffix

### DIFF
--- a/vsphere/resource_vsphere_virtual_disk.go
+++ b/vsphere/resource_vsphere_virtual_disk.go
@@ -51,6 +51,12 @@ func resourceVSphereVirtualDisk() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (warns []string, errors []error) {
+					if !strings.HasSuffix(v.(string), ".vmdk") {
+						errors = append(errors, fmt.Errorf("vmdk_path must end with '.vmdk'"))
+					}
+					return
+				},
 			},
 
 			"datastore": {


### PR DESCRIPTION
`vmdk_path` must end with a '.vmdk' suffix or the created disks will not
work properly or be able to be found with the `Read` function. Adding a
validate function to provide a better user experience when the suffix is
left off.

Fixes #926 
