### PR TITLE
Only include hardware version in CreateSpecs

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -891,6 +891,9 @@ func expandVirtualMachineConfigSpecChanged(d *schema.ResourceData, client *govmo
 	log.Printf("[DEBUG] %s: Expanding of old config complete", resourceVSphereVirtualMachineIDString(d))
 
 	newSpec, err := expandVirtualMachineConfigSpec(d, client)
+	// Don't include the hardware version in the UpdateSpec. It is only needed
+	// when created new VMs.
+	newSpec.Version = ""
 	if err != nil {
 		return types.VirtualMachineConfigSpec{}, false, err
 	}


### PR DESCRIPTION
It seems that the vSphere API will return an error when some older hardware versions are included in the UpdateSpec. The hardware version is only needed in the CreateSpec, but the two share the Flatten function. Rather than splitting that or making the Flatten function determine if it is a Create or Update spec, I am removing the extre version info when updating.