### PR TITLE
Add job to move crashes to current work list

### DIFF
--- a/.github/workflows/labeled_issues.yml
+++ b/.github/workflows/labeled_issues.yml
@@ -21,3 +21,12 @@ jobs:
         project-url: "https://github.com/orgs/terraform-providers/projects/12"
         column-name: "Requires Investigation"
         label-name: "requires investigation"
+  Move_Crash_Issue_On_Working_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: aareet/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.vsphere_github_actions }}"
+        project-url: "https://github.com/orgs/terraform-providers/projects/12"
+        column-name: "Planned for this week"
+        label-name: "crash"


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Adds a job to move crash reports to current sprint focus

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
