### PR TITLE
Specify cluster membership management

### DIFF
--- a/vsphere/resource_vsphere_host.go
+++ b/vsphere/resource_vsphere_host.go
@@ -37,9 +37,16 @@ func resourceVsphereHost() *schema.Resource {
 				Description: "ID of the vSphere datacenter the host will belong to.",
 			},
 			"cluster": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "ID of the vSphere cluster the host will belong to.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "ID of the vSphere cluster the host will belong to.",
+				ConflictsWith: []string{"cluster_managed"},
+			},
+			"cluster_managed": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Description:   "Must be set if host is a member of a managed compute_cluster resource.",
+				ConflictsWith: []string{"cluster"},
 			},
 			"hostname": {
 				Type:        schema.TypeString,
@@ -128,7 +135,7 @@ func resourceVsphereHostRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error while retrieving properties for host %s. Error: %s", hostID, err)
 	}
 
-	if host.Parent != nil && host.Parent.Type == "ClusterComputeResource" {
+	if host.Parent != nil && host.Parent.Type == "ClusterComputeResource" && !d.Get("cluster_managed").(bool) {
 		d.Set("cluster", host.Parent.Value)
 	} else {
 		d.Set("cluster", "")

--- a/website/docs/r/compute_cluster.html.markdown
+++ b/website/docs/r/compute_cluster.html.markdown
@@ -122,7 +122,10 @@ The following settings control cluster membership or tune how hosts are managed
 within the cluster itself by Terraform.
 
 * `host_system_ids` - (Optional) The [managed object IDs][docs-about-morefs] of
-  the hosts to put in the cluster.
+  the hosts to put in the cluster. Conflicts with: `host_managed`.
+* `host_managed` - (Optional) Can be set to `true` if compute cluster
+  membership will be managed through the `host` resource rather than the
+  `compute_cluster` resource. Conflicts with: `host_system_ids`.
 * `host_cluster_exit_timeout` - The timeout for each host maintenance mode
   operation when removing hosts from a cluster. The value is specified in
   seconds. Default: `3600` (1 hour).

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -63,7 +63,11 @@ The following arguments are supported:
 * `datacenter` - (Optional) The ID of the datacenter this host should
   be added to. This should not be set if `cluster` is set.
 * `cluster` - (Optional) The ID of the Compute Cluster this host should
-  be added to. This should not be set if `datacenter` is set.
+  be added to. This should not be set if `datacenter` is set. Conflicts with:
+  `cluster`.
+* `cluster_managed` - (Optional) Can be set to `true` if compute cluster
+  membership will be managed through the `compute_cluster` resource rather
+  than the`host` resource. Conflicts with: `cluster`.
 * `thumbprint` - (Optional) Host's certificate SHA-1 thumbprint. If not set the the
   CA that signed the host's certificate should be trusted. If the CA is not trusted
   and no thumbprint is set then the operation will fail.


### PR DESCRIPTION
Adding management arguments to `hosts` and `compute_clusters` so that the two do not conflict when both resources are in use.