### PR TITLE
Adding vm_storage_policy_profile resource for tag based placement policy management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/terraform-providers/terraform-provider-null v1.0.1-0.20191204185112-e5c592237f62
 	github.com/terraform-providers/terraform-provider-random v1.3.2-0.20190925210718-83518d96ae4f
 	github.com/terraform-providers/terraform-provider-template v1.0.0 // indirect
-	github.com/vmware/govmomi v0.22.2-0.20200420222347-5fceac570f29
+	github.com/vmware/govmomi v0.22.2-0.20200523220130-61b30e20be49
 	google.golang.org/genproto v0.0.0-20200122232147-0452cf42e150 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,8 @@ github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElyw
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmware/govmomi v0.22.2-0.20200420222347-5fceac570f29 h1:8S2J/LGp5U19G4tia+aq+KvlNPuynIeui7W8xc8PGqU=
 github.com/vmware/govmomi v0.22.2-0.20200420222347-5fceac570f29/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.22.2-0.20200523220130-61b30e20be49 h1:bBp4s6KFH+6pwN2SjZPLC4W+SSEld0q1pycrcPTVyj4=
+github.com/vmware/govmomi v0.22.2-0.20200523220130-61b30e20be49/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/vsphere/helper_test.go
+++ b/vsphere/helper_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/contentlibrary"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/spbm"
 	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vapi/rest"
 	"os"
@@ -1127,4 +1128,18 @@ func testGetDatastoreClusterVMAntiAffinityRule(s *terraform.State, resourceName 
 	}
 
 	return resourceVSphereDatastoreClusterVMAntiAffinityRuleFindEntry(pod, key)
+}
+
+func testGetVmStoragePolicy(s *terraform.State, resourceName string) (string, error) {
+
+	tVars, err := testClientVariablesForResource(s, fmt.Sprintf("vsphere_vm_storage_policy.%s", resourceName))
+	if err != nil {
+		return "", err
+	}
+	policyId, ok := tVars.resourceAttributes["id"]
+	if !ok {
+		return "", fmt.Errorf("resource %q has no id", resourceName)
+	}
+
+	return spbm.PolicyNameByID(tVars.client, policyId)
 }

--- a/vsphere/internal/helper/spbm/spbm_helper.go
+++ b/vsphere/internal/helper/spbm/spbm_helper.go
@@ -40,7 +40,7 @@ func PolicyIDByName(client *govmomi.Client, name string) (string, error) {
 }
 
 // policyNameByID returns storage policy name by its ID.
-func policyNameByID(client *govmomi.Client, id string) (string, error) {
+func PolicyNameByID(client *govmomi.Client, id string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), provider.DefaultAPITimeout)
 	defer cancel()
 	pc, err := pbmClientFromGovmomiClient(ctx, client)

--- a/vsphere/internal/virtualdevice/virtual_machine_tag_rules_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_tag_rules_subresource.go
@@ -1,0 +1,27 @@
+package virtualdevice
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func VirtualMachineTagRulesSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"tag_category": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "category",
+		},
+		"tags": {
+			Type:        schema.TypeList,
+			Required:    true,
+			Description: "tags",
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"include_datastores_with_tags": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Whether to include or exclude datastores tagged with the provided tags",
+			Default:     true,
+		},
+	}
+}

--- a/vsphere/internal/virtualdevice/virtual_machine_tag_rules_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_tag_rules_subresource.go
@@ -9,12 +9,13 @@ func VirtualMachineTagRulesSchema() map[string]*schema.Schema {
 		"tag_category": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "category",
+			Description: "The tag category to select the tags from.",
 		},
 		"tags": {
 			Type:        schema.TypeList,
 			Required:    true,
-			Description: "tags",
+			MinItems:    1,
+			Description: "The tags to use for creating a tag-based vm placement rule.",
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		"include_datastores_with_tags": {

--- a/vsphere/provider.go
+++ b/vsphere/provider.go
@@ -130,6 +130,7 @@ func Provider() terraform.ResourceProvider {
 			"vsphere_virtual_machine_snapshot":                resourceVSphereVirtualMachineSnapshot(),
 			"vsphere_host":                                    resourceVsphereHost(),
 			"vsphere_vnic":                                    resourceVsphereNic(),
+			"vsphere_vm_storage_policy":                       resourceVmStoragePolicy(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/vsphere/resource_vsphere_tag_category.go
+++ b/vsphere/resource_vsphere_tag_category.go
@@ -21,6 +21,7 @@ const (
 	// vSphereTagCategoryCardinalityMultiple defines the API type for multiple
 	// cardinality.
 	vSphereTagCategoryCardinalityMultiple = "MULTIPLE"
+	vim25Prefix                           = "urn:vim25:"
 )
 
 func resourceVSphereTagCategory() *schema.Resource {
@@ -72,9 +73,11 @@ func resourceVSphereTagCategoryCreate(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
+	associableTypesRaw := structure.SliceInterfacesToStrings(d.Get("associable_types").(*schema.Set).List())
+	associableTypes := appendPrefix(associableTypesRaw)
 
 	spec := &tags.Category{
-		AssociableTypes: structure.SliceInterfacesToStrings(d.Get("associable_types").(*schema.Set).List()),
+		AssociableTypes: associableTypes,
 		Cardinality:     d.Get("cardinality").(string),
 		Description:     d.Get("description").(string),
 		Name:            d.Get("name").(string),
@@ -143,9 +146,12 @@ func resourceVSphereTagCategoryUpdate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	id := d.Id()
+	associableTypesRaw := structure.SliceInterfacesToStrings(d.Get("associable_types").(*schema.Set).List())
+	associableTypes := appendPrefix(associableTypesRaw)
+
 	spec := &tags.Category{
 		ID:              id,
-		AssociableTypes: structure.SliceInterfacesToStrings(d.Get("associable_types").(*schema.Set).List()),
+		AssociableTypes: associableTypes,
 		Cardinality:     d.Get("cardinality").(string),
 		Description:     d.Get("description").(string),
 		Name:            d.Get("name").(string),
@@ -191,4 +197,13 @@ func resourceVSphereTagCategoryImport(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(id)
 	return []*schema.ResourceData{d}, nil
+}
+
+func appendPrefix(associableTypes []string) []string {
+
+	var appendedTypes []string
+	for _, associableType := range associableTypes {
+		appendedTypes = append(appendedTypes, vim25Prefix+associableType)
+	}
+	return appendedTypes
 }

--- a/vsphere/resource_vsphere_vm_storage_policy.go
+++ b/vsphere/resource_vsphere_vm_storage_policy.go
@@ -1,0 +1,300 @@
+package vsphere
+
+import (
+	"fmt"
+	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/virtualdevice"
+	"github.com/vmware/govmomi/pbm"
+	types2 "github.com/vmware/govmomi/pbm/types"
+	"github.com/vmware/govmomi/vapi/tags"
+	"log"
+	"strings"
+)
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const TAG_NAMESPACE = "http://www.vmware.com/storage/tag"
+const TAG_PLACEMENT = "Tag based placement"
+
+func resourceVmStoragePolicy() *schema.Resource {
+	sch := map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Name of the storage policy",
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Description of the storage policy",
+		},
+		"tag_rules": {
+			Type:        schema.TypeList,
+			Required:    true,
+			Description: "tag rules to filter datastores to be used for placement of VMs",
+			Elem:        &schema.Resource{Schema: virtualdevice.VirtualMachineTagRulesSchema()},
+		},
+	}
+
+	return &schema.Resource{
+		Create: resourceVmStoragePolicyCreate,
+		Read:   resourceVmStoragePolicyRead,
+		Update: resourceVmStoragePolicyUpdate,
+		Delete: resourceVmStoragePolicyDelete,
+		Schema: sch,
+	}
+}
+
+func resourceVmStoragePolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Print("[DEBUG] Beginning create")
+	client := meta.(*VSphereClient).vimClient
+	rc := meta.(*VSphereClient).restClient
+
+	pbmClient, err := pbm.NewClient(context.Background(), client.Client)
+	if err != nil {
+		return fmt.Errorf("error while creating pbm client %s", err)
+	}
+
+	tagsManager := tags.NewManager(rc)
+	tagRules := d.Get("tag_rules").([]interface{})
+
+	var capabilities []pbm.Capability
+
+	for _, tagRule := range tagRules {
+
+		tagCategory := tagRule.(map[string]interface{})["tag_category"].(string)
+		_, err := tagCategoryByName(tagsManager, tagCategory)
+		if err != nil {
+			return fmt.Errorf("error while getting the tag %s %s", tagCategory, err)
+		}
+
+		tagValues := tagRule.(map[string]interface{})["tags"].([]interface{})
+		tagValuesArr := make([]string, len(tagValues))
+		for i, v := range tagValues {
+			tagValuesArr[i] = fmt.Sprint(v)
+		}
+		tagsStr := strings.Join(tagValuesArr, ",")
+
+		var includeTags string
+		if !tagRule.(map[string]interface{})["include_datastores_with_tags"].(bool) {
+			includeTags = "NOT"
+		}
+
+		var properties []pbm.Property
+		properties = append(properties, pbm.Property{
+			ID:       "com.vmware.storage.tag." + tagCategory + ".property",
+			DataType: "Set",
+			Value:    tagsStr,
+			Operator: includeTags,
+		})
+		capability := pbm.Capability{
+			ID:           tagCategory,
+			Namespace:    TAG_NAMESPACE,
+			PropertyList: properties,
+		}
+		capabilities = append(capabilities, capability)
+	}
+
+	name := d.Get("name").(string)
+	description := d.Get("description").(string)
+
+	capabilityProfileCreateSpec := pbm.CapabilityProfileCreateSpec{
+		Name:           name,
+		Description:    description,
+		CapabilityList: capabilities,
+		SubProfileName: TAG_PLACEMENT,
+	}
+	pbmCapabilityProfileCreateSpec, err := pbm.CreateCapabilityProfileSpec(capabilityProfileCreateSpec)
+	if err != nil {
+		return fmt.Errorf("error while creating storage policy spec %s", err)
+	}
+
+	profileID, err := pbmClient.CreateProfile(context.Background(), *pbmCapabilityProfileCreateSpec)
+	if err != nil {
+		return fmt.Errorf("error while creating storage policy %s", err)
+	}
+
+	d.SetId(profileID.UniqueId)
+	log.Printf("[DEBUG] Storage policy Create complete with Id %s", profileID.UniqueId)
+
+	return resourceVmStoragePolicyRead(d, meta)
+}
+
+func resourceVmStoragePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] %s: Reading vm storage policy profile", resourceVSphereVirtualMachineIDString(d))
+	client := meta.(*VSphereClient).vimClient
+	pbmClient, err := pbm.NewClient(context.Background(), client.Client)
+	if err != nil {
+		return fmt.Errorf("error while creating pbm client %s", err)
+	}
+	profileId := types2.PbmProfileId{
+		UniqueId: d.Id(),
+	}
+	pbmProfileIds := []types2.PbmProfileId{profileId}
+
+	vmStoragePolicies, err := pbmClient.RetrieveContent(context.Background(), pbmProfileIds)
+	if err != nil {
+		if strings.Contains(err.Error(), "Profile not found") {
+			log.Printf("[DEBUG] storage policy profile %s: Resource has been deleted", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error while reading vm storage policy profile with Id %s %s", d.Id(), err.Error())
+	}
+	if len(vmStoragePolicies) == 0 {
+		d.SetId("")
+		return nil
+	}
+
+	pbmCapabilityProfile := vmStoragePolicies[0].(*types2.PbmCapabilityProfile)
+	d.SetId(pbmCapabilityProfile.ProfileId.UniqueId)
+	d.Set("name", pbmCapabilityProfile.Name)
+	d.Set("description", pbmCapabilityProfile.Description)
+
+	var tagRules []map[string]interface{}
+	if pbmCapabilityProfile.Constraints != nil {
+		pbmSubProfileConstraints := pbmCapabilityProfile.Constraints.(*types2.PbmCapabilitySubProfileConstraints)
+		if pbmSubProfileConstraints == nil {
+			return nil
+		}
+		pbmSubProfiles := pbmSubProfileConstraints.SubProfiles
+		for _, subProfile := range pbmSubProfiles {
+			if subProfile.Name != TAG_PLACEMENT {
+				continue
+			}
+			capabilities := subProfile.Capability
+			for _, capability := range capabilities {
+
+				if capability.Id.Namespace != TAG_NAMESPACE {
+					continue
+				}
+				tagCategory := capability.Id.Id
+
+				constraints := capability.Constraint
+				if len(constraints) == 0 {
+					continue
+				}
+				propertyInstances := constraints[0].PropertyInstance
+				if len(propertyInstances) == 0 {
+					continue
+				}
+				tagsSet := propertyInstances[0].Value.(types2.PbmCapabilityDiscreteSet)
+				tagRule := make(map[string]interface{})
+				tagRule["tag_category"] = tagCategory
+				tagRule["tags"] = tagsSet.Values
+
+				includeTags := true
+				if propertyInstances[0].Operator == "NOT" {
+					includeTags = false
+				}
+				tagRule["include_datastores_with_tags"] = includeTags
+
+				tagRules = append(tagRules, tagRule)
+			}
+		}
+	}
+	d.Set("tag_rules", tagRules)
+	return nil
+}
+
+func resourceVmStoragePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Print("[DEBUG] :  Performing update")
+	client := meta.(*VSphereClient).vimClient
+	rc := meta.(*VSphereClient).restClient
+	pbmClient, err := pbm.NewClient(context.Background(), client.Client)
+	if err != nil {
+		return fmt.Errorf("error while creating pbm client %s", err)
+	}
+
+	updateSpec := types2.PbmCapabilityProfileUpdateSpec{}
+
+	updateSpec.Name = d.Get("name").(string)
+	updateSpec.Description = d.Get("description").(string)
+	log.Print("update spec ", updateSpec)
+
+	if d.HasChange("tag_rules") {
+
+		tagsManager := tags.NewManager(rc)
+		tagRules := d.Get("tag_rules").([]interface{})
+		var capabilities []pbm.Capability
+
+		for _, tagRule := range tagRules {
+
+			tagCategory := tagRule.(map[string]interface{})["tag_category"].(string)
+			_, err := tagCategoryByName(tagsManager, tagCategory)
+			if err != nil {
+				return fmt.Errorf("error while getting the tag %s %s", tagCategory, err)
+			}
+
+			tagValues := tagRule.(map[string]interface{})["tags"].([]interface{})
+			tagValuesArr := make([]string, len(tagValues))
+			for i, v := range tagValues {
+				tagValuesArr[i] = fmt.Sprint(v)
+			}
+			tagsStr := strings.Join(tagValuesArr, ",")
+
+			var includeTags string
+			if !tagRule.(map[string]interface{})["include_datastores_with_tags"].(bool) {
+				includeTags = "NOT"
+			}
+
+			var properties []pbm.Property
+			properties = append(properties, pbm.Property{
+				ID:       "com.vmware.storage.tag." + tagCategory + ".property",
+				DataType: "Set",
+				Value:    tagsStr,
+				Operator: includeTags,
+			})
+			capability := pbm.Capability{
+				ID:           tagCategory,
+				Namespace:    TAG_NAMESPACE,
+				PropertyList: properties,
+			}
+			capabilities = append(capabilities, capability)
+		}
+
+		capabilityProfileCreateSpec := pbm.CapabilityProfileCreateSpec{
+			CapabilityList: capabilities,
+			SubProfileName: TAG_PLACEMENT,
+		}
+		pbmCapabilityProfileCreateSpec, err := pbm.CreateCapabilityProfileSpec(capabilityProfileCreateSpec)
+		if err != nil {
+			return fmt.Errorf("error while creating profile updatespec %s", err)
+		}
+		updateSpec.Constraints = pbmCapabilityProfileCreateSpec.Constraints
+	}
+
+	policyIdToUpdate := types2.PbmProfileId{
+		UniqueId: d.Id(),
+	}
+	err = pbmClient.UpdateProfile(context.Background(), policyIdToUpdate, updateSpec)
+	if err != nil {
+		return fmt.Errorf("error while performing profile update for Id %s %s", d.Id(), err)
+
+	}
+	log.Print("[DEBUG] : update complete")
+	return resourceVmStoragePolicyRead(d, meta)
+}
+
+func resourceVmStoragePolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Performing create of VM storage policy with ID %s", d.Id())
+	client := meta.(*VSphereClient).vimClient
+	pbmClient, err := pbm.NewClient(context.Background(), client.Client)
+	if err != nil {
+		return fmt.Errorf("error while creating pbm client %s", err)
+	}
+	var policyIdsToDelete []types2.PbmProfileId
+	policyIdsToDelete = append(policyIdsToDelete, types2.PbmProfileId{
+		UniqueId: d.Id(),
+	})
+
+	_, err = pbmClient.DeleteProfile(context.Background(), policyIdsToDelete)
+	if err != nil {
+		return fmt.Errorf("error while deleting policy with ID %s %s", d.Id(), err)
+	}
+	d.SetId("")
+	log.Printf("[DEBUG] %s: Delete complete", d.Id())
+	return nil
+}

--- a/vsphere/resource_vsphere_vm_storage_policy.go
+++ b/vsphere/resource_vsphere_vm_storage_policy.go
@@ -1,18 +1,15 @@
 package vsphere
 
 import (
+	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/virtualdevice"
 	"github.com/vmware/govmomi/pbm"
 	types2 "github.com/vmware/govmomi/pbm/types"
 	"github.com/vmware/govmomi/vapi/tags"
 	"log"
 	"strings"
-)
-
-import (
-	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 const TAG_NAMESPACE = "http://www.vmware.com/storage/tag"
@@ -23,17 +20,17 @@ func resourceVmStoragePolicy() *schema.Resource {
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "Name of the storage policy",
+			Description: "Name of the storage policy.",
 		},
 		"description": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "Description of the storage policy",
+			Description: "Description of the storage policy.",
 		},
 		"tag_rules": {
 			Type:        schema.TypeList,
 			Required:    true,
-			Description: "tag rules to filter datastores to be used for placement of VMs",
+			Description: "Tag rules to filter datastores to be used for placement of VMs.",
 			Elem:        &schema.Resource{Schema: virtualdevice.VirtualMachineTagRulesSchema()},
 		},
 	}
@@ -48,7 +45,7 @@ func resourceVmStoragePolicy() *schema.Resource {
 }
 
 func resourceVmStoragePolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Print("[DEBUG] Beginning create")
+	log.Printf("[DEBUG] Beginning create storage policy profile %s", d.Get("name").(string))
 	client := meta.(*VSphereClient).vimClient
 	rc := meta.(*VSphereClient).restClient
 
@@ -117,7 +114,7 @@ func resourceVmStoragePolicyCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.SetId(profileID.UniqueId)
-	log.Printf("[DEBUG] Storage policy Create complete with Id %s", profileID.UniqueId)
+	log.Printf("[DEBUG] Storage policy create complete with Id %s", profileID.UniqueId)
 
 	return resourceVmStoragePolicyRead(d, meta)
 }

--- a/vsphere/resource_vsphere_vm_storage_policy_test.go
+++ b/vsphere/resource_vsphere_vm_storage_policy_test.go
@@ -1,0 +1,105 @@
+package vsphere
+
+import (
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"strings"
+	"testing"
+)
+
+const policyResource = "policy1"
+
+func TestAccResourceVMStoragePolicy_basic(t *testing.T) {
+	policyName := "terraform_test_policy" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccResourceVMStoragePolicyCheckExists(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceVSphereVMStoragePolicyonfigBasic(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccResourceVMStoragePolicyCheckExists(true),
+					resource.TestCheckResourceAttr("vsphere_vm_storage_policy."+policyResource, "name", policyName),
+					resource.TestCheckResourceAttr("vsphere_vm_storage_policy."+policyResource, "tag_rules.0.tag_category", "cat1"),
+					resource.TestCheckResourceAttr("vsphere_vm_storage_policy."+policyResource, "tag_rules.0.tags.0", "tag1"),
+					resource.TestCheckResourceAttr("vsphere_vm_storage_policy."+policyResource, "tag_rules.1.tag_category", "cat2"),
+					resource.TestCheckResourceAttr("vsphere_vm_storage_policy."+policyResource, "tag_rules.1.tags.0", "tag2"),
+					resource.TestCheckResourceAttr("vsphere_vm_storage_policy."+policyResource, "tag_rules.1.tags.1", "tag3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceVMStoragePolicyCheckExists(expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := testGetVmStoragePolicy(s, policyResource)
+		if err != nil {
+			if strings.Contains(err.Error(), "Profile not found") && !expected {
+				// Expected missing
+				return nil
+			}
+			return err
+		}
+		if !expected {
+			return errors.New("expected policy profile to be missing")
+		}
+		return nil
+	}
+}
+
+func testAccResourceVSphereVMStoragePolicyonfigBasic(policyName string) string {
+	return fmt.Sprintf(`
+resource "vsphere_tag_category" "category1" {
+  name = "cat1"
+  cardinality = "SINGLE"
+  associable_types = ["Datastore"]
+}
+
+resource "vsphere_tag_category" "category2" {
+  name = "cat2"
+  cardinality = "SINGLE"
+  associable_types = ["Datastore"]
+}
+
+resource "vsphere_tag" "tag1" {
+  name        = "tag1"
+  category_id = "${vsphere_tag_category.category1.id}"
+}
+
+resource "vsphere_tag" "tag2" {
+  name        = "tag2"
+  category_id = "${vsphere_tag_category.category2.id}"
+}
+
+resource "vsphere_tag" "tag3" {
+  name        = "tag3"
+  category_id = "${vsphere_tag_category.category2.id}"
+}
+
+resource "vsphere_vm_storage_policy" "%s" {
+  name = "%s"
+  description = "description"
+
+  tag_rules {
+    tag_category = vsphere_tag_category.category1.name
+    tags = [vsphere_tag.tag1.name]
+  }
+
+ tag_rules {
+    tag_category = vsphere_tag_category.category2.name
+    tags = [vsphere_tag.tag2.name, vsphere_tag.tag3.name]
+  }
+  
+}
+`, policyResource,
+		policyName,
+	)
+
+}

--- a/website/docs/r/vm_storage_policy.html.markdown
+++ b/website/docs/r/vm_storage_policy.html.markdown
@@ -5,7 +5,7 @@ page_title: "VMware vSphere: vm_storage_policy"
 sidebar_current: "docs-vsphere-resource-vm-storage-policy"
 description: |-
   Provides CRUD operations on vm storage policy profiles. These policies help create tag based rules for placement of a 
-  VM on datastores. While placing a VM, Compatible Datastores can be filtered using these profiles.
+  VM on datastores. While placing a VM, compatible datastores can be filtered using these profiles.
 ---
 
 # vsphere\_vm\_storage\_policy
@@ -17,7 +17,7 @@ place a VM on a particular tagged datastore.
 ## Example Usage
 
 This example creates a storage policy with tag_rule having cat1 as tag_category and 
-tag1,tag2 as the tags. While creating a VM, this policy can be referenced to place 
+tag1, tag2 as the tags. While creating a VM, this policy can be referenced to place 
 the VM in any of the compatible datastore tagged with these tags.
 
 
@@ -42,12 +42,12 @@ data "vsphere_tag" "tag2" {
 }
 
 resource "vsphere_vm_storage_policy" "policy_tag_based_placement" {
-  name = "policy1"
+  name        = "policy1"
   description = "description"
 
   tag_rules {
-    tag_category = data.vsphere_tag_category.tag_category.name
-    tags = [data.vsphere_tag.tag1.name, data.vsphere_tag.tag2.name]
+    tag_category                 = data.vsphere_tag_category.tag_category.name
+    tags                         = [data.vsphere_tag.tag1.name, data.vsphere_tag.tag2.name]
     include_datastores_with_tags = true
   }
 
@@ -60,8 +60,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the storage policy.
 * `description` - (Optional) Description of the storage policy. 
-* `tag_rules` - (Required) List of tag rules. The tag_category and tags to be associated in this profile.
-  * `tag_category` - (Required) Name of the tag_category.
+* `tag_rules` - (Required) List of tag rules. The tag category and tags to be associated to this storage policy.
+  * `tag_category` - (Required) Name of the tag category.
   * `tags` - (Required) List of Name of tags to select from the given category.
   * `include_datastores_with_tags` - (Optional) Whether to include datastores with the given tags or exclude. Default 
      value is true i.e. include datastores with the given tags.

--- a/website/docs/r/vm_storage_policy.html.markdown
+++ b/website/docs/r/vm_storage_policy.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Storage"
+layout: "vsphere"
+page_title: "VMware vSphere: vm_storage_policy"
+sidebar_current: "docs-vsphere-resource-vm-storage-policy"
+description: |-
+  Provides CRUD operations on vm storage policy profiles. These policies help create tag based rules for placement of a 
+  VM on datastores. While placing a VM, Compatible Datastores can be filtered using these profiles.
+---
+
+# vsphere\_vm\_storage\_policy
+
+The `vsphere_vm_storage_policy` resource can be used to create and manage storage 
+policies. Using this storage policy, tag based placement rules can be created to 
+place a VM on a particular tagged datastore.
+
+## Example Usage
+
+This example creates a storage policy with tag_rule having cat1 as tag_category and 
+tag1,tag2 as the tags. While creating a VM, this policy can be referenced to place 
+the VM in any of the compatible datastore tagged with these tags.
+
+
+```hcl
+
+data "vsphere_datacenter" "dc" {
+  name = "DC"
+}
+
+data "vsphere_tag_category" "tag_category" {
+  name = "cat1"
+}
+
+data "vsphere_tag" "tag1" {
+  name        = "tag1"
+  category_id = "${data.vsphere_tag_category.tag_category.id}"
+}
+
+data "vsphere_tag" "tag2" {
+  name        = "tag2"
+  category_id = "${data.vsphere_tag_category.tag_category.id}"
+}
+
+resource "vsphere_vm_storage_policy" "policy_tag_based_placement" {
+  name = "policy1"
+  description = "description"
+
+  tag_rules {
+    tag_category = data.vsphere_tag_category.tag_category.name
+    tags = [data.vsphere_tag.tag1.name, data.vsphere_tag.tag2.name]
+    include_datastores_with_tags = true
+  }
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the storage policy.
+* `description` - (Optional) Description of the storage policy. 
+* `tag_rules` - (Required) List of tag rules. The tag_category and tags to be associated in this profile.
+  * `tag_category` - (Required) Name of the tag_category.
+  * `tags` - (Required) List of Name of tags to select from the given category.
+  * `include_datastores_with_tags` - (Optional) Whether to include datastores with the given tags or exclude. Default 
+     value is true i.e. include datastores with the given tags.
+

--- a/website/vsphere.erb
+++ b/website/vsphere.erb
@@ -63,7 +63,7 @@
             </li>
           </ul>
         </li>
-        
+
         <li<%= sidebar_current("docs-vsphere-resource-compute") %>>
           <a href="#">Host and Cluster Management Resources</a>
           <ul class="nav nav-visible">
@@ -167,6 +167,9 @@
             </li>
             <li<%= sidebar_current("docs-vsphere-resource-storage-vmfs-datastore") %>>
               <a href="/docs/providers/vsphere/r/vmfs_datastore.html">vsphere_vmfs_datastore</a>
+            </li>
+            <li<%= sidebar_current("docs-vsphere-resource-vm-storage-policy") %>>
+              <a href="/docs/providers/vsphere/r/vm_storage_policy.html">vm_storage_policy</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION

### Description
Adding VM_storage_policy_profile resource
CRUD operations for tag based placement policy rules

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
yes
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)
VM_storage_policy_profile acceptance test: https://gist.github.com/sumitAgrawal007/9db3c782a3a4af268f51ce0f9cdb30d5

tag category acceptance test
https://gist.github.com/sumitAgrawal007/91ff0b3fe9af063de0deca85242f51cd

### References
https://github.com/terraform-providers/terraform-provider-vsphere/issues/993
