### PR TITLE
Use Go 1.13.x for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-  - "1.11.x"
+  - "1.13.x"
 
 install:
 # This script is used by the Travis build to install a cookie for


### PR DESCRIPTION
Switching from Go 1.11.x to 1.13.x