### PR TITLE
Fix working with orphaned devices

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -463,6 +463,7 @@ func DiskRefreshOperation(d *schema.ResourceData, c *govmomi.Client, l object.Vi
 				// Skip any of these keys as we won't be matching any of those anyway here
 				continue
 			}
+
 			if !diskUUIDMatch(device, m["uuid"].(string)) {
 				// Skip any device that doesn't match UUID
 				continue
@@ -472,6 +473,12 @@ func DiskRefreshOperation(d *schema.ResourceData, c *govmomi.Client, l object.Vi
 			if err := r.Read(l); err != nil {
 				return fmt.Errorf("%s: %s", r.Addr(), err)
 			}
+
+			if strings.HasPrefix(r.Get("label").(string), diskOrphanedPrefix) {
+				// Skip if it's previously discovered orphaned device
+				continue
+			}
+
 			// Done reading, push this onto our new set and remove the device from
 			// the list
 			newSet = append(newSet, r.Data())


### PR DESCRIPTION
Fixes this bug: https://github.com/terraform-providers/terraform-provider-vsphere/issues/875

Problem is that if VM had orphaned disk saved in state file and same VM gets _another_ orphaned disk after that, Terraform will add new disk with the same orpahed_disk_0 label. This breaks the run because label names must be unique according to virtual_machine_disk_subresource.go

The fix itself simply detects orphaned disks among already existing resources and skips them, so that they are re-added to state file as orphaned disks again, thus making this provider iterate over _compelte_ list of orphaned disks and not only newly discovered ones.