### PR TITLE
handling cases of network port groups with same name 

### DIFF
--- a/vsphere/data_source_vsphere_network.go
+++ b/vsphere/data_source_vsphere_network.go
@@ -28,6 +28,11 @@ func dataSourceVSphereNetwork() *schema.Resource {
 				Description: "The managed object type of the network.",
 				Computed:    true,
 			},
+			"distributed_virtual_switch_uuid": {
+				Type:        schema.TypeString,
+				Description: "Id of the distributed virtual switch of which the port group is a part of",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -36,6 +41,7 @@ func dataSourceVSphereNetworkRead(d *schema.ResourceData, meta interface{}) erro
 	client := meta.(*VSphereClient).vimClient
 
 	name := d.Get("name").(string)
+	dvSwitchUuid := d.Get("distributed_virtual_switch_uuid").(string)
 	var dc *object.Datacenter
 	if dcID, ok := d.GetOk("datacenter_id"); ok {
 		var err error
@@ -44,7 +50,7 @@ func dataSourceVSphereNetworkRead(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("cannot locate datacenter: %s", err)
 		}
 	}
-	net, err := network.FromPath(client, name, dc)
+	net, err := network.FromNameAndDVSUuid(client, name, dc, dvSwitchUuid)
 	if err != nil {
 		return fmt.Errorf("error fetching network: %s", err)
 	}

--- a/vsphere/data_source_vsphere_network_test.go
+++ b/vsphere/data_source_vsphere_network_test.go
@@ -94,6 +94,28 @@ func TestAccDataSourceVSphereNetwork_absolutePathEndingInSameName(t *testing.T) 
 	})
 }
 
+func TestAccDataSourceVSphereNetworkConfigSameDVSPortgroupName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccDataSourceVSphereNetworkPreCheck(t)
+			testAccSkipIfEsxi(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVSphereNetworkConfigSameDVSPortgroupName(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.vsphere_network.net", "id",
+						"vsphere_distributed_port_group.pg1", "id",
+					),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceVSphereNetworkPreCheck(t *testing.T) {
 	if os.Getenv("VSPHERE_HOST_NIC0") == "" {
 		t.Skip("set VSPHERE_HOST_NIC0 to run vsphere_network acceptance tests")
@@ -287,5 +309,53 @@ data "vsphere_network" "net" {
 		os.Getenv("VSPHERE_ESXI_HOST3"),
 		os.Getenv("VSPHERE_HOST_NIC0"),
 		os.Getenv("VSPHERE_HOST_NIC1"),
+	)
+}
+
+func testAccDataSourceVSphereNetworkConfigSameDVSPortgroupName() string {
+	return fmt.Sprintf(`
+variable "datacenter" {
+  default = "%s"
+}
+
+data "vsphere_datacenter" "dc" {
+  name = "${var.datacenter}"
+}
+
+resource "vsphere_folder" "netfolder" {
+  path                            = "netfolder"
+  type                            = "network"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_distributed_virtual_switch" "dvs1" {
+  name          = "dvs1"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+}
+
+resource "vsphere_distributed_virtual_switch" "dvs2" {
+  name          = "dvs2"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  folder 		= "${vsphere_folder.netfolder.path}"
+}
+
+resource "vsphere_distributed_port_group" "pg1" {
+  name                            = "terraform-test-pg"
+  distributed_virtual_switch_uuid = "${vsphere_distributed_virtual_switch.dvs1.id}"
+}
+
+resource "vsphere_distributed_port_group" "pg2" {
+  name                            = "${vsphere_distributed_port_group.pg1.name}"
+  distributed_virtual_switch_uuid = "${vsphere_distributed_virtual_switch.dvs2.id}"
+}
+
+data "vsphere_network" "net" {
+  name          = "${vsphere_distributed_port_group.pg1.name}"
+  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  distributed_virtual_switch_uuid = "${vsphere_distributed_virtual_switch.dvs1.id}"
+}
+
+`,
+		os.Getenv("VSPHERE_DATACENTER"),
 	)
 }

--- a/vsphere/data_source_vsphere_network_test.go
+++ b/vsphere/data_source_vsphere_network_test.go
@@ -135,6 +135,7 @@ resource "vsphere_distributed_port_group" "pg" {
 data "vsphere_network" "net" {
   name          = "${vsphere_distributed_port_group.pg.name}"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  distributed_virtual_switch_uuid = "${vsphere_distributed_virtual_switch.dvs.id}"
 }
 `,
 		os.Getenv("VSPHERE_DATACENTER"),


### PR DESCRIPTION
handling cases of reading network port groups with same name by providing an optional param distributed port switch id to differentiate them.

https://github.com/terraform-providers/terraform-provider-vsphere/issues/925