### PR TITLE
Mark product_key as sensitive

### DIFF
--- a/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
@@ -192,6 +192,7 @@ func VirtualMachineCustomizeSchema() map[string]*schema.Schema {
 				"product_key": {
 					Type:        schema.TypeString,
 					Optional:    true,
+					Sensitive:   true,
 					Description: "The product key for this virtual machine.",
 				},
 			}},


### PR DESCRIPTION
### Description

Not sure if you can agree, but I would feel more comfortable having the `product_key` parameter hidden in the plan.

Whether it should be considered sensitive or not could be questionable, but since there are no side-effects I would mark it as such.

Thanks for your review :wink:

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
