### PR TITLE
Increase max hw version for vSphere 7.0

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -286,7 +286,7 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 		"hardware_version": {
 			Type:         schema.TypeInt,
 			Optional:     true,
-			ValidateFunc: validation.IntBetween(4, 15),
+			ValidateFunc: validation.IntBetween(4, 17),
 			Description:  "The hardware version for the virtual machine.",
 			Computed:     true,
 		},


### PR DESCRIPTION
vSphere v7.0 has added a new hardware version, so the max version needs to be increased to support it.