### PR TITLE
Replace sysprep.inf with sysprep.xml in docs

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -1243,7 +1243,7 @@ text - keep this in mind when provisioning your infrastructure.
 #### Supplying your own SysPrep file
 
 Alternative to the `windows_options` supplied above, you can instead supply
-your own `sysprep.inf` file contents via the `windows_sysprep_text` option.
+your own `sysprep.xml` file contents via the `windows_sysprep_text` option.
 This allows full control of the customization process out-of-band of vSphere.
 Example below:
 
@@ -1257,7 +1257,7 @@ resource "vsphere_virtual_machine" "vm" {
     customize {
       ...
 
-      windows_sysprep_text = "${file("${path.module}/sysprep.inf")}"
+      windows_sysprep_text = "${file("${path.module}/sysprep.xml")}"
     }
   }
 }


### PR DESCRIPTION
### Description

I think it would be more correct to mention `sysprep.xml` as file name, as this is the default name from Windows Vista onwards:

https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-1330EEEE-12D1-42FE-B647-E731A01B1A7D.html

Using the old `sysprep.inf` could be misleading for some folks IMHO.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
