### PR TITLE
vsphere_virtual_machine: fix broken codeblock

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -253,8 +253,8 @@ files also should be present in the same directory as the .ovf file. While deplo
 the VM properties like `name`, `datacenter_id`, `resource_pool_id`, `datastore_id`, 
 `host_system_id`, `folder` can only be set. All other VM properties are taken from the OVF 
 template and setting them in the configuration file is redundant.
-```hcl
 
+```hcl
 data "vsphere_datacenter" "dc" {
   name = "DC"
 }


### PR DESCRIPTION
Formatting is broken on the online docs: https://www.terraform.io/docs/providers/vsphere/r/virtual_machine.html#deploying-vm-from-an-ovf-template
The markdown codeblock is not rendered correctly. It works fine on GitHub. Perhaps the CSS for the hashicorp docs site requires a newline before codeblocks, as is implemented by the other code blocks.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
