### PR TITLE
Optimize OS family query

### DIFF
--- a/vsphere/internal/helper/envbrowse/environment_browser_helper.go
+++ b/vsphere/internal/helper/envbrowse/environment_browser_helper.go
@@ -77,10 +77,13 @@ func (b *EnvironmentBrowser) OSFamily(ctx context.Context, guest string) (string
 		return "", err
 	}
 
-	req := types.QueryConfigOption{
+	req := types.QueryConfigOptionEx{
 		This: b.Reference(),
+		Spec: &types.EnvironmentBrowserConfigOptionQuerySpec{
+			GuestId: []string{guest},
+		},
 	}
-	res, err := methods.QueryConfigOption(ctx, b.Client(), &req)
+	res, err := methods.QueryConfigOptionEx(ctx, b.Client(), &req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Optimize OS family query

Switching from QueryConfigOption to QueryConfigOptionEx to query the specific descriptor,
rather than returning all supported descriptors.
Against vCenter 6.7U3, this reduces the response from ~600K to ~10K

This change will also simplify the vcsim implementation of this query (Issue #940)
