### PR TITLE
Fix id in error message when category cant be load

### DIFF
--- a/vsphere/resource_vsphere_custom_attribute.go
+++ b/vsphere/resource_vsphere_custom_attribute.go
@@ -81,7 +81,7 @@ func resourceVSphereCustomAttributeRead(d *schema.ResourceData, meta interface{}
 	}
 	field := fields.ByKey(int32(key))
 	if field == nil {
-		return fmt.Errorf("could not locate category with id %q", key)
+		return fmt.Errorf("could not locate category with id '%d'", key)
 	}
 	d.Set("name", field.Name)
 	d.Set("managed_object_type", field.ManagedObjectType)


### PR DESCRIPTION
Fix the error message currently displaying cryptic characters in error messages instead of the actual category id

### Description

Currently when the category id can not be found, it displays a error message like this:
![screenshot from error](http://i.imgur.com/X5fGnDH.png)

This is very confusing and doesnt look like its actually just a problem with a missing resource.

The cause for this lies in %q it leads to a non-human-readable output. Using %d fixes the problem, cause it displays as a literal number.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References
n/a
