### PR TITLE
Respect `session_persistence` for rest sessions

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -220,6 +220,7 @@ func (c *Config) SavedRestSessionOrNew(s *cache.Session) (*rest.Client, error) {
 	defer cancel()
 
 	s.DirREST = c.RestSessionPath
+	s.Passthrough = !c.Persist
 	restClient := new(rest.Client)
 	err := s.Login(ctx, restClient, nil)
 	if err != nil {


### PR DESCRIPTION
Only store rest session information if `session_persistence` is set.

Fixes #1076 
