### PR TITLE
Disconnect on delete instead of maintenance mode

### DIFF
--- a/vsphere/resource_vsphere_host.go
+++ b/vsphere/resource_vsphere_host.go
@@ -395,9 +395,9 @@ func resourceVsphereHostDelete(d *schema.ResourceData, meta interface{}) error {
 
 	if connectionState != types.HostSystemConnectionStateDisconnected {
 		// We cannot put a disconnected server in maintenance mode.
-		err = hostsystem.EnterMaintenanceMode(hs, int(defaultAPITimeout/time.Minute), true)
+		err = resourceVSphereHostDisconnect(d, meta)
 		if err != nil {
-			return fmt.Errorf("error while putting host to maintenance mode: %s", err.Error())
+			return fmt.Errorf("error while disconnecting host: %s", err.Error())
 		}
 	}
 


### PR DESCRIPTION
Changing from putting hosts into maintenance mode and then removing them to disconnecting hosts and then removing them. This allows host resources to be deleted even if they have imported VMs running on them still.