### PR TITLE
Add configurable timeout for VM PowerOn operations

### DIFF
--- a/vsphere/internal/helper/viapi/vim_helper.go
+++ b/vsphere/internal/helper/viapi/vim_helper.go
@@ -60,6 +60,28 @@ func IsManagedObjectNotFoundError(err error) bool {
 	return false
 }
 
+// IsInvalidStateError checks an error to see if it's of the
+// InvalidState type.
+func IsInvalidStateError(err error) bool {
+	if f, ok := vimSoapFault(err); ok {
+		if _, ok := f.(types.InvalidState); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// IsInvalidPowerStateError checks an error to see if it's of the
+// InvalidState type.
+func IsInvalidPowerStateError(err error) bool {
+	if f, ok := vimSoapFault(err); ok {
+		if _, ok := f.(types.InvalidPowerState); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // isNotFoundError checks an error to see if it's of the NotFoundError type.
 //
 // Note this is different from the other "not found" faults and is an error

--- a/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
+++ b/vsphere/internal/helper/virtualmachine/virtual_machine_helper.go
@@ -518,8 +518,6 @@ powerLoop:
 					log.Printf("[DEBUG] Failed to submit PowerOn task for vm %q. Error: %s", vmPath, err)
 					return fmt.Errorf("failed to submit poweron task for vm %q: %s", vmPath, err)
 				}
-				//tctx, tcancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
-				//defer tcancel()
 				err = task.Wait(ctx)
 				if err != nil {
 					if err.Error() == "The operation is not allowed in the current state." {

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -1347,11 +1347,7 @@ func resourceVSphereVirtualMachineCreateClone(d *schema.ResourceData, meta inter
 		}
 	}
 	// Finally time to power on the virtual machine!
-	pTimeoutStr := fmt.Sprintf("%ds", d.Get("poweron_timeout").(int))
-	pTimeout, err := time.ParseDuration(pTimeoutStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse poweron_timeout as a valid duration: %s", err)
-	}
+	pTimeout := time.Duration(d.Get("poweron_timeout").(int)) * time.Second
 	if err := virtualmachine.PowerOn(vm, pTimeout); err != nil {
 		return nil, fmt.Errorf("error powering on virtual machine: %s", err)
 	}


### PR DESCRIPTION
There is a conflict right now between the way the vsphere provider
builds VMs and how vSphere expects VMs that are part of a vApp to
behave, especially in the way things are powered on.

vApps expect that the VMs will be built but not powered on, because it
handles powering on the VM on its own in a specific order. On the other
hand the provider will build the VM and instantly power it on regardless
of where it belongs.

The result of this conflict is that vsphere will not allow any VM to
power on until all VMs in the vApp are ready to be powered on. So for
example while cloning two VMs in the same vApp, we are only allowed to
power on the first VM once both of them are done cloning. Any attempts
to power on a VM earlier result in a "InvalidState" response.

This commit introduces a configurable timeout, `poweron_timeout`, that
represents the amount of time we are going to give a VM to power on. The
default (and minimum) is 300 seconds (5 minutes).

The full power on process goes like this:

- Timer starts (for as long as poweron_timeout is set to).
- First we poll the `Disabled Methods` list for the VM object until
PowerOnVM_Task is no longer in it.
- Next we enter a loop for the remainder of the time where we issue
PowerOnVM requests, and check the response. If it's successful we
return, otherwise we check the error message. If the error message is
about the VM being in an invalid state then we sleep for 500ms and
retry, otherwise we return an error.
- If we hit the timeout and we have not been able to successfully power
on the VM so far, we return an error.